### PR TITLE
chore(renovate): disable updates for github/gh-aw-actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,15 @@
     "config:recommended"
   ],
   "automerge": true,
-  "platformAutomerge": true
+  "platformAutomerge": true,
+  "packageRules": [
+    {
+      "description": "gh-aw manages github/gh-aw-actions pins via the agentic-workflows toolchain; Renovate must not touch them",
+      "matchPackageNames": [
+        "github/gh-aw-actions",
+        "github/gh-aw-actions/**"
+      ],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Disables Renovate updates for `github/gh-aw-actions` (and its subdirectory actions, e.g. `github/gh-aw-actions/setup`).

These action pins are managed by the **gh-aw (GitHub Agentic Workflows) toolchain** in `.github/aw/actions-lock.json` and the generated `*.lock.yml` workflows. Letting Renovate bump them would fight that tooling, producing PRs that the next gh-aw regeneration overwrites.

Adds a `packageRules` entry with `enabled: false` matching the repo and its subdir actions.

## Test plan

- `renovate.json` validated as well-formed JSON.