### PR TITLE
Fix for Use of exit() or quit()

### DIFF
--- a/scripts/test_live_vad.py
+++ b/scripts/test_live_vad.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import queue
+import sys
 import threading
 import time
 
@@ -122,4 +123,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())


### PR DESCRIPTION
Use `sys.exit(main())` instead of `exit(main())`, and import `sys`.

Best fix without changing behavior:
- In `scripts/test_live_vad.py`, add `import sys` with the other standard library imports.
- Replace the entrypoint call on line 125 from `exit(main())` to `sys.exit(main())`.

This preserves current functionality (return code propagation) while removing dependence on `site.Quitter`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._