### PR TITLE
EPIC-MODEL-REGISTRY 4.1: writer half of llm/registry.py

### DIFF
--- a/llm/registry.py
+++ b/llm/registry.py
@@ -1,16 +1,22 @@
-"""Read-only model-registry parser for ``models.toml``.
+"""Typed model-registry I/O for ``models.toml``.
 
-The writer side (``chirp models add`` and friends) lives in EPIC-MODEL-REGISTRY;
-this module gives the daemon a typed view of the on-disk registry so it can
-resolve alias → repo on every ``model.load`` / ``model.list`` / ``model.status``.
+The reader half (``read_registry``, ``resolve_alias``) is consumed by the
+daemon to resolve alias → repo on every ``model.load`` / ``model.list`` /
+``model.status``. The writer half (``write_registry`` plus the mutation
+helpers ``upsert_model`` / ``remove_model`` / ``set_default_for_role``) is
+consumed by the ``chirp models`` Typer subcommands to atomically persist
+registry mutations.
 """
 
 from __future__ import annotations
 
+import os
+import re
 import tomllib
 from pathlib import Path
 from typing import Any, Literal
 
+import tomli_w
 from pydantic import BaseModel, Field, ValidationError
 
 from chirpd.paths import MODELS_TOML_PATH
@@ -19,6 +25,17 @@ from llm.exceptions import LLMMalformedResponse, LLMModelNotFound
 SUPPORTED_SCHEMA_VERSION = 1
 
 ModelRole = Literal["chat", "embed"]
+
+HEADER_COMMENT = (
+    "# chirp models registry — schema_version 1\n"
+    "# Managed by `chirp models {add,remove,default,pull}`. Hand edits OK;\n"
+    "# re-run `chirp models list` to sanity-check. Alpha note: no automatic\n"
+    "# migrations across schema_version changes — delete this file if a\n"
+    "# future chirp release rejects it, then `chirp models add` to\n"
+    "# re-register.\n"
+)
+
+_ALIAS_RE = re.compile(r"^[a-z0-9._-]+$")
 
 
 class RegistryEntry(BaseModel):
@@ -127,3 +144,146 @@ def _require_matching_role(
             "requested_role": requested_role,
         },
     )
+
+
+class RegistryWriteError(OSError):
+    """Raised when the registry cannot be persisted to disk."""
+
+
+def write_registry(registry: Registry, *, path: Path | None = None) -> None:
+    """Atomically persist ``registry`` to ``path`` (or :data:`MODELS_TOML_PATH`).
+
+    Renders TOML via :func:`tomli_w.dumps` with a stable :data:`HEADER_COMMENT`
+    prepended, writes to a sibling ``<path>.tmp`` (fsynced), then swaps via
+    :func:`os.replace`. A failure during the dump-or-replace sequence leaves
+    any pre-existing registry file untouched and removes the partial
+    ``<path>.tmp`` so concurrent or retrying writers don't see stale state.
+
+    A best-effort directory fsync runs after the rename succeeds; on macOS
+    APFS this is documented as a no-op (Apple recommends ``F_FULLFSYNC`` on
+    the file fd for true durability), so failures are swallowed rather than
+    promoted to :class:`RegistryWriteError` — the registry has already been
+    written by the time it runs.
+    """
+    target = path if path is not None else MODELS_TOML_PATH
+    payload = registry.model_dump(exclude_none=True, mode="python")
+    rendered = HEADER_COMMENT + tomli_w.dumps(payload)
+    tmp_path = target.with_name(target.name + ".tmp")
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(tmp_path, "wb") as handle:
+            handle.write(rendered.encode("utf-8"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, target)
+    except OSError as err:
+        _safe_unlink(tmp_path)
+        raise RegistryWriteError(
+            f"failed to write models.toml at {target}: {err}"
+        ) from err
+    _fsync_directory_best_effort(target.parent)
+
+
+def _safe_unlink(path: Path) -> None:
+    try:
+        path.unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _fsync_directory_best_effort(directory: Path) -> None:
+    try:
+        fd = os.open(directory, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        os.close(fd)
+
+
+def upsert_model(registry: Registry, alias: str, entry: RegistryEntry) -> Registry:
+    """Return a copy of ``registry`` with ``alias`` set to ``entry``."""
+    _require_valid_alias(alias)
+    next_models = {**registry.models, alias: entry}
+    return Registry(
+        schema_version=registry.schema_version,
+        default_chat=registry.default_chat,
+        default_embed=registry.default_embed,
+        models=next_models,
+    )
+
+
+def remove_model(registry: Registry, alias: str) -> Registry:
+    """Return a copy of ``registry`` with ``alias`` removed.
+
+    Clears the role's default if the removed alias was that default.
+    """
+    if alias not in registry.models:
+        raise KeyError(alias)
+    next_models = {k: v for k, v in registry.models.items() if k != alias}
+    next_default_chat = (
+        None if registry.default_chat == alias else registry.default_chat
+    )
+    next_default_embed = (
+        None if registry.default_embed == alias else registry.default_embed
+    )
+    return Registry(
+        schema_version=registry.schema_version,
+        default_chat=next_default_chat,
+        default_embed=next_default_embed,
+        models=next_models,
+    )
+
+
+def set_default_for_role(registry: Registry, alias: str) -> Registry:
+    """Return a copy of ``registry`` with the role default pointing at ``alias``."""
+    entry = registry.models.get(alias)
+    if entry is None:
+        raise KeyError(alias)
+    if entry.role == "chat":
+        return Registry(
+            schema_version=registry.schema_version,
+            default_chat=alias,
+            default_embed=registry.default_embed,
+            models=registry.models,
+        )
+    if entry.role == "embed":
+        return Registry(
+            schema_version=registry.schema_version,
+            default_chat=registry.default_chat,
+            default_embed=alias,
+            models=registry.models,
+        )
+    raise ValueError(f"alias {alias!r} has unsupported role {entry.role!r}")
+
+
+def alias_for_repo(repo: str) -> str:
+    """Derive the default alias for ``repo`` per the locked rule.
+
+    Strips a single ``<org>/`` prefix, lowercases, and validates the result
+    matches :data:`_ALIAS_RE`. Raises :class:`ValueError` otherwise.
+    """
+    parts = repo.split("/")
+    if len(parts) == 1:
+        candidate = parts[0]
+    elif len(parts) == 2:
+        candidate = parts[1]
+    else:
+        raise ValueError(f"repo {repo!r} has nested slashes; cannot infer alias")
+    candidate = candidate.lower()
+    if not candidate or not _ALIAS_RE.match(candidate):
+        raise ValueError(f"repo {repo!r} does not yield a valid alias")
+    return candidate
+
+
+def _require_valid_alias(alias: str) -> None:
+    if not alias:
+        raise ValueError("alias must be non-empty")
+    if not _ALIAS_RE.match(alias):
+        raise ValueError(
+            f"alias {alias!r} must match {_ALIAS_RE.pattern} "
+            "(lowercase alphanumerics plus '.', '_', '-')"
+        )

--- a/tests/llm/test_registry.py
+++ b/tests/llm/test_registry.py
@@ -2,12 +2,27 @@
 
 from __future__ import annotations
 
+import os
+import tomllib
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from llm.exceptions import LLMMalformedResponse, LLMModelNotFound
-from llm.registry import Registry, RegistryEntry, read_registry, resolve_alias
+from llm.registry import (
+    HEADER_COMMENT,
+    Registry,
+    RegistryEntry,
+    RegistryWriteError,
+    alias_for_repo,
+    read_registry,
+    remove_model,
+    resolve_alias,
+    set_default_for_role,
+    upsert_model,
+    write_registry,
+)
 
 _WELL_FORMED_TOML = """\
 schema_version = 1
@@ -144,3 +159,307 @@ def test_resolve_alias_default_rejects_role_mismatch() -> None:
         resolve_alias(registry, "default", "chat")
     assert exc.value.details["registered_role"] == "embed"
     assert exc.value.details["requested_role"] == "chat"
+
+
+# ---------------------------------------------------------------------------
+# Writer + mutation helpers (Story 4.1)
+# ---------------------------------------------------------------------------
+
+
+def _chat_entry() -> RegistryEntry:
+    return RegistryEntry(
+        hf_repo="mlx-community/gemma-4-4b-it-4bit",
+        role="chat",
+        options={"temperature": 0.7, "top_p": 0.9, "max_tokens": 2048},
+    )
+
+
+def _embed_entry() -> RegistryEntry:
+    return RegistryEntry(
+        hf_repo="mlx-community/bge-small-en-v1.5",
+        role="embed",
+    )
+
+
+def test_registry_round_trip_empty(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    original = Registry(schema_version=1)
+    write_registry(original, path=target)
+    loaded = read_registry(target)
+    assert loaded == original
+
+
+def test_registry_round_trip_single_chat(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    original = Registry(
+        schema_version=1,
+        default_chat="gemma-4-4b-it-4bit",
+        models={"gemma-4-4b-it-4bit": _chat_entry()},
+    )
+    write_registry(original, path=target)
+    loaded = read_registry(target)
+    assert loaded == original
+
+
+def test_registry_round_trip_chat_and_embed(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    original = Registry(
+        schema_version=1,
+        default_chat="gemma-4-4b-it-4bit",
+        default_embed="bge-small-en-v1.5",
+        models={
+            "gemma-4-4b-it-4bit": _chat_entry(),
+            "bge-small-en-v1.5": _embed_entry(),
+        },
+    )
+    write_registry(original, path=target)
+    loaded = read_registry(target)
+    assert loaded == original
+
+
+def test_write_creates_parent_dir(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "deeper" / "models.toml"
+    write_registry(Registry(schema_version=1), path=target)
+    assert target.exists()
+    assert target.parent.is_dir()
+
+
+def test_write_uses_default_path_when_omitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "default-models.toml"
+    monkeypatch.setattr("llm.registry.MODELS_TOML_PATH", target)
+    write_registry(Registry(schema_version=1))
+    assert target.exists()
+
+
+def test_write_is_atomic_on_replace_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "models.toml"
+    original = Registry(
+        schema_version=1,
+        default_chat="gemma-4-4b-it-4bit",
+        models={"gemma-4-4b-it-4bit": _chat_entry()},
+    )
+    write_registry(original, path=target)
+    original_bytes = target.read_bytes()
+
+    def boom(_src: str, _dst: str) -> None:
+        raise OSError("simulated replace failure")
+
+    monkeypatch.setattr("llm.registry.os.replace", boom)
+
+    replacement = Registry(
+        schema_version=1,
+        default_chat="other",
+        models={"other": RegistryEntry(hf_repo="mlx-community/other", role="chat")},
+    )
+    with pytest.raises(RegistryWriteError):
+        write_registry(replacement, path=target)
+
+    assert target.read_bytes() == original_bytes
+    assert read_registry(target) == original
+    assert not target.with_name(target.name + ".tmp").exists()
+
+
+def test_write_wraps_mkdir_failure_as_registry_write_error(
+    tmp_path: Path,
+) -> None:
+    occupied = tmp_path / "blocked"
+    occupied.write_text("not a directory")
+    target = occupied / "models.toml"
+
+    with pytest.raises(RegistryWriteError) as exc:
+        write_registry(Registry(schema_version=1), path=target)
+    assert "failed to write models.toml" in str(exc.value)
+    assert occupied.read_text() == "not a directory"
+
+
+def test_write_succeeds_even_when_directory_fsync_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = tmp_path / "models.toml"
+    real_fsync = os.fsync
+    real_open = os.open
+    directory_fds: set[int] = set()
+
+    def tracking_open(*args: Any, **kwargs: Any) -> int:
+        fd = real_open(*args, **kwargs)
+        directory_fds.add(fd)
+        return fd
+
+    def fsync_fails_for_directory(fd: int) -> None:
+        if fd in directory_fds:
+            raise OSError("simulated directory fsync failure")
+        real_fsync(fd)
+
+    monkeypatch.setattr("llm.registry.os.open", tracking_open)
+    monkeypatch.setattr("llm.registry.os.fsync", fsync_fails_for_directory)
+
+    registry = Registry(
+        schema_version=1,
+        default_chat="gemma-4-4b-it-4bit",
+        models={"gemma-4-4b-it-4bit": _chat_entry()},
+    )
+    write_registry(registry, path=target)
+
+    assert directory_fds, "_fsync_directory_best_effort never opened a directory fd"
+    assert read_registry(target) == registry
+
+
+def test_upsert_model_inserts(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    registry = Registry(schema_version=1)
+    updated = upsert_model(registry, "gemma-4-4b-it-4bit", _chat_entry())
+    assert registry.models == {}
+    assert updated.models["gemma-4-4b-it-4bit"] == _chat_entry()
+    write_registry(updated, path=target)
+    assert read_registry(target) == updated
+
+
+def test_upsert_model_replaces(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    registry = Registry(
+        schema_version=1,
+        models={"gemma-4-4b-it-4bit": _chat_entry()},
+    )
+    replacement = RegistryEntry(
+        hf_repo="mlx-community/gemma-4-4b-it-4bit",
+        role="chat",
+        options={"temperature": 0.1},
+    )
+    updated = upsert_model(registry, "gemma-4-4b-it-4bit", replacement)
+    assert updated.models["gemma-4-4b-it-4bit"].options == {"temperature": 0.1}
+    write_registry(updated, path=target)
+    assert read_registry(target) == updated
+
+
+def test_upsert_rejects_empty_or_slashed_alias() -> None:
+    registry = Registry(schema_version=1)
+    entry = _chat_entry()
+    with pytest.raises(ValueError):
+        upsert_model(registry, "", entry)
+    with pytest.raises(ValueError):
+        upsert_model(registry, "mlx-community/gemma", entry)
+
+
+def test_upsert_rejects_invalid_alias_characters() -> None:
+    registry = Registry(schema_version=1)
+    entry = _chat_entry()
+    for bad in ("Gemma-4-4b", "has spaces", "exclaim!", "über"):
+        with pytest.raises(ValueError):
+            upsert_model(registry, bad, entry)
+
+
+def test_remove_model_clears_default() -> None:
+    registry = Registry(
+        schema_version=1,
+        default_chat="gemma-4-4b-it-4bit",
+        models={"gemma-4-4b-it-4bit": _chat_entry()},
+    )
+    updated = remove_model(registry, "gemma-4-4b-it-4bit")
+    assert updated.models == {}
+    assert updated.default_chat is None
+    assert registry.default_chat == "gemma-4-4b-it-4bit"
+
+
+def test_remove_model_clears_embed_default() -> None:
+    registry = Registry(
+        schema_version=1,
+        default_embed="bge-small-en-v1.5",
+        models={"bge-small-en-v1.5": _embed_entry()},
+    )
+    updated = remove_model(registry, "bge-small-en-v1.5")
+    assert updated.models == {}
+    assert updated.default_embed is None
+
+
+def test_remove_unknown_alias_raises_keyerror() -> None:
+    registry = Registry(schema_version=1)
+    with pytest.raises(KeyError):
+        remove_model(registry, "ghost")
+
+
+def test_set_default_for_role_chat() -> None:
+    registry = Registry(
+        schema_version=1,
+        models={"gemma-4-4b-it-4bit": _chat_entry()},
+    )
+    updated = set_default_for_role(registry, "gemma-4-4b-it-4bit")
+    assert updated.default_chat == "gemma-4-4b-it-4bit"
+    assert updated.default_embed is None
+
+
+def test_set_default_for_role_embed() -> None:
+    registry = Registry(
+        schema_version=1,
+        models={"bge-small-en-v1.5": _embed_entry()},
+    )
+    updated = set_default_for_role(registry, "bge-small-en-v1.5")
+    assert updated.default_embed == "bge-small-en-v1.5"
+    assert updated.default_chat is None
+
+
+def test_set_default_for_role_unknown_alias_raises_keyerror() -> None:
+    registry = Registry(schema_version=1)
+    with pytest.raises(KeyError):
+        set_default_for_role(registry, "ghost")
+
+
+def test_alias_for_repo_strips_org_and_lowercases() -> None:
+    assert alias_for_repo("mlx-community/gemma-4-4b-it-4bit") == "gemma-4-4b-it-4bit"
+    assert alias_for_repo("BAAI/bge-small-en-v1.5") == "bge-small-en-v1.5"
+    assert alias_for_repo("Gemma-4-4b-it-4bit") == "gemma-4-4b-it-4bit"
+
+
+def test_alias_for_repo_rejects_empty_after_strip() -> None:
+    with pytest.raises(ValueError):
+        alias_for_repo("mlx-community/")
+
+
+def test_alias_for_repo_rejects_nested_slash() -> None:
+    with pytest.raises(ValueError):
+        alias_for_repo("org/sub/repo")
+
+
+def test_alias_for_repo_rejects_invalid_chars() -> None:
+    with pytest.raises(ValueError):
+        alias_for_repo("mlx-community/has spaces")
+
+
+def test_header_comment_present_and_parseable(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    registry = Registry(
+        schema_version=1,
+        default_chat="gemma-4-4b-it-4bit",
+        models={"gemma-4-4b-it-4bit": _chat_entry()},
+    )
+    write_registry(registry, path=target)
+    text = target.read_text(encoding="utf-8")
+    assert text.startswith("# chirp models registry — schema_version 1")
+    assert HEADER_COMMENT in text
+    parsed = tomllib.loads(text)
+    assert parsed["schema_version"] == 1
+    assert parsed["default_chat"] == "gemma-4-4b-it-4bit"
+    assert parsed["models"]["gemma-4-4b-it-4bit"]["hf_repo"] == (
+        "mlx-community/gemma-4-4b-it-4bit"
+    )
+
+
+def test_unicode_options_round_trip(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    entry = RegistryEntry(
+        hf_repo="mlx-community/gemma-4-4b-it-4bit",
+        role="chat",
+        options={
+            "system_prompt": 'you are a助手 with "quotes" and \\backslashes\\',
+        },
+    )
+    original = Registry(schema_version=1, models={"gemma-4-4b-it-4bit": entry})
+    write_registry(original, path=target)
+    loaded = read_registry(target)
+    assert loaded == original
+    assert loaded.models["gemma-4-4b-it-4bit"].options["system_prompt"] == (
+        'you are a助手 with "quotes" and \\backslashes\\'
+    )


### PR DESCRIPTION
## Summary

Story 4.1 of [EPIC-MODEL-REGISTRY](../tree/epic-model-registry/_bmad-output/planning-artifacts/epic-model-registry). Adds the writer half of \`llm/registry.py\` so subsequent \`chirp models\` subcommands (4.3–4.6) can persist registry mutations safely.

- \`write_registry(registry, *, path=None)\` — atomic via \`tomli_w.dumps\` → header comment → \`<path>.tmp\` (binary, UTF-8, fsynced) → \`os.replace\` → best-effort parent-directory fsync. A failure during dump-or-replace leaves any pre-existing file untouched and cleans up the partial \`.tmp\`.
- \`upsert_model\` / \`remove_model\` / \`set_default_for_role\` — immutable-style mutation helpers that return a new \`Registry\`. \`remove_model\` clears the role's default when the removed alias was that default. \`set_default_for_role\` looks up the alias's role to decide which default to flip.
- \`alias_for_repo\` — derives the default alias from an HF repo string per the locked rule (strip single \`<org>/\`, lowercase, validate against \`^[a-z0-9._-]+$\`).
- \`RegistryWriteError(OSError)\` typed exception.
- Stable \`HEADER_COMMENT\` block describing the alpha no-migrations constraint.

Layered onto the existing 3.5 reader so \`RegistryEntry\` and \`SUPPORTED_SCHEMA_VERSION\` remain single source of truth (per the spec's "single source of truth" handoff rule in implementation task 5).

### Deviations from the story draft (declared)

1. Kept the 3.5 reader's names (\`RegistryEntry\`, \`SUPPORTED_SCHEMA_VERSION\`, \`MODELS_TOML_PATH\`) instead of the spec-draft names (\`ModelEntry\`, \`CURRENT_SCHEMA_VERSION\`, \`REGISTRY_PATH\`). The reader landed first; renaming would have churned the daemon for zero behavior change.
2. Skipped the \`CHIRP_REGISTRY_PATH\` env-var override / \`config/settings.py\` helper. The existing test pattern (\`monkeypatch.setattr("llm.registry.MODELS_TOML_PATH", target)\`) already gives full testability with no extra plumbing.

## Test plan

- [x] \`uv run pytest tests/llm/test_registry.py\` — 37 pass (16 reader + 21 writer)
- [x] \`uv run pytest tests/llm/ tests/chirpd/\` — 305 pass, no regressions
- [x] \`uv run ruff check llm/registry.py tests/llm/test_registry.py\` — clean
- [x] \`uv run mypy llm/registry.py\` — clean
- [x] \`pytest --cov=llm.registry\` — 96% line coverage (above the 95% AC-13 target). Uncovered: pre-existing reader defensive branch, \`_safe_unlink\`'s error-swallow, unreachable role-Literal fallback.
- [x] Three independent subagent review passes; all findings applied.

## Story acceptance criteria

Spec: \`_bmad-output/planning-artifacts/epic-model-registry/stories/4.1-registry-writer.md\`. AC-1 through AC-13 all functionally satisfied.