### PR TITLE
ci: trigger PR Quality Checks and CodeQL on epic-* base branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'epic-*' ]
   schedule:
     - cron: '21 6 * * 1'
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: PR Quality Checks
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'epic-*' ]
     types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:


### PR DESCRIPTION
## Summary

Story branches targeting an epic integration branch (\`story/4.1-...\` → \`epic-model-registry\`) were skipping CI because both \`pr-checks.yml\` and \`codeql.yml\` filter \`branches: [ main ]\`. This broadens the \`pull_request\` triggers to also match \`epic-*\` so the same quality gates run before stories land on the epic.

## Changes

- \`.github/workflows/pr-checks.yml\` — add \`'epic-*'\` to the \`pull_request.branches\` filter
- \`.github/workflows/codeql.yml\` — same

\`main-build.yml\` (push-to-main only) is intentionally unchanged — epic branches aren't deployed.

## Test plan

- [x] Workflow YAMLs pass \`check yaml\` pre-commit hook
- [ ] After merge, cherry-pick onto \`epic-model-registry\` so the existing PR #62 (story 4.1) picks up the new triggers
- [ ] Verify next push to story 4.1 triggers PR Quality Checks against the epic base