### PR TITLE
feat: add quick wins bundle - version, list, config, and quality fixes

### DIFF
--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -223,7 +223,6 @@ def record(
                 termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 
         if recorder.start_time:
-
             actual_duration = get_recording_duration(recorder.start_time)
             duration_str = format_duration(actual_duration)
             console.print(f"[green]✅ Recording saved: {filename}[/green]")
@@ -254,6 +253,53 @@ def record(
         console.print(f"[red]❌ Unexpected error: {str(e)}[/red]")
         console.print("[dim]Please report this issue if it persists[/dim]")
         raise typer.Exit(1)
+
+
+@app.command(name="list", rich_help_panel=CHAT_PANEL)
+def list_notes():
+    """List all meeting notes"""
+    settings = get_settings()
+    notes_files = get_notes_files(settings.directories.notes)
+
+    if not notes_files:
+        console.print(
+            f"[yellow]No notes found in {settings.directories.notes}[/yellow]"
+        )
+        console.print(
+            "[dim]Run 'chirp generate' to create notes from transcriptions[/dim]"
+        )
+        return
+
+    table = Table(title="📝 Meeting Notes")
+    table.add_column("Date", style="cyan", no_wrap=True)
+    table.add_column("Title")
+    table.add_column("File", style="dim")
+    table.add_column("Size", style="dim", justify="right")
+
+    from datetime import datetime as dt
+
+    for note_file in reversed(notes_files):
+        title = note_file.stem
+        try:
+            with open(note_file, encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line.startswith("# "):
+                        title = line[2:].strip()
+                        break
+        except Exception:
+            pass
+
+        stat = note_file.stat()
+        size_kb = stat.st_size / 1024
+        size_str = f"{size_kb:.1f} KB"
+
+        date_str = dt.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d")
+
+        table.add_row(date_str, title, note_file.name, size_str)
+
+    console.print(table)
+    console.print(f"[dim]Total: {len(notes_files)} note(s)[/dim]")
 
 
 @app.command(rich_help_panel=CHAT_PANEL)
@@ -383,6 +429,12 @@ def transcribe(
     force: bool = typer.Option(
         False, "--force", "-f", help="Re-transcribe already processed files"
     ),
+    model: Optional[str] = typer.Option(
+        None,
+        "--model",
+        "-m",
+        help="Whisper model to use (e.g. tiny, base, small, medium, large-v3)",
+    ),
 ):
     """Transcribe audio files to text"""
     from transcriber.batch_processor import BatchProcessor
@@ -398,7 +450,10 @@ def transcribe(
         console.print(f"[yellow]No audio files found in {input_dir}[/yellow]")
         return
 
-    processor = BatchProcessor(settings)
+    if model:
+        console.print(f"[cyan]Using Whisper model: {model}[/cyan]")
+
+    processor = BatchProcessor(settings, model_override=model)
 
     with Progress(
         SpinnerColumn(),
@@ -546,6 +601,22 @@ def config(
     notes_dir: Optional[Path] = typer.Option(
         None, "--notes-dir", help="Set notes directory"
     ),
+    whisper_model: Optional[str] = typer.Option(
+        None,
+        "--whisper-model",
+        help="Set Whisper model (e.g. tiny, base, small, medium, large-v3)",
+    ),
+    llm_model: Optional[str] = typer.Option(
+        None, "--llm-model", help="Set LLM model (e.g. llama3.1:8b)"
+    ),
+    ollama_url: Optional[str] = typer.Option(
+        None, "--ollama-url", help="Set Ollama server URL"
+    ),
+    embedding_model: Optional[str] = typer.Option(
+        None,
+        "--embedding-model",
+        help="Set embedding model (e.g. nomic-embed-text)",
+    ),
 ):
     """Manage Chirp configuration"""
     settings = get_settings()
@@ -562,6 +633,7 @@ Templates: {settings.directories.templates}
 Whisper: {settings.models.whisper}
 LLM: {settings.models.llm}
 Ollama URL: {settings.models.ollama_url}
+Embedding: {settings.notes_chat.emb_model}
 
 [cyan]Audio:[/cyan]
 Sample Rate: {settings.audio.sample_rate}
@@ -587,6 +659,22 @@ Interval: {settings.monitoring.warning_interval} minutes""",
 
     if notes_dir:
         settings.directories.notes = notes_dir
+        changes_made = True
+
+    if whisper_model:
+        settings.models.whisper = whisper_model
+        changes_made = True
+
+    if llm_model:
+        settings.models.llm = llm_model
+        changes_made = True
+
+    if ollama_url:
+        settings.models.ollama_url = ollama_url
+        changes_made = True
+
+    if embedding_model:
+        settings.notes_chat.emb_model = embedding_model
         changes_made = True
 
     if changes_made:
@@ -687,14 +775,18 @@ def setup():
     else:
         console.print("[red]Step 1: Install BlackHole[/red]")
         console.print("  Download from: https://existential.audio/blackhole/")
-        console.print("  BlackHole is a virtual audio driver that captures system audio.")
+        console.print(
+            "  BlackHole is a virtual audio driver that captures system audio."
+        )
         console.print()
-        console.print("[yellow]Install BlackHole and re-run 'chirp setup' to continue.[/yellow]")
+        console.print(
+            "[yellow]Install BlackHole and re-run 'chirp setup' to continue.[/yellow]"
+        )
         return
 
     # Step 2: Multi-Output Device
     console.print()
-    console.print("[bold]Step 2: Create a Multi-Output Device (\"Chirp Output\")[/bold]")
+    console.print('[bold]Step 2: Create a Multi-Output Device ("Chirp Output")[/bold]')
     console.print()
     console.print(
         "  This routes system audio to both your speakers AND BlackHole,\n"
@@ -702,14 +794,18 @@ def setup():
     )
     console.print()
     console.print("  1. Open [bold]Audio MIDI Setup[/bold] (/Applications/Utilities/)")
-    console.print("  2. Click [bold]+[/bold] at bottom left → Create Multi-Output Device")
-    console.print("  3. Check your [bold]speakers/headphones[/bold] (so you can still hear)")
+    console.print(
+        "  2. Click [bold]+[/bold] at bottom left → Create Multi-Output Device"
+    )
+    console.print(
+        "  3. Check your [bold]speakers/headphones[/bold] (so you can still hear)"
+    )
     console.print("  4. Check [bold]BlackHole 2ch[/bold]")
     console.print("  5. Rename it to [bold]Chirp Output[/bold] (double-click the name)")
 
     # Step 3: Aggregate Device
     console.print()
-    console.print("[bold]Step 3: Create an Aggregate Device (\"Chirp Input\")[/bold]")
+    console.print('[bold]Step 3: Create an Aggregate Device ("Chirp Input")[/bold]')
     console.print()
     console.print(
         "  This combines your microphone AND BlackHole into a single input,\n"
@@ -717,9 +813,13 @@ def setup():
         "  participants on a call)."
     )
     console.print()
-    console.print("  1. In [bold]Audio MIDI Setup[/bold], click [bold]+[/bold] → Create Aggregate Device")
+    console.print(
+        "  1. In [bold]Audio MIDI Setup[/bold], click [bold]+[/bold] → Create Aggregate Device"
+    )
     console.print("  2. Check [bold]BlackHole 2ch[/bold]")
-    console.print("  3. Check your [bold]microphone[/bold] (e.g. Built-in, USB mic, etc.)")
+    console.print(
+        "  3. Check your [bold]microphone[/bold] (e.g. Built-in, USB mic, etc.)"
+    )
     console.print("  4. Rename it to [bold]Chirp Input[/bold] (double-click the name)")
 
     # Step 4: Set system audio
@@ -841,6 +941,20 @@ def test():
                 "\n[yellow]⚠️  Configuration issues. Run setup commands to fix.[/yellow]"
             )
         console.print("[dim]Run 'chirp --help' for setup commands[/dim]")
+
+
+@app.command(rich_help_panel=INFO_PANEL)
+def version():
+    """Show the installed Chirp version"""
+    from importlib.metadata import PackageNotFoundError
+    from importlib.metadata import version as pkg_version
+
+    try:
+        ver = pkg_version("chirp-notes-ai")
+    except PackageNotFoundError:
+        ver = "dev (not installed as package)"
+
+    console.print(f"[bold]chirp[/bold] {ver}")
 
 
 if __name__ == "__main__":

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -287,14 +287,17 @@ def list_notes():
                     if line.startswith("# "):
                         title = line[2:].strip()
                         break
-        except Exception:
+        except OSError:
             pass
 
-        stat = note_file.stat()
-        size_kb = stat.st_size / 1024
-        size_str = f"{size_kb:.1f} KB"
-
-        date_str = dt.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d")
+        try:
+            stat = note_file.stat()
+            size_kb = stat.st_size / 1024
+            size_str = f"{size_kb:.1f} KB"
+            date_str = dt.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d")
+        except OSError:
+            size_str = "?"
+            date_str = "?"
 
         table.add_row(date_str, title, note_file.name, size_str)
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -130,7 +130,7 @@ class ChirpSettings(BaseModel):
     def save_to_file(self, config_path: Path):
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
-        config_dict = self.dict()
+        config_dict = self.model_dump()
         for key, value in config_dict.items():
             if isinstance(value, dict):
                 for subkey, subvalue in value.items():

--- a/notes_chat/cli.py
+++ b/notes_chat/cli.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import typer
 from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from notes_chat.config import get_notes_config
 
@@ -23,7 +24,23 @@ def index(
     try:
         from notes_chat.index import build_index
 
-        result = build_index(config, force=force)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+            transient=True,
+        ) as progress:
+            task = progress.add_task("Indexing notes...", total=None)
+            files_indexed = 0
+
+            def on_progress():
+                nonlocal files_indexed
+                files_indexed += 1
+                progress.update(
+                    task, description=f"Indexing notes... ({files_indexed} files)"
+                )
+
+            result = build_index(config, force=force, progress_callback=on_progress)
 
         if result.get("success"):
             console.print(

--- a/notes_chat/index.py
+++ b/notes_chat/index.py
@@ -81,8 +81,8 @@ class IndexManager:
             for file_path in added_files + modified_files:
                 if self._add_to_index(Path(file_path)):
                     processed_count += 1
-                if progress_callback:
-                    progress_callback()
+                    if progress_callback:
+                        progress_callback()
 
             new_manifest = current_files
             self._save_manifest(new_manifest)

--- a/notes_chat/index.py
+++ b/notes_chat/index.py
@@ -3,7 +3,7 @@ import json
 import re
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import chromadb
 import requests
@@ -33,7 +33,11 @@ class IndexManager:
         self.manifest_file = self.settings.index_dir / "manifest.json"
         self.bm25_file = self.settings.index_dir / "bm25.json"
 
-    def build_index(self, force: bool = False) -> dict[str, Any]:
+    def build_index(
+        self,
+        force: bool = False,
+        progress_callback: Optional[Callable] = None,
+    ) -> dict[str, Any]:
         """Build or update the search index."""
         try:
             self.config.ensure_directories_exist()
@@ -71,10 +75,14 @@ class IndexManager:
             for file_path in removed_files:
                 self._remove_from_index(file_path)
                 processed_count += 1
+                if progress_callback:
+                    progress_callback()
 
             for file_path in added_files + modified_files:
                 if self._add_to_index(Path(file_path)):
                     processed_count += 1
+                if progress_callback:
+                    progress_callback()
 
             new_manifest = current_files
             self._save_manifest(new_manifest)
@@ -95,7 +103,7 @@ class IndexManager:
         """Reset the entire index."""
         try:
             self.chroma_client.delete_collection("notes")
-        except:
+        except Exception:
             pass
 
         self.collection = self.chroma_client.get_or_create_collection(
@@ -132,7 +140,7 @@ class IndexManager:
             with open(self.manifest_file) as f:
                 data = json.load(f)
                 return data if isinstance(data, dict) else {}
-        except:
+        except Exception:
             return {}
 
     def _save_manifest(self, manifest: dict[str, Any]):
@@ -354,7 +362,11 @@ class IndexManager:
             console.print(f"[yellow]⚠️ Failed to rebuild BM25 index: {e}[/yellow]")
 
 
-def build_index(config: ChirpSettings, force: bool = False) -> dict[str, Any]:
+def build_index(
+    config: ChirpSettings,
+    force: bool = False,
+    progress_callback: Optional[Callable] = None,
+) -> dict[str, Any]:
     """Build the notes search index."""
     manager = IndexManager(config)
-    return manager.build_index(force=force)
+    return manager.build_index(force=force, progress_callback=progress_callback)

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
@@ -9,6 +10,8 @@ from config.settings import ChirpSettings
 from notes_chat.bm25 import BM25Index
 from notes_chat.index import IndexManager
 from notes_chat.time_ranges import parse_time_range
+
+logger = logging.getLogger(__name__)
 
 
 def retrieve_context(
@@ -130,7 +133,7 @@ def _search_chroma(
         return chroma_results
 
     except Exception as e:
-        print(f"Chroma search failed: {e}")
+        logger.debug("Chroma search failed: %s", e)
         return []
 
 
@@ -147,7 +150,7 @@ def _search_bm25(
         ]
 
     except Exception as e:
-        print(f"BM25 search failed: {e}")
+        logger.debug("BM25 search failed: %s", e)
         return []
 
 

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -133,7 +133,7 @@ def _search_chroma(
         return chroma_results
 
     except Exception as e:
-        logger.debug("Chroma search failed: %s", e)
+        logger.debug("Chroma search failed: %s", e, exc_info=True)
         return []
 
 
@@ -150,7 +150,7 @@ def _search_bm25(
         ]
 
     except Exception as e:
-        logger.debug("BM25 search failed: %s", e)
+        logger.debug("BM25 search failed: %s", e, exc_info=True)
         return []
 
 

--- a/recorder/device_manager.py
+++ b/recorder/device_manager.py
@@ -123,7 +123,10 @@ class DeviceManager:
         search_name = name.lower()
 
         for device in devices:
-            if device["name"].lower() == search_name and device["max_input_channels"] > 0:
+            if (
+                device["name"].lower() == search_name
+                and device["max_input_channels"] > 0
+            ):
                 return int(device["index"])
 
         for device in devices:

--- a/tests/test_audio_recorder.py
+++ b/tests/test_audio_recorder.py
@@ -113,7 +113,9 @@ class TestAudioRecorder:
                         mock_wave_file = Mock()
                         mock_wave.return_value.__enter__.return_value = mock_wave_file
 
-                        recorder._save_recording(test_file_path, 2, 2, 16000, test_title)
+                        recorder._save_recording(
+                            test_file_path, 2, 2, 16000, test_title
+                        )
 
                         expected_metadata_path = Path(
                             "/mock/audio/test_recording.wav.meta"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -93,6 +93,9 @@ class TestVersion:
 
 class TestTranscribeModelOverride:
     def test_model_override_passed_to_batch_processor(self, tmp_path, monkeypatch):
+        import sys
+        from unittest.mock import MagicMock
+
         settings = _make_settings(tmp_path)
 
         audio_dir = tmp_path / "audio"
@@ -111,14 +114,7 @@ class TestTranscribeModelOverride:
                 return [{"success": True}]
 
         monkeypatch.setattr("chirp.cli.get_settings", lambda: settings)
-
-        import sys
-        from unittest.mock import MagicMock
-
-        # Stub faster_whisper so batch_processor can be imported
-        if "faster_whisper" not in sys.modules:
-            sys.modules["faster_whisper"] = MagicMock()
-
+        monkeypatch.setitem(sys.modules, "faster_whisper", MagicMock())
         monkeypatch.setattr(
             "transcriber.batch_processor.BatchProcessor",
             FakeBatchProcessor,
@@ -129,11 +125,15 @@ class TestTranscribeModelOverride:
         import chirp.cli
 
         runner = CliRunner()
-        runner.invoke(chirp.cli.app, ["transcribe", "--model", "small"])
+        result = runner.invoke(chirp.cli.app, ["transcribe", "--model", "small"])
 
+        assert result.exit_code == 0
         assert captured_args.get("model_override") == "small"
 
     def test_transcribe_without_model_override(self, tmp_path, monkeypatch):
+        import sys
+        from unittest.mock import MagicMock
+
         settings = _make_settings(tmp_path)
 
         audio_dir = tmp_path / "audio"
@@ -151,13 +151,7 @@ class TestTranscribeModelOverride:
                 return [{"success": True}]
 
         monkeypatch.setattr("chirp.cli.get_settings", lambda: settings)
-
-        import sys
-        from unittest.mock import MagicMock
-
-        if "faster_whisper" not in sys.modules:
-            sys.modules["faster_whisper"] = MagicMock()
-
+        monkeypatch.setitem(sys.modules, "faster_whisper", MagicMock())
         monkeypatch.setattr(
             "transcriber.batch_processor.BatchProcessor",
             FakeBatchProcessor,
@@ -168,6 +162,7 @@ class TestTranscribeModelOverride:
         import chirp.cli
 
         runner = CliRunner()
-        runner.invoke(chirp.cli.app, ["transcribe"])
+        result = runner.invoke(chirp.cli.app, ["transcribe"])
 
+        assert result.exit_code == 0
         assert captured_args.get("model_override") is None

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,173 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from config.settings import ChirpSettings
+
+
+def _make_settings(tmp_path: Path) -> ChirpSettings:
+    settings = ChirpSettings()
+    settings.directories.notes = tmp_path
+    return settings
+
+
+class TestListNotes:
+    def test_list_notes_empty_directory(self, tmp_path, monkeypatch, capsys):
+        from chirp.cli import list_notes
+
+        settings = _make_settings(tmp_path)
+        monkeypatch.setattr("chirp.cli.get_settings", lambda: settings)
+
+        list_notes()
+
+        output = capsys.readouterr().out
+        assert "No notes found" in output
+
+    def test_list_notes_shows_title_from_header(self, tmp_path, monkeypatch, capsys):
+        from chirp.cli import list_notes
+
+        settings = _make_settings(tmp_path)
+        monkeypatch.setattr("chirp.cli.get_settings", lambda: settings)
+
+        note = tmp_path / "meetings_2025_01_15.md"
+        note.write_text("# Team Standup\n\nSome meeting content here.\n")
+
+        list_notes()
+
+        output = capsys.readouterr().out
+        assert "Team Standup" in output
+        assert "meetings_2025_01_15.md" in output
+
+    def test_list_notes_shows_stem_when_no_header(self, tmp_path, monkeypatch, capsys):
+        from chirp.cli import list_notes
+
+        settings = _make_settings(tmp_path)
+        monkeypatch.setattr("chirp.cli.get_settings", lambda: settings)
+
+        note = tmp_path / "my_note.md"
+        note.write_text("No heading here, just content.\n")
+
+        list_notes()
+
+        output = capsys.readouterr().out
+        assert "my_note" in output
+
+    def test_list_notes_shows_total_count(self, tmp_path, monkeypatch, capsys):
+        from chirp.cli import list_notes
+
+        settings = _make_settings(tmp_path)
+        monkeypatch.setattr("chirp.cli.get_settings", lambda: settings)
+
+        (tmp_path / "note1.md").write_text("# First\n")
+        (tmp_path / "note2.md").write_text("# Second\n")
+
+        list_notes()
+
+        output = capsys.readouterr().out
+        assert "2 note(s)" in output
+
+
+class TestVersion:
+    def test_version_installed(self, capsys):
+        from chirp.cli import version
+
+        with patch("importlib.metadata.version", return_value="1.2.3"):
+            version()
+
+        output = capsys.readouterr().out
+        assert "1.2.3" in output
+
+    def test_version_not_installed(self, capsys):
+        from importlib.metadata import PackageNotFoundError
+
+        from chirp.cli import version
+
+        with patch(
+            "importlib.metadata.version",
+            side_effect=PackageNotFoundError("chirp-notes-ai"),
+        ):
+            version()
+
+        output = capsys.readouterr().out
+        assert "dev" in output
+
+
+class TestTranscribeModelOverride:
+    def test_model_override_passed_to_batch_processor(self, tmp_path, monkeypatch):
+        settings = _make_settings(tmp_path)
+
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        (audio_dir / "test.wav").write_bytes(b"\x00" * 100)
+        settings.directories.raw_audio = audio_dir
+
+        captured_args = {}
+
+        class FakeBatchProcessor:
+            def __init__(self, s, model_override=None):
+                captured_args["settings"] = s
+                captured_args["model_override"] = model_override
+
+            def process_files(self, files, force=False, progress_callback=None):
+                return [{"success": True}]
+
+        monkeypatch.setattr("chirp.cli.get_settings", lambda: settings)
+
+        import sys
+        from unittest.mock import MagicMock
+
+        # Stub faster_whisper so batch_processor can be imported
+        if "faster_whisper" not in sys.modules:
+            sys.modules["faster_whisper"] = MagicMock()
+
+        monkeypatch.setattr(
+            "transcriber.batch_processor.BatchProcessor",
+            FakeBatchProcessor,
+        )
+
+        from typer.testing import CliRunner
+
+        import chirp.cli
+
+        runner = CliRunner()
+        runner.invoke(chirp.cli.app, ["transcribe", "--model", "small"])
+
+        assert captured_args.get("model_override") == "small"
+
+    def test_transcribe_without_model_override(self, tmp_path, monkeypatch):
+        settings = _make_settings(tmp_path)
+
+        audio_dir = tmp_path / "audio"
+        audio_dir.mkdir()
+        (audio_dir / "test.wav").write_bytes(b"\x00" * 100)
+        settings.directories.raw_audio = audio_dir
+
+        captured_args = {}
+
+        class FakeBatchProcessor:
+            def __init__(self, s, model_override=None):
+                captured_args["model_override"] = model_override
+
+            def process_files(self, files, force=False, progress_callback=None):
+                return [{"success": True}]
+
+        monkeypatch.setattr("chirp.cli.get_settings", lambda: settings)
+
+        import sys
+        from unittest.mock import MagicMock
+
+        if "faster_whisper" not in sys.modules:
+            sys.modules["faster_whisper"] = MagicMock()
+
+        monkeypatch.setattr(
+            "transcriber.batch_processor.BatchProcessor",
+            FakeBatchProcessor,
+        )
+
+        from typer.testing import CliRunner
+
+        import chirp.cli
+
+        runner = CliRunner()
+        runner.invoke(chirp.cli.app, ["transcribe"])
+
+        assert captured_args.get("model_override") is None

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -266,8 +266,18 @@ class TestDeviceManager:
 
             with patch.object(device_manager, "list_devices") as mock_list:
                 mock_list.return_value = [
-                    {"index": 0, "name": "Built-in Microphone", "max_input_channels": 1, "max_output_channels": 0},
-                    {"index": 1, "name": "Aggregate Device", "max_input_channels": 2, "max_output_channels": 0},
+                    {
+                        "index": 0,
+                        "name": "Built-in Microphone",
+                        "max_input_channels": 1,
+                        "max_output_channels": 0,
+                    },
+                    {
+                        "index": 1,
+                        "name": "Aggregate Device",
+                        "max_input_channels": 2,
+                        "max_output_channels": 0,
+                    },
                 ]
 
                 result = device_manager.find_device_by_name("Aggregate Device")
@@ -279,8 +289,18 @@ class TestDeviceManager:
 
             with patch.object(device_manager, "list_devices") as mock_list:
                 mock_list.return_value = [
-                    {"index": 0, "name": "Built-in Microphone", "max_input_channels": 1, "max_output_channels": 0},
-                    {"index": 1, "name": "My Aggregate Device", "max_input_channels": 2, "max_output_channels": 0},
+                    {
+                        "index": 0,
+                        "name": "Built-in Microphone",
+                        "max_input_channels": 1,
+                        "max_output_channels": 0,
+                    },
+                    {
+                        "index": 1,
+                        "name": "My Aggregate Device",
+                        "max_input_channels": 2,
+                        "max_output_channels": 0,
+                    },
                 ]
 
                 result = device_manager.find_device_by_name("Aggregate")
@@ -292,7 +312,12 @@ class TestDeviceManager:
 
             with patch.object(device_manager, "list_devices") as mock_list:
                 mock_list.return_value = [
-                    {"index": 0, "name": "Built-in Microphone", "max_input_channels": 1, "max_output_channels": 0},
+                    {
+                        "index": 0,
+                        "name": "Built-in Microphone",
+                        "max_input_channels": 1,
+                        "max_output_channels": 0,
+                    },
                 ]
 
                 result = device_manager.find_device_by_name("Aggregate Device")

--- a/transcriber/batch_processor.py
+++ b/transcriber/batch_processor.py
@@ -14,8 +14,16 @@ from utils.time_utils import derive_recording_id
 
 
 class BatchProcessor:
-    def __init__(self, settings: ChirpSettings):
+    def __init__(self, settings: ChirpSettings, model_override: Optional[str] = None):
         self.settings = settings
+        if model_override:
+            settings = settings.model_copy(
+                update={
+                    "models": settings.models.model_copy(
+                        update={"whisper": model_override}
+                    )
+                }
+            )
         self.transcriber = WhisperTranscriber(settings)
         self.compressor = JSONCompressor()
         self.popup_manager = PopupManager()

--- a/transcriber/batch_processor.py
+++ b/transcriber/batch_processor.py
@@ -15,7 +15,6 @@ from utils.time_utils import derive_recording_id
 
 class BatchProcessor:
     def __init__(self, settings: ChirpSettings, model_override: Optional[str] = None):
-        self.settings = settings
         if model_override:
             settings = settings.model_copy(
                 update={
@@ -24,6 +23,7 @@ class BatchProcessor:
                     )
                 }
             )
+        self.settings = settings
         self.transcriber = WhisperTranscriber(settings)
         self.compressor = JSONCompressor()
         self.popup_manager = PopupManager()


### PR DESCRIPTION
- Add `chirp version` command to show installed package version
- Add `chirp list` command to browse all meeting notes in a table
- Add `--model` flag to `chirp transcribe` for per-run Whisper model override
- Expand `chirp config` with --whisper-model, --llm-model, --ollama-url,
  --embedding-model options and show embedding model in --list output
- Add progress spinner to `chirp index` with file count feedback
- Fix deprecated Pydantic .dict() → .model_dump() in config/settings.py
- Fix bare except: clauses in notes_chat/index.py
- Replace raw print() with logging in notes_chat/retrieval.py
- Apply ruff formatting fixes across touched files

https://claude.ai/code/session_014DPy1UJ3FjktV2ffwCQMvJ