### PR TITLE
EPIC-MODEL-REGISTRY 4.4: chirp models list subcommand

### DIFF
--- a/_bmad-output/implementation-artifacts/bug-chirpd-registry-reread-and-embed-load.md
+++ b/_bmad-output/implementation-artifacts/bug-chirpd-registry-reread-and-embed-load.md
@@ -1,0 +1,66 @@
+# BUG: chirpd does not re-read the registry per op, and cannot load embed models
+
+- **Status:** Open
+- **Severity:** High (blocks the Maya/Priya end-to-end journeys: a freshly `add`ed model can't be warmed; no embed model can be warmed at all)
+- **Owning epic:** EPIC-CHIRPD-CORE
+- **Owning stories:** 3.5-model-lifecycle (Issue 2), 3.6-backend-and-inference (Issue 1) — both currently marked **Done**
+- **Found during:** manual smoke of story 4.4 (`chirp models list`) on 2026-05-28, Apple Silicon (arm64), against `mlx-community/bge-small-en-v1.5-bf16` and `mlx-community/Qwen2.5-0.5B-Instruct-4bit`
+- **Not a defect in:** story 4.4 — `chirp models list` behaved correctly throughout (rendered `loaded: false`/`null` faithfully, never spawned a daemon under `spawn_if_absent=False`). These are escaped defects in already-Done CHIRPD-CORE stories, surfaced by exercising `list` against a real daemon.
+
+## Summary
+
+Two independent daemon-side defects, both discovered while validating `chirp models list` against a live `chirpd`:
+
+1. **Embed models cannot be loaded.** `MLXBackend.load` routes every role through `mlx_lm.load`, which only supports causal LMs. Warming a `bert`-class embed model fails.
+2. **The daemon never re-reads `models.toml` after startup.** It caches the registry once at construction, so a model registered (or re-roled) after the daemon started is invisible to `model.load`/`model.list`/`model.status` until the daemon restarts — directly contradicting the architecture contract.
+
+---
+
+## Issue 1 — `MLXBackend.load` cannot load embed (`bert`) models
+
+- **Owning story:** 3.6-backend-and-inference (embed inference path)
+- **Symptom:**
+  ```
+  $ chirp models add mlx-community/bge-small-en-v1.5-bf16
+  Warming bge-small-en-v1.5-bf16...
+  Error: Model registered but warm failed: mlx_lm.load failed for
+  'mlx-community/bge-small-en-v1.5-bf16': Model type bert not supported.
+  ```
+- **Root cause:** `chirpd/backend.py:49` — `MLXBackend.load` calls `mlx_lm.load(local_path)` (`chirpd/backend.py:82`) for **both** `chat` and `embed` roles. `mlx_lm.load` only constructs causal-LM architectures, so any embedding model (`bert`, sentence-transformers, etc.) raises `Model type <x> not supported`. The downstream embed path (`MLXBackend.embed` / `_invoke_embed`, `chirpd/backend.py:170`/`:189`) is never reached because `load()` fails first.
+- **Expected (per spec):**
+  - Story 3.5 deferred inference to 3.6: *"`stream_generate` and `embed` raise `NotImplementedError` in this story; story 3.6 fills them in"* (`stories/3.5-model-lifecycle.md:105`).
+  - The epic assigns embed to 3.6: *"3.6 | Backend abstraction + MLX implementation: `chat` (streaming), `embed`, `cancel` ops"* (`epic-chirpd-core/epic.md:98`), with an acceptance bullet that `client.embed([...])` returns the right vector count (`epic.md:110`).
+  So `embed`-role loading was in 3.6's scope but the `load()` side was never branched for it.
+- **Proposed fix:** branch `MLXBackend.load` on `role`. For `role == "embed"`, use an embedding-capable loader (an MLX embedding model loader / sentence-transformers-style path) instead of `mlx_lm.load`, returning a handle whose `embed`/`embed_tokens` callable satisfies `_invoke_embed`. Add a `@slow @integration` test that loads and embeds against a small real `bge` model.
+
+---
+
+## Issue 2 — daemon caches the registry at startup; never re-reads per op
+
+- **Owning story:** 3.5-model-lifecycle (per-op registry read)
+- **Symptom:** after a daemon is already running, registering a new alias and warming it fails until the daemon is restarted:
+  ```
+  $ chirp models add mlx-community/Qwen2.5-0.5B-Instruct-4bit   # daemon already up
+  Warming qwen2.5-0.5b-instruct-4bit...
+  Error: Model registered but warm failed: unknown model alias
+  'qwen2.5-0.5b-instruct-4bit'. ...
+  # kill chirpd, retry → "Ready." (fresh daemon re-read the registry)
+  ```
+- **Root cause:** `chirpd/__main__.py` (`main()`) calls `read_registry()` exactly once at startup and hands the result to `DaemonState`. `DaemonState._registry` (`chirpd/state.py:46`) stores that snapshot for the daemon's lifetime; `resolve_alias` always consults the frozen copy (`chirpd/state.py:78`, `:88`) and `list_models` iterates it (`chirpd/state.py:145`). Nothing re-reads `models.toml`.
+- **Expected (per spec) — this is a contract violation, not a missing feature:**
+  - Story 3.5 dev notes: *"Reading `models.toml` happens **on every `model.load`/`model.list`/`model.status`** per architecture § Configuration & Persistence (no hot-reload; daemon doesn't watch the file)"* (`stories/3.5-model-lifecycle.md:289`).
+  - Model-registry epic: *"The daemon re-reads on `model.*` ops; manual edits between ops are visible to the next op without requiring restart, but file-watcher complexity is not introduced"* (`epic-model-registry/epic.md:138`).
+- **Proposed fix:** re-read `models.toml` at the start of each `model.load` / `model.list` / `model.status` handler (or via a `DaemonState` accessor that re-reads), replacing the cached `self._registry`. Keep it a plain per-op read — **not** a file-watcher (hot-reload is explicitly out of scope per PRD §Explicit Out of Scope and `epic.md:138`). Mind the existing `_registry_locks` / per-model lock discipline when swapping the registry reference. Add a test: construct `DaemonState`, mutate the on-disk `models.toml`, assert the next `model.list`/`model.load` sees the new alias without reconstruction.
+
+---
+
+## Evidence (4.4 smoke, isolated `HOME`, real `chirpd`, real MLX)
+
+- `list` with no daemon → `(daemon not running — loaded state unknown)`, table with `★`/`—`, `--json` → `daemon_reachable: false`, `loaded: null`. No socket created (confirmed `list` does not spawn). ✅ (4.4 correct)
+- Warming embed `bge-small-en-v1.5-bf16` → Issue 1 (`Model type bert not supported`).
+- Warming newly-added `Qwen2.5-0.5B-Instruct-4bit` against an already-running daemon → Issue 2 (`unknown model alias`); succeeded after daemon restart (`Ready.`).
+- Post-restart `list` (daemon up, qwen warmed) → `daemon_reachable: true`, qwen `loaded ●` / `true`, bge `loaded —` / `false`; `list --json | jq -e .` parsed OK. ✅ (4.4 correct)
+
+## Recommended handling
+
+Both owning stories are **Done**, so log via BMAD **correct course** against EPIC-CHIRPD-CORE (3.5 and 3.6) to record the deviation and schedule the fixes, or reopen 3.5/3.6 directly. Issue 2 is the higher priority — it breaks the core "`add` then use" loop for chat models too, not just embed.

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -40,3 +40,7 @@
 
 - Banner test exercises the format string in isolation, not the `InteractiveChatSession.start()` code path. `start()` calls `prompt_toolkit.PromptSession.prompt()` which expects a real TTY; defer an end-to-end banner test until a `prompt_toolkit` session stub is in place. [tests/test_ask_sources.py]
 - `_build_note_index` rebuilds the slug→index map on every retrieval call (`list_notes` + `meta.toml` reads per query). Acceptable at typical scale (10–100 notes); revisit if profiling flags it. [notes_chat/retrieval.py]
+
+## Found during: smoke of 4.4-models-list (2026-05-28)
+
+- Two escaped CHIRPD-CORE defects surfaced while validating `chirp models list` against a real daemon: (1) `MLXBackend.load` can't load embed (`bert`) models — story 3.6; (2) the daemon never re-reads `models.toml` per op, so newly-added aliases fail to warm until restart — story 3.5 (contract violation). Full report: [bug-chirpd-registry-reread-and-embed-load.md](bug-chirpd-registry-reread-and-embed-load.md). Story 4.4 itself is unaffected. [chirpd/backend.py:49, chirpd/state.py:46]

--- a/_bmad-output/planning-artifacts/epic-model-registry/stories/4.4-models-list.md
+++ b/_bmad-output/planning-artifacts/epic-model-registry/stories/4.4-models-list.md
@@ -1,6 +1,6 @@
 # Story 4.4 — `chirp models list` subcommand
 
-- **Status:** Review
+- **Status:** Done
 - **Epic:** [EPIC-MODEL-REGISTRY](../epic.md)
 - **Depends on:** 4.1 (registry shape + reader contract via CHIRPD-CORE 3.5), 4.3 (shared `RichProgressCallback` and error-mapping helpers), EPIC-CHIRPD-CORE story 3.7 (`model.list` daemon op + `llm.client.model_list()`)
 - **Blocks:** 4.6
@@ -145,4 +145,7 @@ The stable contract from this story: a working `chirp models list` (TTY + JSON) 
   - **`cache_path` deferred to 4.5** per the AC-3 note; marked with a `# TODO(4.5)` comment in `models.py`. Kept out of the list table and the JSON schema (which matches AC-5 exactly).
   - **Sort order:** `(role, alias)` ascending — `chat` sorts before `embed` alphabetically. Documented in `_compose_rows`.
   - Non-TTY without `--json` still renders the table; `stdout_console = Console()` auto-degrades (no ANSI/color) when stdout is piped, so the output stays grep-friendly.
-- **AC-10 manual smoke:** not run in this environment (requires Apple-silicon hardware + a live `chirpd`). To verify before merge: `chirp models add mlx-community/bge-small-en-v1.5 --no-warm` → `chirp models list` (expect `loaded = —`, `default = ★`), then warm and re-list (expect `loaded = ●`), and `chirp models list --json | jq .`.
+- **AC-10 manual smoke — run 2026-05-28, Apple Silicon (arm64), real `chirpd` + real MLX, isolated `HOME`:**
+  - `models add mlx-community/bge-small-en-v1.5-bf16 --no-warm` → registered, `default_embed` set, no daemon spawned. `models list` (no daemon) → `(daemon not running — loaded state unknown)` on stderr, table with `default = ★` / `loaded = —`; `--json` → `daemon_reachable: false`, `loaded: null`. **`list` did not create the socket — confirmed non-spawning.**
+  - Warmed a real chat model (`mlx-community/Qwen2.5-0.5B-Instruct-4bit` → `Ready.`); `models list` → `daemon_reachable: true`, qwen `loaded = ●` / `true`, sorted `chat` before `embed`; `models list --json | jq -e .` parsed OK.
+  - **Two daemon-side defects surfaced (NOT 4.4 defects — `list` rendered every state faithfully):** embed models can't be warmed (`mlx_lm.load` rejects `bert`) and the daemon caches the registry at startup (newly-added alias fails to warm until restart). Filed: [`implementation-artifacts/bug-chirpd-registry-reread-and-embed-load.md`](../../implementation-artifacts/bug-chirpd-registry-reread-and-embed-load.md) against EPIC-CHIRPD-CORE 3.5/3.6. The embed-warm step of the AC-10 script was substituted with a chat model to demonstrate `loaded = ●`.

--- a/_bmad-output/planning-artifacts/epic-model-registry/stories/4.4-models-list.md
+++ b/_bmad-output/planning-artifacts/epic-model-registry/stories/4.4-models-list.md
@@ -1,6 +1,6 @@
 # Story 4.4 — `chirp models list` subcommand
 
-- **Status:** Draft
+- **Status:** Review
 - **Epic:** [EPIC-MODEL-REGISTRY](../epic.md)
 - **Depends on:** 4.1 (registry shape + reader contract via CHIRPD-CORE 3.5), 4.3 (shared `RichProgressCallback` and error-mapping helpers), EPIC-CHIRPD-CORE story 3.7 (`model.list` daemon op + `llm.client.model_list()`)
 - **Blocks:** 4.6
@@ -133,3 +133,16 @@ The output is a Rich table on TTY and a single JSON document on `--json`. Implem
 - **4.6 (Typer wiring + completion)** registers the `list` command (along with `add`, `show`, `default`, `remove`, `pull`) under the top-level `chirp` Typer app.
 
 The stable contract from this story: a working `chirp models list` (TTY + JSON) per Priya's journey, and a row-composer helper that 4.5's `show` reuses.
+
+## Dev Agent Record
+
+- **Implemented:** `llm/cli/models.py` (`list` command + `ListRow` dataclass, `_query_loaded_state`, `_compose_rows`, `_render_list_table`, `_render_list_json`); `llm/cli/_console.py` (added `stdout_console` so the table lands on stdout while diagnostics stay on stderr); `llm/client.py` (added `spawn_if_absent` kwarg threaded through `model_list`/`model_list_sync`/`_request`/`_connect_with_handshake`/`_open_connection`). Tests: 12 in `tests/llm/test_cli_models.py` (AC-7) + 1 in `tests/llm/test_client.py` for the no-spawn path.
+- **Gates:** `uv run pytest tests/llm` green (276+ tests); `ruff check`, `ruff format --check`, `mypy` clean; 100% line coverage on `models.py` (AC-9).
+- **Spec-vs-reality deviations (intentional):**
+  - The CHIRPD-CORE client exposes no `spawn_if_absent` flag, so it was added (the AC explicitly allowed "or its equivalent"). When `spawn_if_absent=False` and the socket is absent/refused, `_open_connection` raises `LLMDaemonUnreachable` instead of lazy-spawning.
+  - The daemon `model.list` op returns `list[dict]` with a per-entry `loaded` bool (see `chirpd/state.py:list_models`), **not** the spec's hypothetical `{"loaded_aliases": [...]}`. `_query_loaded_state` derives the loaded-alias `set` from the real shape.
+  - Unsupported `schema_version` surfaces as `LLMModelNotFound` (registry reality), mapped to exit 1 via the reused `_read_registry` helper from 4.3 — not the spec's `RegistryUnsupportedSchemaVersion`.
+  - **`cache_path` deferred to 4.5** per the AC-3 note; marked with a `# TODO(4.5)` comment in `models.py`. Kept out of the list table and the JSON schema (which matches AC-5 exactly).
+  - **Sort order:** `(role, alias)` ascending — `chat` sorts before `embed` alphabetically. Documented in `_compose_rows`.
+  - Non-TTY without `--json` still renders the table; `stdout_console = Console()` auto-degrades (no ANSI/color) when stdout is piped, so the output stays grep-friendly.
+- **AC-10 manual smoke:** not run in this environment (requires Apple-silicon hardware + a live `chirpd`). To verify before merge: `chirp models add mlx-community/bge-small-en-v1.5 --no-warm` → `chirp models list` (expect `loaded = —`, `default = ★`), then warm and re-list (expect `loaded = ●`), and `chirp models list --json | jq .`.

--- a/llm/cli/_console.py
+++ b/llm/cli/_console.py
@@ -1,10 +1,12 @@
-"""Shared Rich console for the ``chirp models`` subcommands.
+"""Shared Rich consoles for the ``chirp models`` subcommands.
 
-All progress, status, and error output from ``chirp models *`` goes to
-**stderr** so stdout stays clean for future structured output (architecture
-§CLI Output Patterns). A single console instance is shared across the
-subcommand modules and the progress adapter rather than each call site building
-its own, so width, theme, and terminal detection stay consistent.
+Progress, status, and error output from ``chirp models *`` goes to **stderr**
+(``console``) so stdout stays clean for structured output (architecture §CLI
+Output Patterns). Commands whose primary result is a rendered artifact — e.g.
+the ``chirp models list`` table — write that artifact to **stdout**
+(``stdout_console``) while keeping diagnostic preamble on stderr. Sharing single
+console instances across the subcommand modules and the progress adapter keeps
+width, theme, and terminal detection consistent.
 """
 
 from __future__ import annotations
@@ -12,3 +14,4 @@ from __future__ import annotations
 from rich.console import Console
 
 console = Console(stderr=True)
+stdout_console = Console()

--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -158,7 +158,11 @@ def _compose_rows(registry: Registry, loaded_aliases: set[str]) -> list[ListRow]
     Sorted by ``(role, alias)`` ascending — ``chat`` sorts before ``embed`` —
     so the table order is stable across runs.
     """
-    defaults = {registry.default_chat, registry.default_embed}
+    defaults = {
+        alias
+        for alias in (registry.default_chat, registry.default_embed)
+        if alias is not None
+    }
     rows = [
         ListRow(
             alias=alias,

--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -15,18 +15,23 @@ weights land, and the user retries the warm with ``chirp models pull``.
 
 from __future__ import annotations
 
+import json
 import os
+import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, NoReturn
+from typing import Any, Literal, NoReturn
 
 import typer
+from rich.table import Table
 
 from chirpd.paths import MODELS_TOML_PATH
 from llm import hf
-from llm.cli._console import console
+from llm.cli._console import console, stdout_console
 from llm.cli._progress import RichProgressCallback
 from llm.client import LLMClient
 from llm.exceptions import (
+    LLMDaemonUnreachable,
     LLMMalformedResponse,
     LLMModelError,
     LLMModelNotFound,
@@ -51,10 +56,9 @@ app = typer.Typer(name="models", help="Manage chirp's MLX model registry")
 def models_main() -> None:
     """Manage chirp's MLX model registry.
 
-    This callback exists to keep ``models`` a multi-command group while ``add``
-    is its only subcommand; without it Typer auto-promotes the lone command to
-    the group root and ``chirp models add`` would stop parsing. Future
-    subcommands (4.4/4.5) make it load-bearing.
+    This callback keeps ``models`` a multi-command group so Typer does not
+    auto-promote a lone subcommand to the group root. ``add`` (4.3) and ``list``
+    (4.4) live here; ``show``/``default``/``remove``/``pull`` follow in 4.5.
     """
 
 
@@ -93,6 +97,130 @@ def add_command(
 
     if not no_warm:
         _warm(resolved_alias, resolved_role)
+
+
+# TODO(4.5): include cache_path (huggingface_hub.try_to_load_from_cache) in the
+# `show` command. Story 4.4 deferred it from the `list` view to keep the table
+# narrow and the JSON schema minimal.
+
+
+@dataclass(frozen=True)
+class ListRow:
+    """One rendered row of ``chirp models list`` — one registered alias."""
+
+    alias: str
+    role: ModelRole
+    is_default: bool
+    loaded: bool
+    hf_repo: str
+
+
+@app.command("list")
+def list_command(
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit a JSON document on stdout instead of a table.",
+    ),
+) -> None:
+    """List registered models with role, default, and daemon-loaded state."""
+    registry = _read_registry()
+    daemon_reachable, loaded_aliases = _query_loaded_state()
+    rows = _compose_rows(registry, loaded_aliases)
+    if json_output:
+        _render_list_json(registry, rows, daemon_reachable)
+    else:
+        _render_list_table(rows, daemon_reachable)
+
+
+def _query_loaded_state() -> tuple[bool, set[str]]:
+    """Return ``(daemon_reachable, loaded_aliases)`` without spawning a daemon.
+
+    ``list`` is a diagnostic command, so a missing daemon is a soft fail: we
+    report loaded state as unknown rather than lazy-spawning one (which would
+    mask the very "is the daemon running?" question ``list`` answers).
+    """
+    try:
+        models = LLMClient().model_list_sync(spawn_if_absent=False)
+    except LLMDaemonUnreachable:
+        return False, set()
+    loaded_aliases = {
+        model["alias"]
+        for model in models
+        if isinstance(model.get("alias"), str) and model.get("loaded")
+    }
+    return True, loaded_aliases
+
+
+def _compose_rows(registry: Registry, loaded_aliases: set[str]) -> list[ListRow]:
+    """Build the sorted render rows from the registry and loaded-alias set.
+
+    Sorted by ``(role, alias)`` ascending — ``chat`` sorts before ``embed`` —
+    so the table order is stable across runs.
+    """
+    defaults = {registry.default_chat, registry.default_embed}
+    rows = [
+        ListRow(
+            alias=alias,
+            role=entry.role,
+            is_default=alias in defaults,
+            loaded=alias in loaded_aliases,
+            hf_repo=entry.hf_repo,
+        )
+        for alias, entry in registry.models.items()
+    ]
+    rows.sort(key=lambda row: (row.role, row.alias))
+    return rows
+
+
+def _render_list_table(rows: list[ListRow], daemon_reachable: bool) -> None:
+    if not rows:
+        console.print(
+            "No models registered. Run `chirp models add <hf-repo>` to get started.",
+            markup=False,
+            soft_wrap=True,
+        )
+        return
+    if not daemon_reachable:
+        console.print(
+            "(daemon not running — loaded state unknown)",
+            markup=False,
+            soft_wrap=True,
+        )
+    table = Table(title="Models")
+    for column in ("alias", "role", "default", "loaded", "hf_repo"):
+        table.add_column(column)
+    for row in rows:
+        table.add_row(
+            row.alias,
+            row.role,
+            "★" if row.is_default else "",
+            "●" if daemon_reachable and row.loaded else "—",
+            row.hf_repo,
+        )
+    stdout_console.print(table)
+
+
+def _render_list_json(
+    registry: Registry, rows: list[ListRow], daemon_reachable: bool
+) -> None:
+    payload: dict[str, Any] = {
+        "schema_version": registry.schema_version,
+        "default_chat": registry.default_chat,
+        "default_embed": registry.default_embed,
+        "models": [
+            {
+                "alias": row.alias,
+                "role": row.role,
+                "default": row.is_default,
+                "loaded": row.loaded if daemon_reachable else None,
+                "hf_repo": row.hf_repo,
+            }
+            for row in rows
+        ],
+        "daemon_reachable": daemon_reachable,
+    }
+    sys.stdout.write(json.dumps(payload, indent=2) + "\n")
 
 
 def _validate_repo(hf_repo: str) -> hf.HfRepoMetadata:

--- a/llm/client.py
+++ b/llm/client.py
@@ -147,10 +147,10 @@ class LLMClient:
     def health_sync(self) -> dict[str, Any]:
         return _run_sync(self.health())
 
-    async def model_list(self) -> list[dict[str, Any]]:
+    async def model_list(self, *, spawn_if_absent: bool = True) -> list[dict[str, Any]]:
         envelope = {"id": new_request_id(), "op": OP_MODEL_LIST}
         status_payload: dict[str, Any] | None = None
-        async for event in self._request(envelope):
+        async for event in self._request(envelope, spawn_if_absent=spawn_if_absent):
             if event.get("event") == EVENT_STATUS:
                 status_payload = event
         if status_payload is None:
@@ -165,8 +165,8 @@ class LLMClient:
             )
         return models
 
-    def model_list_sync(self) -> list[dict[str, Any]]:
-        return _run_sync(self.model_list())
+    def model_list_sync(self, *, spawn_if_absent: bool = True) -> list[dict[str, Any]]:
+        return _run_sync(self.model_list(spawn_if_absent=spawn_if_absent))
 
     async def model_load(
         self,
@@ -334,11 +334,15 @@ class LLMClient:
     def cancel_sync(self, target_id: str) -> dict[str, Any]:
         return _run_sync(self.cancel(target_id))
 
-    async def _request(self, envelope: dict[str, Any]) -> AsyncIterator[dict[str, Any]]:
+    async def _request(
+        self, envelope: dict[str, Any], *, spawn_if_absent: bool = True
+    ) -> AsyncIterator[dict[str, Any]]:
         attempted_respawn = False
         while True:
             try:
-                reader, writer = await self._connect_with_handshake()
+                reader, writer = await self._connect_with_handshake(
+                    spawn_if_absent=spawn_if_absent
+                )
             except _HandshakeVersionMismatch as err:
                 if attempted_respawn or not self.retry_on_version_mismatch:
                     raise LLMVersionMismatch(
@@ -372,9 +376,9 @@ class LLMClient:
             await self._wait_for_socket_gone(VERSION_MISMATCH_RESPAWN_WAIT_S)
 
     async def _connect_with_handshake(
-        self,
+        self, *, spawn_if_absent: bool = True
     ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
-        reader, writer = await self._open_connection()
+        reader, writer = await self._open_connection(spawn_if_absent=spawn_if_absent)
         try:
             hello_event = await self._do_hello(reader, writer)
         except BaseException:
@@ -396,14 +400,19 @@ class LLMClient:
         )
 
     async def _open_connection(
-        self,
+        self, *, spawn_if_absent: bool = True
     ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
         try:
             return await asyncio.open_unix_connection(
                 str(self.socket_path), limit=_LINE_READ_LIMIT
             )
-        except (FileNotFoundError, ConnectionRefusedError):
-            pass
+        except (FileNotFoundError, ConnectionRefusedError) as err:
+            if not spawn_if_absent:
+                raise LLMDaemonUnreachable(
+                    f"daemon socket at {self.socket_path} is not accepting "
+                    "connections and spawn was disabled",
+                    details={"socket_path": str(self.socket_path)},
+                ) from err
 
         await self._spawn_daemon()
         try:

--- a/tests/llm/test_cli_models.py
+++ b/tests/llm/test_cli_models.py
@@ -9,6 +9,7 @@ network, or daemon subprocess.
 from __future__ import annotations
 
 import io
+import json
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -485,6 +486,241 @@ def test_add_registry_write_error_exits_1(
 
     assert result.exit_code == 1
     assert "Could not write registry" in result.stderr
+
+
+def _mock_list_client(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    models: list[dict[str, object]] | None = None,
+    unreachable: bool = False,
+) -> MagicMock:
+    client = MagicMock()
+    if unreachable:
+        client.model_list_sync.side_effect = LLMDaemonUnreachable("no socket")
+    else:
+        client.model_list_sync.return_value = models or []
+    factory = MagicMock(return_value=client)
+    monkeypatch.setattr(models_module, "LLMClient", factory)
+    return client
+
+
+@pytest.fixture
+def wide_table(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Widen the stdout table console so cells are not ellipsized in capture."""
+    monkeypatch.setattr(models_module, "stdout_console", Console(width=200))
+
+
+def _seed_chat_model(path: Path, alias: str = "gemma-4-4b-it-4bit") -> None:
+    _seed_registry(
+        path,
+        Registry(
+            schema_version=1,
+            default_chat=alias,
+            models={alias: RegistryEntry(hf_repo=CHAT_REPO, role="chat")},
+        ),
+    )
+
+
+def _seed_chat_and_embed(path: Path) -> None:
+    _seed_registry(
+        path,
+        Registry(
+            schema_version=1,
+            default_chat="gemma-4-4b-it-4bit",
+            default_embed="bge-small-en-v1.5",
+            models={
+                "gemma-4-4b-it-4bit": RegistryEntry(hf_repo=CHAT_REPO, role="chat"),
+                "bge-small-en-v1.5": RegistryEntry(hf_repo=EMBED_REPO, role="embed"),
+            },
+        ),
+    )
+
+
+def test_list_empty_registry_tty(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["list"])
+
+    assert result.exit_code == 0
+    assert "chirp models add" in result.stderr
+    assert result.stdout == ""
+
+
+def test_list_empty_registry_json(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["models"] == []
+    assert payload["default_chat"] is None
+    assert payload["daemon_reachable"] is True
+
+
+def test_list_one_chat_model_tty(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_list_client(
+        monkeypatch, models=[{"alias": "gemma-4-4b-it-4bit", "loaded": True}]
+    )
+
+    result = runner.invoke(models_module.app, ["list"])
+
+    assert result.exit_code == 0
+    assert "gemma-4-4b-it-4bit" in result.stdout
+    assert "★" in result.stdout
+    assert "●" in result.stdout
+
+
+def test_list_one_chat_model_json(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_list_client(
+        monkeypatch, models=[{"alias": "gemma-4-4b-it-4bit", "loaded": True}]
+    )
+
+    result = runner.invoke(models_module.app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["default_chat"] == "gemma-4-4b-it-4bit"
+    assert len(payload["models"]) == 1
+    model = payload["models"][0]
+    assert model["alias"] == "gemma-4-4b-it-4bit"
+    assert model["role"] == "chat"
+    assert model["default"] is True
+    assert model["loaded"] is True
+
+
+def test_list_chat_and_embed_tty(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
+) -> None:
+    _seed_chat_and_embed(registry_path)
+    _mock_list_client(
+        monkeypatch, models=[{"alias": "bge-small-en-v1.5", "loaded": True}]
+    )
+
+    result = runner.invoke(models_module.app, ["list"])
+
+    assert result.exit_code == 0
+    assert "gemma-4-4b-it-4bit" in result.stdout
+    assert "bge-small-en-v1.5" in result.stdout
+    assert result.stdout.count("★") == 2
+
+
+def test_list_chat_and_embed_json(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_and_embed(registry_path)
+    _mock_list_client(
+        monkeypatch, models=[{"alias": "bge-small-en-v1.5", "loaded": True}]
+    )
+
+    result = runner.invoke(models_module.app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    by_alias = {model["alias"]: model for model in payload["models"]}
+    assert by_alias["gemma-4-4b-it-4bit"]["loaded"] is False
+    assert by_alias["bge-small-en-v1.5"]["loaded"] is True
+    assert by_alias["bge-small-en-v1.5"]["role"] == "embed"
+    assert payload["default_embed"] == "bge-small-en-v1.5"
+
+
+def test_list_daemon_unreachable_tty(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_list_client(monkeypatch, unreachable=True)
+
+    result = runner.invoke(models_module.app, ["list"])
+
+    assert result.exit_code == 0
+    assert "daemon not running" in result.stderr
+    assert "●" not in result.stdout
+    assert "—" in result.stdout
+
+
+def test_list_daemon_unreachable_json(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_list_client(monkeypatch, unreachable=True)
+
+    result = runner.invoke(models_module.app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["daemon_reachable"] is False
+    assert all(model["loaded"] is None for model in payload["models"])
+
+
+def test_list_does_not_spawn_daemon(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    client = _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["list"])
+
+    assert result.exit_code == 0
+    client.model_list_sync.assert_called_once_with(spawn_if_absent=False)
+
+
+def test_list_unsupported_schema_version_exits_1(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registry_path.write_text("schema_version = 99\n", encoding="utf-8")
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["list"])
+
+    assert result.exit_code == 1
+    assert "schema version" in result.stderr
+
+
+def test_list_json_is_jq_compatible(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_list_client(
+        monkeypatch, models=[{"alias": "gemma-4-4b-it-4bit", "loaded": True}]
+    )
+
+    result = runner.invoke(models_module.app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert set(payload) == {
+        "schema_version",
+        "default_chat",
+        "default_embed",
+        "models",
+        "daemon_reachable",
+    }
+
+
+def test_list_stdout_clean_in_json_mode(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_list_client(
+        monkeypatch, models=[{"alias": "gemma-4-4b-it-4bit", "loaded": True}]
+    )
+
+    result = runner.invoke(models_module.app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) is not None
+    assert result.stdout.endswith("}\n")
+    assert result.stderr == ""
 
 
 def test_rich_progress_callback_non_tty_emits_status_lines() -> None:

--- a/tests/llm/test_client.py
+++ b/tests/llm/test_client.py
@@ -148,6 +148,20 @@ def test_health_sync_against_in_process_daemon(
     assert payload["status"] == "ok"
 
 
+async def test_model_list_spawn_if_absent_false_raises_without_spawning(
+    temp_socket_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fail_popen(*args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("spawn_if_absent=False must not spawn a daemon")
+
+    monkeypatch.setattr(subprocess, "Popen", _fail_popen)
+
+    llm_client = LLMClient(socket_path=temp_socket_path)
+    with pytest.raises(LLMDaemonUnreachable):
+        await llm_client.model_list(spawn_if_absent=False)
+
+
 async def test_lazy_spawn_when_socket_missing(
     temp_socket_path: Path,
     fake_daemon_factory: FakeDaemonFactory,


### PR DESCRIPTION
Implements story 4.4 — `chirp models list [--json]`. Base: `epic-model-registry` (4.1–4.3 already merged).

## What's in scope
- **`chirp models list`** in `llm/cli/models.py`: reads the registry, queries the daemon for loaded state **without lazy-spawning**, composes sorted rows, and renders a Rich `Table` (stdout) or a JSON document (stdout); diagnostics/errors on stderr.
  - Empty registry → stderr hint, exit 0. Daemon unreachable → `(daemon not running …)` + `—` (TTY) / `daemon_reachable: false` + `loaded: null` (JSON), exit 0. Sort `(role, alias)` (chat before embed). `cache_path` deferred to 4.5 (TODO).
- **`llm/client.py`**: added `spawn_if_absent` kwarg, threaded through `model_list`/`model_list_sync`/`_request`/`_connect_with_handshake`/`_open_connection`; raises `LLMDaemonUnreachable` instead of spawning when `False`. Default `True` preserves existing callers.
- **`llm/cli/_console.py`**: added `stdout_console` so the table lands on stdout while diagnostics stay on stderr.

## Spec reconciliations (documented in the story's Dev Agent Record)
- The client had no `spawn_if_absent` and returns `list[dict]` with a per-entry `loaded` bool (not the spec's hypothetical `{"loaded_aliases": […]}`); added the param (AC allowed "or its equivalent") and derive the loaded set from the real shape.
- Unsupported `schema_version` surfaces as `LLMModelNotFound` → exit 1 via the reused `_read_registry` helper (no `RegistryUnsupportedSchemaVersion` type exists).

## Tests & gates
- 12 new CLI tests (AC-7) + 1 client test; `tests/llm` suite green (89 in the touched files), **100% line coverage on `models.py`** (AC-9). `ruff`, `ruff format`, `mypy` clean.

## AC-10 manual smoke (run 2026-05-28, Apple Silicon, real `chirpd` + MLX, isolated `HOME`)
- `add --no-warm` (embed) → `list` shows `★`/`—`, `--json` → `daemon_reachable: false`/`loaded: null`; **`list` did not spawn the daemon** (no socket created).
- Warmed a real chat model (`Qwen2.5-0.5B-Instruct-4bit`) → `list` shows `loaded ●` / `true`, `daemon_reachable: true`, `list --json | jq -e .` parses OK.

## Out-of-scope defects found during smoke (NOT 4.4 — `list` rendered every state faithfully)
Filed `_bmad-output/implementation-artifacts/bug-chirpd-registry-reread-and-embed-load.md` against EPIC-CHIRPD-CORE 3.5/3.6:
1. `MLXBackend.load` can't load embed (`bert`) models (story 3.6 scope gap).
2. Daemon caches `models.toml` at startup; newly-added aliases fail to warm until restart — contradicts the per-op re-read contract (story 3.5).