### PR TITLE
ci: harden workflow permissions and enable CodeQL quality queries

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '21 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: ⤵️ Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🛠️ Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: 🔎 Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   quality-and-build:
     runs-on: macos-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -9,10 +9,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality-checks:
     if: github.event.pull_request.draft == false
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - name: ⤵️ Checkout code
         uses: actions/checkout@v6
@@ -32,6 +37,8 @@ jobs:
     needs: quality-checks
     if: github.event.pull_request.draft == false
     uses: ./.github/workflows/shared-build-and-test.yaml
+    permissions:
+      contents: read
     with:
       python-version: '3.11'
       os-matrix: '["macos-latest"]'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,9 +17,14 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     uses: ./.github/workflows/shared-build-and-test.yaml
+    permissions:
+      contents: read
     with:
       python-version: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.python-version || '3.11' }}
       os-matrix: '["macos-latest"]'

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -46,6 +46,8 @@ on:
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -162,6 +164,8 @@ jobs:
     if: ${{ inputs.run-integration-tests }}
     needs: build-and-test
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Add explicit least-privilege `permissions:` blocks to `main-build.yml`, `pr-checks.yml`, `publish.yaml`, and `shared-build-and-test.yaml`. This clears the **6 open `actions/missing-workflow-permissions` CodeQL alerts** ([Security → Code scanning](https://github.com/Code-and-Sorts/chirp-ai-note-app/security/code-scanning)).
- Add `.github/workflows/codeql.yml` (advanced CodeQL setup) running the `security-and-quality` query suite for `actions` and `python`, so findings populate the [Code Quality](https://github.com/Code-and-Sorts/chirp-ai-note-app/security/quality) view in addition to Code Scanning.

## ⚠️ Action required before merging
This repo currently has **CodeQL Default Setup** enabled. Default setup and an advanced CodeQL workflow file cannot run side-by-side — the new workflow will fail until default setup is disabled.

Disable it via either:
- **UI:** Settings → Code security → Code scanning → CodeQL analysis → ⋯ → *Switch to advanced*, or *Disable*.
- **API:** `gh api -X PATCH repos/Code-and-Sorts/chirp-ai-note-app/code-scanning/default-setup -f state=not-configured`

After disabling, the `CodeQL` workflow defined here will take over (same languages: `actions`, `python`) and additionally emit quality-tagged findings.

## Why these permission scopes
| Workflow | Job-level scope | Reason |
|---|---|---|
| `main-build.yml` | `contents: read` (workflow root) | only needs to checkout + build + upload artifacts (artifact upload doesn't require write to `contents`). |
| `pr-checks.yml` | `contents: read` root + per-job `contents: read`; existing `pull-requests: write` / `id-token: write` retained for the publish-to-test-pypi job | quality and build jobs only read; publish job keeps OIDC + PR-comment scopes. |
| `publish.yaml` | `contents: read` root + per-job `contents: read` for build-and-test; existing publish/sync-version permissions retained | release sync job already declared `contents: write` + `pull-requests: write`; left intact. |
| `shared-build-and-test.yaml` | `contents: read` on both jobs | only checkout + build + tests + artifact upload. |

## Test plan
- [ ] CI passes on this PR with the new permission blocks.
- [ ] After disabling default setup and merging, confirm new `CodeQL` workflow runs on `main` and on PRs.
- [ ] Confirm 6 `actions/missing-workflow-permissions` alerts close as fixed once analysis re-runs against `main`.
- [ ] Verify `/security/quality` view begins showing quality-tagged findings (or stays empty if codebase is clean against the quality suite).