### PR TITLE
EPIC-MODEL-REGISTRY 4.5: chirp models show/default/remove/pull subcommands

### DIFF
--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -1,22 +1,26 @@
 """``chirp models`` Typer subcommands.
 
 This module is the eventual home of all six ``chirp models`` subcommands.
-Story 4.3 adds the first — ``add`` — which pulls together the three pieces of
-plumbing the model-registry epic introduces: HuggingFace validation/download
-(:mod:`llm.hf`), atomic registry writes (:mod:`llm.registry`), and daemon warm
-(:class:`llm.client.LLMClient`).
+Story 4.3 adds ``add`` and 4.4 adds ``list``; story 4.5 fills in the update /
+delete / refresh surface — ``show``, ``default``, ``remove``, and ``pull`` —
+each pulling on the same plumbing the model-registry epic introduces:
+HuggingFace validation/download/cache lookup (:mod:`llm.hf`), atomic registry
+writes (:mod:`llm.registry`), and daemon warm (:class:`llm.client.LLMClient`).
 
-The execution order is fixed (epic §3 decision 8): validate → resolve role →
-resolve alias → download → read registry → mutate → write → warm. Any failure
-before the registry write aborts without touching ``models.toml``. A failed
-warm leaves the registry write intact — the model is registered the moment its
-weights land, and the user retries the warm with ``chirp models pull``.
+``add``'s execution order is fixed (epic §3 decision 8): validate → resolve
+role → resolve alias → download → read registry → mutate → write → warm. Any
+failure before the registry write aborts without touching ``models.toml``. A
+failed warm leaves the registry write intact — the model is registered the
+moment its weights land, and the user retries the warm with ``chirp models
+pull``. The 4.5 commands share that read → mutate-or-display → optional-write
+shape and route every failure through the same error-mapping helpers.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -44,6 +48,7 @@ from llm.registry import (
     RegistryWriteError,
     alias_for_repo,
     read_registry,
+    remove_model,
     set_default_for_role,
     upsert_model,
     write_registry,
@@ -57,8 +62,8 @@ def models_main() -> None:
     """Manage chirp's MLX model registry.
 
     This callback keeps ``models`` a multi-command group so Typer does not
-    auto-promote a lone subcommand to the group root. ``add`` (4.3) and ``list``
-    (4.4) live here; ``show``/``default``/``remove``/``pull`` follow in 4.5.
+    auto-promote a lone subcommand to the group root. ``add`` (4.3), ``list``
+    (4.4), and ``show``/``default``/``remove``/``pull`` (4.5) all live here.
     """
 
 
@@ -97,11 +102,6 @@ def add_command(
 
     if not no_warm:
         _warm(resolved_alias, resolved_role)
-
-
-# TODO(4.5): include cache_path (huggingface_hub.try_to_load_from_cache) in the
-# `show` command. Story 4.4 deferred it from the `list` view to keep the table
-# narrow and the JSON schema minimal.
 
 
 @dataclass(frozen=True)
@@ -227,6 +227,219 @@ def _render_list_json(
     sys.stdout.write(json.dumps(payload, indent=2) + "\n")
 
 
+@dataclass(frozen=True)
+class ShowState:
+    """Resolved view of one model for ``chirp models show``.
+
+    Pure data shared by the JSON and Rich renderers (AC-3 field set).
+    """
+
+    alias: str
+    hf_repo: str
+    role: ModelRole
+    default: bool
+    loaded: bool | None
+    cache_path: str | None
+    options: dict[str, Any]
+    daemon_reachable: bool
+
+
+@app.command("show")
+def show_command(
+    alias: str = typer.Argument(..., help="Registered model alias to inspect."),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit a JSON document on stdout instead of a panel.",
+    ),
+) -> None:
+    """Show a single model's resolved config, cache, and daemon-loaded state."""
+    registry = _read_registry()
+    entry = _require_registered(registry, alias)
+    cache_path = hf.resolved_cache_path(entry.hf_repo)
+    daemon_reachable, loaded_aliases = _query_loaded_state()
+    state = _compose_show_state(
+        alias, registry, loaded_aliases, cache_path, daemon_reachable
+    )
+    if json_output:
+        _render_show_json(state)
+    else:
+        _render_show_panel(state)
+
+
+@app.command("default")
+def set_default_command(
+    alias: str = typer.Argument(..., help="Registered alias to make its role default."),
+) -> None:
+    """Flip the default model for the alias's role (chat or embed)."""
+    registry = _read_registry()
+    entry = _require_registered(registry, alias)
+    try:
+        registry = set_default_for_role(registry, alias)
+    except ValueError:
+        _exit(
+            f"Error: Model {alias} has invalid role; edit "
+            f"{_registry_path_display()} or re-run `chirp models add`.",
+            1,
+        )
+    _write(registry)
+    console.print(f"Set {alias} as default {entry.role}.", markup=False, soft_wrap=True)
+
+
+@app.command("remove")
+def remove_command(
+    alias: str = typer.Argument(
+        ..., help="Registered alias to drop from the registry."
+    ),
+    purge: bool = typer.Option(
+        False,
+        "--purge",
+        help="Also delete the model's HuggingFace cache directory.",
+    ),
+) -> None:
+    """Remove a model from the registry, optionally purging its cached weights."""
+    registry = _read_registry()
+    entry = _require_registered(registry, alias)
+    hf_repo = entry.hf_repo
+    registry = remove_model(registry, alias)
+    _write(registry)
+
+    purged_path = _purge_cache(hf_repo) if purge else None
+    if purged_path is not None:
+        console.print(
+            f"Removed {alias} and purged cache ({purged_path}).",
+            markup=False,
+            soft_wrap=True,
+        )
+    else:
+        console.print(f"Removed {alias}.", markup=False, soft_wrap=True)
+
+
+@app.command("pull")
+def pull_command(
+    alias: str = typer.Argument(..., help="Registered alias to force-redownload."),
+    no_warm: bool = typer.Option(
+        False,
+        "--no-warm",
+        help="Skip warming the model on the daemon after pulling it.",
+    ),
+) -> None:
+    """Force-redownload a registered model's weights, then warm it."""
+    registry = _read_registry()
+    entry = _require_registered(registry, alias)
+    result = _download(entry.hf_repo, alias)
+
+    note = "cache hit" if result.cache_hit else f"{result.bytes_downloaded} bytes"
+    console.print(f"Pulled {alias} ({note}).", markup=False, soft_wrap=True)
+
+    if no_warm:
+        console.print(
+            f"Skipped warm for {alias} (--no-warm).", markup=False, soft_wrap=True
+        )
+        return
+    _load_on_daemon(alias, entry.role)
+    console.print(f"Warmed {alias}.", markup=False, soft_wrap=True)
+
+
+def _require_registered(registry: Registry, alias: str) -> RegistryEntry:
+    entry = registry.models.get(alias)
+    if entry is None:
+        _exit(
+            f"Error: Model not registered: {alias}. "
+            "Run `chirp models list` to see what's available.",
+            5,
+        )
+    return entry
+
+
+def _compose_show_state(
+    alias: str,
+    registry: Registry,
+    loaded_aliases: set[str],
+    cache_path: Path | None,
+    daemon_reachable: bool,
+) -> ShowState:
+    entry = registry.models[alias]
+    defaults = {registry.default_chat, registry.default_embed}
+    return ShowState(
+        alias=alias,
+        hf_repo=entry.hf_repo,
+        role=entry.role,
+        default=alias in defaults,
+        loaded=(alias in loaded_aliases) if daemon_reachable else None,
+        cache_path=str(cache_path) if cache_path is not None else None,
+        options=dict(entry.options),
+        daemon_reachable=daemon_reachable,
+    )
+
+
+def _render_show_json(state: ShowState) -> None:
+    payload: dict[str, Any] = {
+        "alias": state.alias,
+        "hf_repo": state.hf_repo,
+        "role": state.role,
+        "default": state.default,
+        "loaded": state.loaded,
+        "cache_path": state.cache_path,
+        "options": state.options,
+        "daemon_reachable": state.daemon_reachable,
+    }
+    sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+
+
+def _render_show_panel(state: ShowState) -> None:
+    loaded = "unknown" if state.loaded is None else ("yes" if state.loaded else "no")
+    table = Table(title=f"Model: {state.alias}", show_header=False)
+    table.add_column("field", style="bold")
+    table.add_column("value")
+    table.add_row("alias", state.alias)
+    table.add_row("hf_repo", state.hf_repo)
+    table.add_row("role", state.role)
+    table.add_row("default", "yes" if state.default else "no")
+    table.add_row("loaded", loaded)
+    table.add_row("cache_path", state.cache_path or "—")
+    for key, value in state.options.items():
+        table.add_row(f"options.{key}", str(value))
+    stdout_console.print(table)
+
+
+def _purge_cache(hf_repo: str) -> str | None:
+    """Delete ``hf_repo``'s cache dir, guarding against paths outside the cache.
+
+    Returns the resolved path on success, or ``None`` when the directory is
+    missing or unreadable (a warning is printed and the caller continues — the
+    registry mutation already succeeded). A resolved path outside the hub cache
+    root is treated as a hard failure (exit 1) per AC-11.
+    """
+    cache_dir = hf.cache_dir_for_repo(hf_repo).resolve()
+    hub_root = hf.hf_hub_cache_root().resolve()
+    if not cache_dir.is_relative_to(hub_root):
+        _exit(
+            f"Error: refusing to purge {cache_dir}: path is outside the "
+            f"HuggingFace cache root {hub_root}.",
+            1,
+        )
+    try:
+        shutil.rmtree(cache_dir, ignore_errors=False)
+    except FileNotFoundError:
+        console.print(
+            f"Warning: cache directory {cache_dir} not found; nothing to purge.",
+            style="yellow",
+            markup=False,
+            soft_wrap=True,
+        )
+        return None
+    except OSError as err:
+        console.print(
+            f"Warning: could not purge cache directory {cache_dir}: {err}.",
+            style="yellow",
+            markup=False,
+            soft_wrap=True,
+        )
+        return None
+    return str(cache_dir)
+
+
 def _validate_repo(hf_repo: str) -> hf.HfRepoMetadata:
     try:
         return hf.validate_repo(hf_repo)
@@ -276,10 +489,10 @@ def _resolve_alias(hf_repo: str, alias: str | None) -> str:
         )
 
 
-def _download(hf_repo: str, alias: str) -> None:
+def _download(hf_repo: str, alias: str) -> hf.DownloadResult:
     callback = RichProgressCallback(hf_repo)
     try:
-        hf.download_model(hf_repo, progress=callback)
+        return hf.download_model(hf_repo, progress=callback)
     except hf.HfRepoNotFound:
         _exit(
             f"Error: HuggingFace repo not found: {hf_repo}. "
@@ -344,6 +557,12 @@ def _write(registry: Registry) -> None:
 
 def _warm(alias: str, role: ModelRole) -> None:
     console.print(f"Warming {alias}...", markup=False, soft_wrap=True)
+    _load_on_daemon(alias, role)
+    console.print("Ready.", markup=False, soft_wrap=True)
+
+
+def _load_on_daemon(alias: str, role: ModelRole) -> None:
+    """Lazy-spawn the daemon and warm ``alias``; map load failures to exit 4."""
     try:
         LLMClient().model_load_sync(alias, role)
     except LLMModelError as err:
@@ -360,7 +579,6 @@ def _warm(alias: str, role: ModelRole) -> None:
             "`chirp daemon logs` to diagnose.",
             4,
         )
-    console.print("Ready.", markup=False, soft_wrap=True)
 
 
 def _warn_on_role_change(

--- a/llm/hf.py
+++ b/llm/hf.py
@@ -19,12 +19,19 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
-from huggingface_hub import HfApi, hf_hub_download, snapshot_download
+from huggingface_hub import (
+    HfApi,
+    hf_hub_download,
+    snapshot_download,
+    try_to_load_from_cache,
+)
+from huggingface_hub import constants as _hf_constants
 from huggingface_hub.errors import (
     EntryNotFoundError,
     HfHubHTTPError,
     RepositoryNotFoundError,
 )
+from huggingface_hub.file_download import repo_folder_name
 from tqdm import tqdm as _BaseTqdm
 
 _EMBED_TAGS = frozenset({"sentence-transformers", "feature-extraction"})
@@ -288,3 +295,34 @@ def _build_tqdm_adapter(
                     progress.on_progress(state["bytes"], self.total or None)
 
     return _CallbackTqdm
+
+
+def resolved_cache_path(hf_repo: str) -> Path | None:
+    """Return the local snapshot directory for ``hf_repo`` if cached, else ``None``.
+
+    Probes the HF cache for ``config.json`` (present in every MLX / transformers
+    snapshot) via :func:`huggingface_hub.try_to_load_from_cache`, which returns
+    the cached file path (``str``), ``None`` when the repo isn't cached, or a
+    sentinel object when the file is known-absent. Only a real path string
+    yields a result, and the snapshot directory is that file's parent.
+    """
+    cached = try_to_load_from_cache(repo_id=hf_repo, filename="config.json")
+    if isinstance(cached, str):
+        return Path(cached).parent
+    return None
+
+
+def hf_hub_cache_root() -> Path:
+    """Return the HuggingFace hub cache root (``~/.cache/huggingface/hub``)."""
+    return Path(_hf_constants.HF_HUB_CACHE)
+
+
+def cache_dir_for_repo(hf_repo: str) -> Path:
+    """Return the top-level cache directory for ``hf_repo``.
+
+    This is the ``models--<org>--<name>`` directory under the hub cache root —
+    the deletion target for ``chirp models remove --purge``. The directory is
+    not guaranteed to exist; callers handle a missing path.
+    """
+    folder: str = repo_folder_name(repo_id=hf_repo, repo_type="model")
+    return hf_hub_cache_root() / folder

--- a/tests/llm/README.md
+++ b/tests/llm/README.md
@@ -50,3 +50,34 @@ the daemon's `model.load` miss the alias. Remove the temp `models.toml` and stop
 
 All progress, status, and error output goes to **stderr**; stdout stays empty,
 so `chirp models add … && …` pipelines stay clean.
+
+## `chirp models show` / `default` / `remove` / `pull` (story 4.5)
+
+Same harness as `add` — invoke the sub-app directly until story 4.6 wires
+`models` into the top-level CLI:
+
+```bash
+run_models() { uv run python -c "import sys; from llm.cli.models import app; sys.argv=['models',*sys.argv[1:]]; app()" "$@"; }
+export CHIRP_REGISTRY_PATH="$(mktemp -d)/models.toml"
+```
+
+End-to-end sequence (AC-19), run on an Apple-silicon Mac with network access:
+
+```bash
+run_models add mlx-community/bge-small-en-v1.5 --no-warm   # register an embed model
+run_models show bge-small-en-v1.5                          # panel: role embed, default yes, cache_path set
+run_models add mlx-community/gemma-4-4b-it-4bit --no-warm  # register a chat model
+run_models default bge-small-en-v1.5                       # flip embed default (no-op if already set)
+run_models pull bge-small-en-v1.5 --no-warm                # cache-hit fast path: "Pulled … (cache hit)."
+run_models remove bge-small-en-v1.5 --purge                # "Removed … and purged cache (<path>)."
+run_models list                                            # bge gone; cache directory gone
+```
+
+JSON contract spot-check:
+
+```bash
+run_models show gemma-4-4b-it-4bit --json | jq -e .default   # -> true
+```
+
+`show` writes its panel (TTY) or JSON document to **stdout**; `default`,
+`remove`, and `pull` print only to **stderr** under every condition.

--- a/tests/llm/test_cli_models.py
+++ b/tests/llm/test_cli_models.py
@@ -833,6 +833,34 @@ def test_show_json_emits_schema(
     assert payload["daemon_reachable"] is True
 
 
+def test_show_renders_options_rows(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
+) -> None:
+    _seed_registry(
+        registry_path,
+        Registry(
+            schema_version=1,
+            default_chat=CHAT_ALIAS,
+            models={
+                CHAT_ALIAS: RegistryEntry(
+                    hf_repo=CHAT_REPO, role="chat", options={"temperature": 0.7}
+                )
+            },
+        ),
+    )
+    _mock_cache_path(monkeypatch, None)
+    _mock_list_client(monkeypatch, models=[])
+
+    tty = runner.invoke(models_module.app, ["show", CHAT_ALIAS])
+    js = runner.invoke(models_module.app, ["show", CHAT_ALIAS, "--json"])
+
+    assert tty.exit_code == 0
+    assert "options.temperature" in tty.stdout
+    assert "0.7" in tty.stdout
+    assert js.exit_code == 0
+    assert json.loads(js.stdout)["options"] == {"temperature": 0.7}
+
+
 def test_show_unknown_alias_exits_5(
     registry_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -934,6 +962,22 @@ def test_default_unknown_alias_exits_5(
 
     assert result.exit_code == 5
     assert "not registered" in result.stderr
+
+
+def test_default_invalid_role_exits_1(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    monkeypatch.setattr(
+        models_module,
+        "set_default_for_role",
+        MagicMock(side_effect=ValueError("unsupported role")),
+    )
+
+    result = runner.invoke(models_module.app, ["default", CHAT_ALIAS])
+
+    assert result.exit_code == 1
+    assert "invalid role" in result.stderr
 
 
 def test_default_does_not_warm(
@@ -1043,6 +1087,29 @@ def test_remove_purge_warns_if_cache_missing(
     assert "not found" in result.stderr
     registry = read_registry(path=registry_path)
     assert CHAT_ALIAS not in registry.models
+
+
+def test_remove_purge_warns_on_permission_error(
+    registry_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    hub_root = tmp_path / "hub"
+    cache_dir = hub_root / "models--mlx-community--gemma-4-4b-it-4bit"
+    cache_dir.mkdir(parents=True)
+    monkeypatch.setattr(hf, "hf_hub_cache_root", lambda: hub_root)
+    monkeypatch.setattr(hf, "cache_dir_for_repo", lambda repo: cache_dir)
+    monkeypatch.setattr(
+        models_module.shutil,
+        "rmtree",
+        MagicMock(side_effect=PermissionError("denied")),
+    )
+
+    result = runner.invoke(models_module.app, ["remove", CHAT_ALIAS, "--purge"])
+
+    assert result.exit_code == 0
+    assert "Warning" in result.stderr
+    assert str(cache_dir.resolve()) in result.stderr
+    assert CHAT_ALIAS not in read_registry(path=registry_path).models
 
 
 def test_remove_purge_refuses_path_outside_hf_cache(

--- a/tests/llm/test_cli_models.py
+++ b/tests/llm/test_cli_models.py
@@ -747,3 +747,415 @@ def test_rich_progress_callback_tty_uses_progress_bar() -> None:
     callback.on_done()
 
     assert f"Downloading {CHAT_REPO}" in buffer.getvalue()
+
+
+# --- story 4.5: show / default / remove / pull -----------------------------
+
+CHAT_ALIAS = "gemma-4-4b-it-4bit"
+EMBED_ALIAS = "bge-small-en-v1.5"
+
+
+def _seed_two_chat(path: Path) -> None:
+    _seed_registry(
+        path,
+        Registry(
+            schema_version=1,
+            default_chat="first",
+            default_embed=EMBED_ALIAS,
+            models={
+                "first": RegistryEntry(hf_repo="org/first", role="chat"),
+                "second": RegistryEntry(hf_repo="org/second", role="chat"),
+                EMBED_ALIAS: RegistryEntry(hf_repo=EMBED_REPO, role="embed"),
+            },
+        ),
+    )
+
+
+def _mock_cache_path(monkeypatch: pytest.MonkeyPatch, value: Path | None) -> None:
+    monkeypatch.setattr(hf, "resolved_cache_path", MagicMock(return_value=value))
+
+
+def _make_download_result(
+    *, cache_hit: bool = False, bytes_downloaded: int = 0
+) -> hf.DownloadResult:
+    return hf.DownloadResult(
+        repo_id=CHAT_REPO,
+        local_path=Path("/cache/snap"),
+        bytes_downloaded=bytes_downloaded,
+        cache_hit=cache_hit,
+    )
+
+
+# show -----------------------------------------------------------------------
+
+
+def test_show_tty_renders_panel(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_cache_path(monkeypatch, None)
+    _mock_list_client(monkeypatch, models=[{"alias": CHAT_ALIAS, "loaded": True}])
+
+    result = runner.invoke(models_module.app, ["show", CHAT_ALIAS])
+
+    assert result.exit_code == 0
+    assert CHAT_ALIAS in result.stdout
+    assert CHAT_REPO in result.stdout
+    assert "chat" in result.stdout
+
+
+def test_show_json_emits_schema(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_cache_path(monkeypatch, None)
+    _mock_list_client(monkeypatch, models=[{"alias": CHAT_ALIAS, "loaded": True}])
+
+    result = runner.invoke(models_module.app, ["show", CHAT_ALIAS, "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert set(payload) == {
+        "alias",
+        "hf_repo",
+        "role",
+        "default",
+        "loaded",
+        "cache_path",
+        "options",
+        "daemon_reachable",
+    }
+    assert payload["alias"] == CHAT_ALIAS
+    assert payload["hf_repo"] == CHAT_REPO
+    assert payload["role"] == "chat"
+    assert payload["default"] is True
+    assert payload["loaded"] is True
+    assert payload["daemon_reachable"] is True
+
+
+def test_show_unknown_alias_exits_5(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_cache_path(monkeypatch, None)
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["show", "nope"])
+
+    assert result.exit_code == 5
+    assert "not registered" in result.stderr
+    assert "chirp models list" in result.stderr
+
+
+def test_show_daemon_unreachable_loaded_null_in_json(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_cache_path(monkeypatch, None)
+    _mock_list_client(monkeypatch, unreachable=True)
+
+    result = runner.invoke(models_module.app, ["show", CHAT_ALIAS, "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["daemon_reachable"] is False
+    assert payload["loaded"] is None
+
+
+def test_show_cache_path_null_when_not_cached(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    _mock_cache_path(monkeypatch, None)
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["show", CHAT_ALIAS, "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["cache_path"] is None
+
+
+def test_show_cache_path_resolved_when_cached(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    snapshot = Path("/cache/hub/models--mlx-community--gemma/snapshots/abc")
+    _mock_cache_path(monkeypatch, snapshot)
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["show", CHAT_ALIAS, "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["cache_path"] == str(snapshot)
+
+
+# default --------------------------------------------------------------------
+
+
+def test_default_flips_chat(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_two_chat(registry_path)
+
+    result = runner.invoke(models_module.app, ["default", "second"])
+
+    assert result.exit_code == 0
+    registry = read_registry(path=registry_path)
+    assert registry.default_chat == "second"
+    assert "Set second as default chat." in result.stderr
+
+
+def test_default_flips_embed(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_registry(
+        registry_path,
+        Registry(
+            schema_version=1,
+            default_embed=None,
+            models={EMBED_ALIAS: RegistryEntry(hf_repo=EMBED_REPO, role="embed")},
+        ),
+    )
+
+    result = runner.invoke(models_module.app, ["default", EMBED_ALIAS])
+
+    assert result.exit_code == 0
+    registry = read_registry(path=registry_path)
+    assert registry.default_embed == EMBED_ALIAS
+    assert "default embed" in result.stderr
+
+
+def test_default_unknown_alias_exits_5(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+
+    result = runner.invoke(models_module.app, ["default", "nope"])
+
+    assert result.exit_code == 5
+    assert "not registered" in result.stderr
+
+
+def test_default_does_not_warm(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_two_chat(registry_path)
+    factory = _mock_client(monkeypatch)
+
+    result = runner.invoke(models_module.app, ["default", "second"])
+
+    assert result.exit_code == 0
+    factory.assert_not_called()
+
+
+def test_default_does_not_modify_other_default(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_two_chat(registry_path)
+
+    result = runner.invoke(models_module.app, ["default", "second"])
+
+    assert result.exit_code == 0
+    registry = read_registry(path=registry_path)
+    assert registry.default_chat == "second"
+    assert registry.default_embed == EMBED_ALIAS
+
+
+# remove ---------------------------------------------------------------------
+
+
+def test_remove_drops_entry(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_and_embed(registry_path)
+
+    result = runner.invoke(models_module.app, ["remove", EMBED_ALIAS])
+
+    assert result.exit_code == 0
+    registry = read_registry(path=registry_path)
+    assert EMBED_ALIAS not in registry.models
+    assert CHAT_ALIAS in registry.models
+    assert "Removed bge-small-en-v1.5." in result.stderr
+
+
+def test_remove_clears_default_when_removed_alias_was_default(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+
+    result = runner.invoke(models_module.app, ["remove", CHAT_ALIAS])
+
+    assert result.exit_code == 0
+    registry = read_registry(path=registry_path)
+    assert registry.default_chat is None
+    assert CHAT_ALIAS not in registry.models
+
+
+def test_remove_unknown_alias_exits_5(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+
+    result = runner.invoke(models_module.app, ["remove", "nope"])
+
+    assert result.exit_code == 5
+    assert "not registered" in result.stderr
+
+
+def test_remove_purge_deletes_cache_dir(
+    registry_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    hub_root = tmp_path / "hub"
+    cache_dir = hub_root / "models--mlx-community--gemma-4-4b-it-4bit"
+    cache_dir.mkdir(parents=True)
+    monkeypatch.setattr(hf, "hf_hub_cache_root", lambda: hub_root)
+    monkeypatch.setattr(hf, "cache_dir_for_repo", lambda repo: cache_dir)
+    rmtree = MagicMock()
+    monkeypatch.setattr(models_module.shutil, "rmtree", rmtree)
+
+    result = runner.invoke(models_module.app, ["remove", CHAT_ALIAS, "--purge"])
+
+    assert result.exit_code == 0
+    rmtree.assert_called_once_with(cache_dir.resolve(), ignore_errors=False)
+    assert "purged cache" in result.stderr
+
+
+def test_remove_purge_warns_if_cache_missing(
+    registry_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    hub_root = tmp_path / "hub"
+    cache_dir = hub_root / "models--mlx-community--gemma-4-4b-it-4bit"
+    cache_dir.mkdir(parents=True)
+    monkeypatch.setattr(hf, "hf_hub_cache_root", lambda: hub_root)
+    monkeypatch.setattr(hf, "cache_dir_for_repo", lambda repo: cache_dir)
+    monkeypatch.setattr(
+        models_module.shutil,
+        "rmtree",
+        MagicMock(side_effect=FileNotFoundError("gone")),
+    )
+
+    result = runner.invoke(models_module.app, ["remove", CHAT_ALIAS, "--purge"])
+
+    assert result.exit_code == 0
+    assert "Warning" in result.stderr
+    assert "not found" in result.stderr
+    registry = read_registry(path=registry_path)
+    assert CHAT_ALIAS not in registry.models
+
+
+def test_remove_purge_refuses_path_outside_hf_cache(
+    registry_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    hub_root = tmp_path / "hub"
+    hub_root.mkdir()
+    outside = tmp_path / "outside"
+    monkeypatch.setattr(hf, "hf_hub_cache_root", lambda: hub_root)
+    monkeypatch.setattr(hf, "cache_dir_for_repo", lambda repo: outside)
+    rmtree = MagicMock()
+    monkeypatch.setattr(models_module.shutil, "rmtree", rmtree)
+
+    result = runner.invoke(models_module.app, ["remove", CHAT_ALIAS, "--purge"])
+
+    assert result.exit_code == 1
+    rmtree.assert_not_called()
+    assert "outside" in result.stderr
+
+
+def test_remove_does_not_call_daemon(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_and_embed(registry_path)
+    factory = _mock_client(monkeypatch)
+
+    result = runner.invoke(models_module.app, ["remove", EMBED_ALIAS])
+
+    assert result.exit_code == 0
+    factory.assert_not_called()
+
+
+# pull -----------------------------------------------------------------------
+
+
+def test_pull_redownloads_and_warms(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    download = MagicMock(return_value=_make_download_result(bytes_downloaded=123))
+    monkeypatch.setattr(hf, "download_model", download)
+    factory = _mock_client(monkeypatch)
+
+    result = runner.invoke(models_module.app, ["pull", CHAT_ALIAS])
+
+    assert result.exit_code == 0
+    download.assert_called_once()
+    factory.return_value.model_load_sync.assert_called_once_with(CHAT_ALIAS, "chat")
+    assert "Pulled gemma-4-4b-it-4bit (123 bytes)." in result.stderr
+    assert "Warmed gemma-4-4b-it-4bit." in result.stderr
+
+
+def test_pull_no_warm_skips_model_load(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    monkeypatch.setattr(
+        hf,
+        "download_model",
+        MagicMock(return_value=_make_download_result(cache_hit=True)),
+    )
+    factory = _mock_client(monkeypatch)
+
+    result = runner.invoke(models_module.app, ["pull", CHAT_ALIAS, "--no-warm"])
+
+    assert result.exit_code == 0
+    factory.assert_not_called()
+    assert "cache hit" in result.stderr
+    assert "Skipped warm" in result.stderr
+
+
+def test_pull_unknown_alias_exits_5(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    download = MagicMock()
+    monkeypatch.setattr(hf, "download_model", download)
+
+    result = runner.invoke(models_module.app, ["pull", "nope"])
+
+    assert result.exit_code == 5
+    download.assert_not_called()
+
+
+def test_pull_download_failed_exits_1(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    monkeypatch.setattr(
+        hf,
+        "download_model",
+        MagicMock(side_effect=hf.HfDownloadFailed(CHAT_REPO, original=OSError("io"))),
+    )
+    factory = _mock_client(monkeypatch)
+
+    result = runner.invoke(models_module.app, ["pull", CHAT_ALIAS])
+
+    assert result.exit_code == 1
+    factory.assert_not_called()
+
+
+def test_pull_does_not_modify_registry(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_model(registry_path)
+    before = registry_path.read_bytes()
+    monkeypatch.setattr(
+        hf, "download_model", MagicMock(return_value=_make_download_result())
+    )
+    _mock_client(monkeypatch)
+
+    result = runner.invoke(models_module.app, ["pull", CHAT_ALIAS])
+
+    assert result.exit_code == 0
+    assert registry_path.read_bytes() == before

--- a/tests/llm/test_hf.py
+++ b/tests/llm/test_hf.py
@@ -29,8 +29,11 @@ from llm.hf import (
     HfUnexpectedError,
     RoleInferenceAmbiguous,
     _status_code_from,
+    cache_dir_for_repo,
     download_model,
+    hf_hub_cache_root,
     infer_role,
+    resolved_cache_path,
     validate_repo,
 )
 
@@ -466,3 +469,33 @@ def test_download_model_cache_hit_reports_zero_bytes(tmp_path: Path) -> None:
     assert recorder.dones == 1
     assert result.bytes_downloaded == 0
     assert result.cache_hit is True
+
+
+# --- story 4.5: cache-path helpers -----------------------------------------
+
+
+def test_resolved_cache_path_returns_snapshot_dir_when_cached(tmp_path: Path) -> None:
+    config_file = tmp_path / "snapshots" / "abc" / "config.json"
+    with patch("llm.hf.try_to_load_from_cache", return_value=str(config_file)) as probe:
+        result = resolved_cache_path("mlx-community/gemma-4-4b-it-4bit")
+
+    probe.assert_called_once_with(
+        repo_id="mlx-community/gemma-4-4b-it-4bit", filename="config.json"
+    )
+    assert result == config_file.parent
+
+
+def test_resolved_cache_path_none_when_not_cached() -> None:
+    with patch("llm.hf.try_to_load_from_cache", return_value=None):
+        assert resolved_cache_path("mlx-community/gemma-4-4b-it-4bit") is None
+
+
+def test_resolved_cache_path_none_when_known_absent_sentinel() -> None:
+    with patch("llm.hf.try_to_load_from_cache", return_value=object()):
+        assert resolved_cache_path("mlx-community/gemma-4-4b-it-4bit") is None
+
+
+def test_cache_dir_for_repo_lives_under_hub_root() -> None:
+    cache_dir = cache_dir_for_repo("mlx-community/gemma-4-4b-it-4bit")
+    assert cache_dir.is_relative_to(hf_hub_cache_root())
+    assert cache_dir.name == "models--mlx-community--gemma-4-4b-it-4bit"


### PR DESCRIPTION
## Summary

Implements story 4.5 — the update / delete / refresh half of the `chirp models` registry surface, completing the read/create flows from 4.3 (`add`) and 4.4 (`list`). Implements FR27–FR30.

Four new subcommands in `llm/cli/models.py`:

- **`show <alias> [--json]`** — resolved config panel (TTY→stdout) or JSON document, with `cache_path`, daemon `loaded` state (`null` when daemon down), and per-key `options` rows.
- **`default <alias>`** — flips the role's default via `set_default_for_role`; does not warm (AC-6).
- **`remove <alias> [--purge]`** — drops the entry; `--purge` deletes the HF cache dir behind a path-safety guard that refuses anything outside the hub cache root (exit 1, AC-11); no daemon contact (AC-9).
- **`pull <alias> [--no-warm]`** — force-redownloads weights **without** mutating the registry (AC-13.5), then warms.

New `llm/hf.py` helpers (keeping all `huggingface_hub` calls in this module): `resolved_cache_path`, `hf_hub_cache_root`, `cache_dir_for_repo`.

Shared with 4.3/4.4: `_query_loaded_state`, the error-mapping helpers, and `_load_on_daemon` (factored out of `_warm` so `pull` reuses the exit-4 warm path).

## Testing

- 23 new tests in `tests/llm/test_cli_models.py` (all AC-16 cases) + 4 in `tests/llm/test_hf.py` for the cache helpers.
- **100% line coverage** on `llm/cli/models.py` and `llm/hf.py`.
- Full suite: 306 passing; `ruff`, `ruff format`, `mypy` clean; pre-commit hooks pass.
- Manual smoke sequence documented in `tests/llm/README.md` (AC-19).

## Review

Reviewed against all 19 ACs by a dedicated review pass — verdict **READY**; three NIT findings (options-rendering coverage, `--purge` PermissionError branch, AC-7 invalid-role mapping) were addressed and re-confirmed.

> [!NOTE]
> The files-changed view may appear to span 4.1–4.5 because 4.1–4.4 were squash-merged into `epic-model-registry` (new commit hashes), pushing the merge-base back. The net `epic-model-registry..HEAD` diff is scoped to 4.5 only (5 files, +820/−21). Can force-push a rebased branch to clean up the view on request.