### PR TITLE
fix(chirpd): re-read models.toml per op so newly-added aliases warm without restart

### DIFF
--- a/_bmad-output/implementation-artifacts/bug-chirpd-registry-reread-and-embed-load.md
+++ b/_bmad-output/implementation-artifacts/bug-chirpd-registry-reread-and-embed-load.md
@@ -1,6 +1,6 @@
 # BUG: chirpd does not re-read the registry per op, and cannot load embed models
 
-- **Status:** Open
+- **Status:** Partially fixed — Issue 2 (per-op registry re-read) resolved; Issue 1 (embed model load) still Open
 - **Severity:** High (blocks the Maya/Priya end-to-end journeys: a freshly `add`ed model can't be warmed; no embed model can be warmed at all)
 - **Owning epic:** EPIC-CHIRPD-CORE
 - **Owning stories:** 3.5-model-lifecycle (Issue 2), 3.6-backend-and-inference (Issue 1) — both currently marked **Done**
@@ -35,8 +35,9 @@ Two independent daemon-side defects, both discovered while validating `chirp mod
 
 ---
 
-## Issue 2 — daemon caches the registry at startup; never re-reads per op
+## Issue 2 — daemon caches the registry at startup; never re-reads per op  ✅ FIXED
 
+- **Resolution:** `DaemonState` now takes an optional `registry_reader` callable. When provided (the daemon passes `read_registry` from `chirpd/__main__.py`), `model.load`, `model.list`, and `resolve_canonical_alias` re-read `models.toml` per op via `DaemonState._refresh_registry()` before resolving. No file watcher (hot-reload stays out of scope). Tests that pass no reader keep their in-memory registry. Regression coverage: `tests/chirpd/test_state.py::test_load_sees_alias_added_after_startup`, `::test_list_models_reflects_registry_changes_after_startup`, `::test_registry_reader_absent_keeps_in_memory_registry`.
 - **Owning story:** 3.5-model-lifecycle (per-op registry read)
 - **Symptom:** after a daemon is already running, registering a new alias and warming it fails until the daemon is restarted:
   ```

--- a/chirpd/__main__.py
+++ b/chirpd/__main__.py
@@ -56,6 +56,7 @@ def main() -> int:
                 backend=backend,
                 registry=registry,
                 idle_timeout_s=resolve_idle_timeout_seconds(),
+                registry_reader=read_registry,
             )
             dispatcher = Dispatcher(state=state)
             logger.info("chirpd starting", extra={"op": "startup"})

--- a/chirpd/dispatcher.py
+++ b/chirpd/dispatcher.py
@@ -305,7 +305,7 @@ class Dispatcher:
             )
             return
 
-        alias = state.resolve_canonical_alias(identifier, "chat")
+        entry, alias = state.resolve(identifier, "chat")
         already_loaded = state.get(alias) is not None
         if not already_loaded:
             await _write_event(
@@ -313,7 +313,7 @@ class Dispatcher:
                 {"id": request_id, "event": EVENT_LOADING, "model": alias},
             )
 
-        loaded = await state.load(identifier, "chat")
+        loaded = await state.load(identifier, "chat", resolved=(entry, alias))
         should_stop = asyncio.Event()
         state.register_cancellation(request_id, should_stop)
         start_ns = time.perf_counter_ns()

--- a/chirpd/state.py
+++ b/chirpd/state.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Any
@@ -41,9 +42,12 @@ class DaemonState:
         backend: LLMBackend,
         registry: Registry,
         idle_timeout_s: float = DEFAULT_IDLE_TIMEOUT_S,
+        *,
+        registry_reader: Callable[[], Registry] | None = None,
     ) -> None:
         self._backend = backend
         self._registry = registry
+        self._registry_reader = registry_reader
         self._idle_timeout_s = idle_timeout_s
         self._models: dict[str, LoadedModel] = {}
         self._registry_locks: dict[str, asyncio.Lock] = {}
@@ -54,6 +58,17 @@ class DaemonState:
 
     @property
     def registry(self) -> Registry:
+        return self._registry
+
+    def _refresh_registry(self) -> Registry:
+        """Re-read ``models.toml`` so aliases added since startup are visible.
+
+        Per-op reads keep the daemon honest without a file watcher (hot-reload
+        is out of scope). Tests that pass no reader keep their in-memory
+        registry untouched.
+        """
+        if self._registry_reader is not None:
+            self._registry = self._registry_reader()
         return self._registry
 
     @property
@@ -75,9 +90,10 @@ class DaemonState:
         return self._models.get(alias)
 
     def resolve_canonical_alias(self, identifier: str, role: ModelRole) -> str:
-        resolve_alias(self._registry, identifier, role)
+        registry = self._refresh_registry()
+        resolve_alias(registry, identifier, role)
         if identifier == "default":
-            return _alias_for_default(self._registry, role)
+            return _alias_for_default(registry, role)
         return identifier
 
     async def load(
@@ -85,11 +101,12 @@ class DaemonState:
         identifier: str,
         role: ModelRole = "chat",
     ) -> LoadedModel:
-        entry = resolve_alias(self._registry, identifier, role)
+        registry = self._refresh_registry()
+        entry = resolve_alias(registry, identifier, role)
         alias = (
             identifier
             if identifier != "default"
-            else _alias_for_default(self._registry, role)
+            else _alias_for_default(registry, role)
         )
 
         lock = self._registry_locks.setdefault(alias, asyncio.Lock())
@@ -139,10 +156,11 @@ class DaemonState:
         )
 
     def list_models(self) -> list[dict[str, Any]]:
+        registry = self._refresh_registry()
         out: list[dict[str, Any]] = []
         seen: set[str] = set()
         now = datetime.now(UTC)
-        for alias, entry in self._registry.models.items():
+        for alias, entry in registry.models.items():
             seen.add(alias)
             loaded = self._models.get(alias)
             out.append(

--- a/chirpd/state.py
+++ b/chirpd/state.py
@@ -16,7 +16,7 @@ import psutil
 from chirpd.backend import LLMBackend, ModelRole
 from llm.exceptions import LLMError
 from llm.protocol import OP_MODEL_LOAD, OP_MODEL_UNLOAD, package_version
-from llm.registry import Registry, resolve_alias
+from llm.registry import Registry, RegistryEntry, resolve_alias
 
 _logger = logging.getLogger("chirpd.state")
 
@@ -89,24 +89,35 @@ class DaemonState:
     def get(self, alias: str) -> LoadedModel | None:
         return self._models.get(alias)
 
-    def resolve_canonical_alias(self, identifier: str, role: ModelRole) -> str:
-        registry = self._refresh_registry()
-        resolve_alias(registry, identifier, role)
-        if identifier == "default":
-            return _alias_for_default(registry, role)
-        return identifier
+    def resolve(self, identifier: str, role: ModelRole) -> tuple[RegistryEntry, str]:
+        """Re-read the registry once and resolve ``identifier`` to (entry, alias).
 
-    async def load(
-        self,
-        identifier: str,
-        role: ModelRole = "chat",
-    ) -> LoadedModel:
+        A request that both announces a model (``loading`` event) and loads it
+        must resolve once and reuse the result. Resolving twice would read the
+        registry twice, so a ``models.toml`` edit landing between the two reads
+        could make the announced alias diverge from the one actually generated.
+        """
         registry = self._refresh_registry()
         entry = resolve_alias(registry, identifier, role)
         alias = (
             identifier
             if identifier != "default"
             else _alias_for_default(registry, role)
+        )
+        return entry, alias
+
+    def resolve_canonical_alias(self, identifier: str, role: ModelRole) -> str:
+        return self.resolve(identifier, role)[1]
+
+    async def load(
+        self,
+        identifier: str,
+        role: ModelRole = "chat",
+        *,
+        resolved: tuple[RegistryEntry, str] | None = None,
+    ) -> LoadedModel:
+        entry, alias = (
+            resolved if resolved is not None else self.resolve(identifier, role)
         )
 
         lock = self._registry_locks.setdefault(alias, asyncio.Lock())

--- a/tests/chirpd/test_state.py
+++ b/tests/chirpd/test_state.py
@@ -10,6 +10,7 @@ import pytest
 
 from chirpd.backend import FakeBackend
 from chirpd.state import DaemonState
+from llm.exceptions import LLMModelNotFound
 from llm.registry import Registry, RegistryEntry
 
 
@@ -236,3 +237,47 @@ async def test_schedule_idle_unload_on_embed_is_noop() -> None:
     loaded = await state.load("nomic", "embed")
     state.schedule_idle_unload(loaded, keep_alive=None)
     assert loaded.idle_unload_task is None
+
+
+async def test_load_sees_alias_added_after_startup() -> None:
+    backend = FakeBackend()
+    current = _registry()
+    state = DaemonState(
+        backend=backend,
+        registry=current,
+        idle_timeout_s=60.0,
+        registry_reader=lambda: current,
+    )
+
+    with pytest.raises(LLMModelNotFound):
+        await state.load("gemma", "chat")
+
+    current = _registry(gemma=_chat_entry())
+    loaded = await state.load("gemma", "chat")
+    assert loaded.alias == "gemma"
+
+
+async def test_list_models_reflects_registry_changes_after_startup() -> None:
+    backend = FakeBackend()
+    current = _registry()
+    state = DaemonState(
+        backend=backend,
+        registry=current,
+        idle_timeout_s=60.0,
+        registry_reader=lambda: current,
+    )
+
+    assert state.list_models() == []
+
+    current = _registry(gemma=_chat_entry())
+    aliases = [item["alias"] for item in state.list_models()]
+    assert aliases == ["gemma"]
+
+
+async def test_registry_reader_absent_keeps_in_memory_registry() -> None:
+    backend = FakeBackend()
+    registry = _registry(gemma=_chat_entry())
+    state = DaemonState(backend=backend, registry=registry, idle_timeout_s=60.0)
+
+    state.list_models()
+    assert state.registry is registry

--- a/tests/chirpd/test_state.py
+++ b/tests/chirpd/test_state.py
@@ -281,3 +281,55 @@ async def test_registry_reader_absent_keeps_in_memory_registry() -> None:
 
     state.list_models()
     assert state.registry is registry
+
+
+def _two_alias_registry(default_alias: str) -> Registry:
+    return Registry(
+        schema_version=1,
+        default_chat=default_alias,
+        models={
+            "gemma": _chat_entry("mlx-community/gemma-4-4b-it-4bit"),
+            "other": _chat_entry("mlx-community/other-4bit"),
+        },
+    )
+
+
+async def test_resolved_snapshot_survives_mid_request_default_change() -> None:
+    # The chat dispatcher resolves once (for the 'loading' event) and then loads.
+    # If models.toml flips 'default' between those steps, the load must still use
+    # the alias that was announced — one registry snapshot per request.
+    backend = FakeBackend()
+    current = _two_alias_registry("gemma")
+    state = DaemonState(
+        backend=backend,
+        registry=current,
+        idle_timeout_s=60.0,
+        registry_reader=lambda: current,
+    )
+
+    entry, alias = state.resolve("default", "chat")
+    assert alias == "gemma"
+
+    current = _two_alias_registry("other")  # default flips mid-request
+
+    loaded = await state.load("default", "chat", resolved=(entry, alias))
+    assert loaded.alias == "gemma"
+    assert backend.load_calls[-1] == ("mlx-community/gemma-4-4b-it-4bit", "chat")
+
+
+async def test_load_without_snapshot_reresolves_current_default() -> None:
+    # Without a snapshot (e.g. the embed path), load does its own single read and
+    # resolves against the live registry.
+    backend = FakeBackend()
+    current = _two_alias_registry("gemma")
+    state = DaemonState(
+        backend=backend,
+        registry=current,
+        idle_timeout_s=60.0,
+        registry_reader=lambda: current,
+    )
+
+    current = _two_alias_registry("other")
+
+    loaded = await state.load("default", "chat")
+    assert loaded.alias == "other"


### PR DESCRIPTION
## What

Fixes **Issue 2** of `bug-chirpd-registry-reread-and-embed-load.md` (High severity): the daemon cached the model registry at startup and never re-read it, so a model registered with `chirp models add <alias>` while the daemon was running was invisible to `model.load` / `model.list` / `model.status` until a restart. This broke the core *add-then-use* loop — for **chat** models too, not just embed.

```
$ chirp models add mlx-community/Qwen2.5-0.5B-Instruct-4bit   # daemon already up
Warming qwen2.5-0.5b-instruct-4bit...
Error: Model registered but warm failed: unknown model alias 'qwen2.5-0.5b-instruct-4bit'.
# kill chirpd, retry → "Ready."
```

## Why

The architecture contract requires `models.toml` to be re-read **on every `model.*` op** (no hot-reload, no file watcher) — see `epic-model-registry/epic.md:138` and `stories/3.5-model-lifecycle.md:289`. `DaemonState` violated this by freezing `self._registry` in `__init__`.

## How

- `DaemonState` gains an optional `registry_reader: Callable[[], Registry]`. A new `_refresh_registry()` helper re-reads and swaps `self._registry`.
- The three registry consumers — `load`, `list_models`, `resolve_canonical_alias` — refresh before resolving. In `load`, the refresh happens **before** lock acquisition, so the existing `_registry_locks` per-model discipline is untouched. `status()` is unchanged (it only reads loaded models).
- The daemon opts in via `__main__.py` passing `registry_reader=read_registry`. It stays a plain per-op read — **not** a file watcher; hot-reload remains explicitly out of scope.
- Tests (and any caller) that pass no reader keep their in-memory registry, so the ~30 existing `DaemonState(...)` call sites and `state.registry is registry` are unaffected.

## Testing

- New regression tests in `tests/chirpd/test_state.py`:
  - `test_load_sees_alias_added_after_startup`
  - `test_list_models_reflects_registry_changes_after_startup`
  - `test_registry_reader_absent_keeps_in_memory_registry`
- `tests/chirpd` + `tests/llm` + `tests/notes_chat` → **510 passed**.
- `ruff` + `mypy` clean; pre-commit hooks pass.

## Scope

Issue 1 (embed/`bert` models cannot load — `MLXBackend.load` routes both roles through `mlx_lm.load`) is **not** in this PR; it's tracked separately and needs real-MLX `@slow @integration` verification.