### PR TITLE
feat(cli): chirp daemon start | stop | restart (story 5.3)

### DIFF
--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.1-logfmt-logging-and-rotation.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.1-logfmt-logging-and-rotation.md
@@ -49,6 +49,7 @@ The architecture lists the required and optional logfmt fields in § Implementat
   | `tokens` | Op completion lines for chat/embed | `tokens=412` |
   | `err_code` | Error lines | `err_code=MODEL_LOAD_FAILED` |
   | `err_type` | Error lines | `err_type=LLMModelLoadFailed` |
+  | `result` | Lifecycle op outcome lines (added by story 5.3) | `result=spawned` |
 
 - **AC-6** Values containing spaces, `=`, `"`, or `\n` are double-quoted with backslash escaping (`\"` for inner quote, `\\` for backslash, `\n` for newline). Values without those characters are emitted bare. A `logfmt_escape(value: str) -> str` helper performs this consistently and is the only place quoting logic lives. Tested by AC-15.
 
@@ -99,7 +100,7 @@ The architecture lists the required and optional logfmt fields in § Implementat
    - `DEFAULT_LOG_DIR_DARWIN = Path.home() / "Library" / "Logs" / "chirp"`
    - `DEFAULT_LOG_DIR_FALLBACK = Path.home() / ".cache" / "chirp"`
    - `LOGFMT_REQUIRED_FIELDS = ("ts", "level", "component", "msg")`
-   - `LOGFMT_OPTIONAL_FIELDS = frozenset({"req_id", "op", "model", "duration_ms", "tokens", "err_code", "err_type"})`
+   - `LOGFMT_OPTIONAL_FIELDS = frozenset({"req_id", "op", "model", "duration_ms", "tokens", "err_code", "err_type", "result"})` (`result` appended by story 5.3)
    - `FORBIDDEN_EXTRA_KEY_PATTERN = re.compile(r"prompt|message|content|text|note|transcript", re.IGNORECASE)`
    - `class LogfmtFormatter(logging.Formatter)` — implements `format()` with the field-order and escaping rules; performs defensive redaction per AC-10.
    - `def logfmt_escape(value: object) -> str` — the only place quoting lives.

--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.3-daemon-start-stop-restart.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.3-daemon-start-stop-restart.md
@@ -1,6 +1,6 @@
 # Story 5.3 — `chirp daemon start | stop | restart`: manual lifecycle controls
 
-- **Status:** Draft
+- **Status:** review
 - **Epic:** [EPIC-DAEMON-LIFECYCLE](../epic.md)
 - **Depends on:** 5.2 (the `daemon_app` Typer instance and the `LLMClient` interaction pattern exist in `llm/cli/daemon.py`); EPIC-CHIRPD-CORE (lazy-spawn via `chirpd` console script; shutdown op or signal-based stop path; `flock` single-instance enforcement)
 - **Blocks:** 5.6 (Typer registration)
@@ -119,22 +119,22 @@ The commands share file structure with story 5.2's `status`: they live in `llm/c
 
 ## Implementation tasks
 
-1. **Pick the shutdown mechanism.** Before writing the `stop` command, confirm what CHIRPD-CORE delivers:
+- [x] 1. **Pick the shutdown mechanism.** Before writing the `stop` command, confirm what CHIRPD-CORE delivers:
    - If a `shutdown` op exists on the wire protocol with a client method `LLMClient.shutdown()`, use it (preferred — surfaces clean shutdown in the daemon's logs, no signal racing).
    - Otherwise use `os.kill(pid, signal.SIGTERM)`. The daemon's signal handler (CHIRPD-CORE) must stop the asyncio loop and exit cleanly. Verify by reading the CHIRPD-CORE story for the signal-handling work.
    - Document which path was chosen in `llm/cli/daemon.py`'s docstring so future maintainers know.
 
-2. **Implement the three commands.** Each is a short function (~30–50 lines). Factor a shared helper `_wait_for_socket(socket_path: Path, *, present: bool, timeout: float) -> bool` that returns True if the socket-state transition occurred within the timeout. Both `start` and `stop` use it (with `present=True` and `present=False` respectively).
+- [x] 2. **Implement the three commands.** Each is a short function (~30–50 lines). Factor a shared helper `_wait_for_socket(socket_path: Path, *, present: bool, timeout: float) -> bool` that returns True if the socket-state transition occurred within the timeout. Both `start` and `stop` use it (with `present=True` and `present=False` respectively).
 
-3. **Add `result` to the logfmt optional fields.** Append `"result"` to `LOGFMT_OPTIONAL_FIELDS` in `chirpd/logging_setup.py` (set introduced in story 5.1's AC-9). Add a one-line note in story 5.1's documented field table — either via a follow-up edit to 5.1's story file (preferred — keep the source of truth singular) or by extending the docstring in `logging_setup.py` to list `result` as well. **In code**: a single-line addition, no logic changes to the helper.
+- [x] 3. **Add `result` to the logfmt optional fields.** Append `"result"` to `LOGFMT_OPTIONAL_FIELDS` in `chirpd/logging_setup.py` (set introduced in story 5.1's AC-9). Add a one-line note in story 5.1's documented field table — either via a follow-up edit to 5.1's story file (preferred — keep the source of truth singular) or by extending the docstring in `logging_setup.py` to list `result` as well. **In code**: a single-line addition, no logic changes to the helper.
 
-4. **Implement `--json` output.** Reuse `_should_use_json` from story 5.2. Construct the response dict, dump with `json.dumps(payload, indent=2)`. On failure paths, build the same dict shape with an `error` sub-object.
+- [x] 4. **Implement `--json` output.** Reuse `_should_use_json` from story 5.2. Construct the response dict, dump with `json.dumps(payload, indent=2)`. On failure paths, build the same dict shape with an `error` sub-object.
 
-5. **Handle the partial-restart failure case carefully.** If `stop` succeeded but `start` failed, the daemon is *down*. The user-facing message must say that clearly so they don't think the old daemon is still running. The `--json` output for this case has `"running": false` and `"error": {...}`.
+- [x] 5. **Handle the partial-restart failure case carefully.** If `stop` succeeded but `start` failed, the daemon is *down*. The user-facing message must say that clearly so they don't think the old daemon is still running. The `--json` output for this case has `"running": false` and `"error": {...}`.
 
-6. **Write the tests.** Extend `tests/llm/test_cli_daemon.py`. Many tests patch `subprocess.Popen` and `LLMClient` methods; use `unittest.mock.patch` consistently. The `_wait_for_socket` helper is straightforward to test by patching `Path.exists` or by writing/removing a real socket file in a `tmp_path`.
+- [x] 6. **Write the tests.** Extend `tests/llm/test_cli_daemon.py`. Many tests patch `subprocess.Popen` and `LLMClient` methods; use `unittest.mock.patch` consistently. The `_wait_for_socket` helper is straightforward to test by patching `Path.exists` or by writing/removing a real socket file in a `tmp_path`.
 
-7. **Manual smoke tests** (against a real daemon on a dev machine):
+- [ ] 7. **Manual smoke tests** (against a real daemon on a dev machine) — *deferred to manual QA; requires a real Apple-Silicon daemon, not run in this automated implementation*:
    - `chirp daemon stop && chirp daemon stop` — second invocation idempotent.
    - `chirp daemon start && chirp daemon start` — second invocation idempotent.
    - `chirp daemon restart` — works against both running and not-running starting states.
@@ -161,3 +161,93 @@ The commands share file structure with story 5.2's `status`: they live in `llm/c
 - **`daemon_app` now hosts four commands** (`status`, `start`, `stop`, `restart`). Story 5.4 adds `enable`/`disable`; story 5.5 adds `logs`; story 5.6 wires the lot into `chirp/cli.py`.
 - **`_wait_for_socket` helper** is available for any future command that needs to poll daemon-running state. Story 5.4's `enable` may want to wait for the LaunchAgent-spawned daemon to appear; reuse this helper.
 - **The shutdown mechanism choice** (op vs signal) is now documented in `llm/cli/daemon.py`. Future stories needing daemon shutdown semantics use the same path.
+
+## Dev Agent Record
+
+### Implementation plan
+
+Implemented `start` / `stop` / `restart` on `daemon_app`, plus a `_wait_for_socket`
+socket-state poller. Each command is a thin Typer wrapper over a side-effect-free
+`_attempt_start` / `_attempt_stop` core that returns an outcome dict, which keeps
+`restart` (which orchestrates both) free of duplicated control flow and makes the
+JSON / text / exit-code mapping a single decision point per command.
+
+### Contract reconciliation (CHIRPD-CORE drift — verified before coding)
+
+The story's interface assumptions diverged from the shipped CHIRPD-CORE contract;
+each was reconciled to the real code (observable ACs are all preserved):
+
+- **Shutdown is signal-based, not op-based (task 1 resolved).** There is no
+  `shutdown` wire op and no `LLMClient.shutdown()` method. `chirpd/__main__.py`
+  installs `SIGTERM`/`SIGINT` handlers that cancel the asyncio serve task and exit
+  cleanly. `stop` therefore reads `pid` from `model.status` and sends `SIGTERM`,
+  escalating to `SIGKILL` if the socket does not vacate in 5 s. The choice is
+  documented in `llm/cli/daemon.py`'s module docstring (per task 1).
+- **No `lazy_spawn=False` client kwarg (AC-4).** `LLMClient` controls spawning
+  per-call via `spawn_if_absent`, exposed only on `model_list`. Added the same
+  `spawn_if_absent` keyword to `health()`/`model_status()` (and their `_sync`
+  variants), backward-compatible (default `True`). `stop`/`restart` probe with
+  `model_status_sync(spawn_if_absent=False)` so they never lazy-spawn a daemon
+  just to stop it. `test_stop_does_not_lazy_spawn` asserts the kwarg.
+- **`pid` comes from `model.status`, not `health` (AC-2/AC-3).** `health`'s ready
+  payload carries only uptime/version (confirmed against story 5.2's
+  `_collect_status`). The non-spawning running-probe helper `_probe_running`
+  returns `(running, pid)` off `model.status`.
+- **`log_op_event` needed wiring, not just a set edit (AC-8/task 3).** Appending
+  `result` to `LOGFMT_OPTIONAL_FIELDS` alone would have passed validation but
+  silently dropped the value (the helper only forwards named optional params, not
+  `**extra`). Added an explicit `result` parameter and updated story 5.1's field
+  table accordingly.
+
+### Test-name adaptations (AC-12)
+
+Because shutdown is signal-based, `test_stop_succeeds_via_shutdown_op` became
+`test_stop_succeeds_via_sigterm` (patches `os.kill` + `_wait_for_socket` instead
+of `LLMClient.shutdown`), and `test_stop_does_not_lazy_spawn` asserts
+`model_status_sync(spawn_if_absent=False)` rather than a `lazy_spawn=False`
+constructor. All other AC-12 cases implemented as specified. `_wait_for_socket`
+covered via `_socket_accepting` patching (both match and timeout paths).
+
+### Completion notes
+
+- ✅ All 12 ACs satisfied. Three commands + `--json` on each; idempotent no-ops;
+  signal-based stop with SIGKILL escalation; restart with fresh-start and
+  partial-failure handling; one `op=daemon_* ... result=...` logfmt line per command.
+- ✅ `uv run pytest` — 1288 passed (49 lifecycle/status + logging + client cases).
+- ✅ `uv run ruff check .` clean; `uv run mypy llm/cli/daemon.py` (and `llm/client.py`,
+  `chirpd/logging_setup.py`) clean.
+- ✅ Coverage on `llm/cli/daemon.py` command bodies: 96% (> 90% target). Uncovered
+  lines are the real OS-touching socket-connect / poll loop, exercised by the
+  deferred manual smoke tests (task 7) per the project's policy of not unit-testing
+  real-device/real-process code.
+- ⏳ Task 7 manual smoke tests deferred — they require a real Apple-Silicon daemon
+  process (the two-terminal in-flight-during-stop test in particular). Left
+  unchecked for manual QA.
+- Help output verified live (AC-11) via `CliRunner` for all three commands and the
+  `daemon --help` group listing (now four commands).
+
+## File List
+
+- `llm/cli/daemon.py` — added `start`/`stop`/`restart` commands, `_wait_for_socket`,
+  `_socket_accepting`, `_attempt_start`/`_attempt_stop`, `_probe_running`,
+  `_spawn_chirpd`, `_signal_pid`/`_pid_alive`, `_emit_json`, `_log_lifecycle`,
+  `_start_exit_code`; documented the signal-based shutdown choice in the docstring.
+- `llm/client.py` — added `spawn_if_absent` keyword to `health()`/`health_sync()`
+  and `model_status()`/`model_status_sync()`.
+- `chirpd/logging_setup.py` — added `result` to `LOGFMT_OPTIONAL_FIELDS` and an
+  explicit `result` parameter on `log_op_event`; docstring note.
+- `tests/llm/test_cli_daemon.py` — added the lifecycle command suite (start/stop/
+  restart, `--json`, logging, `_wait_for_socket`/`_socket_accepting` helpers).
+- `tests/chirpd/test_logging_setup.py` — added `result`-field passthrough test.
+- `tests/llm/test_client.py` — updated `_stub_health` to accept the new
+  `spawn_if_absent` keyword.
+- `_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.1-logfmt-logging-and-rotation.md`
+  — documented the `result` optional field (source-of-truth update, task 3).
+
+## Change Log
+
+- 2026-06-04 — Implemented story 5.3 (`chirp daemon start | stop | restart`):
+  manual lifecycle controls with signal-based shutdown, `--json` on all three
+  commands, and per-command logfmt diagnostics. Reconciled the story's interface
+  assumptions to the shipped CHIRPD-CORE contract (signal-based stop, per-call
+  `spawn_if_absent`, pid from `model.status`). Status: Draft → review.

--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.3-daemon-start-stop-restart.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.3-daemon-start-stop-restart.md
@@ -1,6 +1,6 @@
 # Story 5.3 — `chirp daemon start | stop | restart`: manual lifecycle controls
 
-- **Status:** review
+- **Status:** done
 - **Epic:** [EPIC-DAEMON-LIFECYCLE](../epic.md)
 - **Depends on:** 5.2 (the `daemon_app` Typer instance and the `LLMClient` interaction pattern exist in `llm/cli/daemon.py`); EPIC-CHIRPD-CORE (lazy-spawn via `chirpd` console script; shutdown op or signal-based stop path; `flock` single-instance enforcement)
 - **Blocks:** 5.6 (Typer registration)
@@ -251,3 +251,7 @@ covered via `_socket_accepting` patching (both match and timeout paths).
   commands, and per-command logfmt diagnostics. Reconciled the story's interface
   assumptions to the shipped CHIRPD-CORE contract (signal-based stop, per-call
   `spawn_if_absent`, pid from `model.status`). Status: Draft → review.
+- 2026-06-04 — PR #79: addressed BMAD review (SIGKILL-escalation honesty) and
+  Copilot review (spawn `OSError` handling, `spawned=true` on post-spawn timeout,
+  SIGKILL `running` re-probe, `pid=unknown` messaging). All CI green, all review
+  threads resolved. Status: review → done.

--- a/chirpd/logging_setup.py
+++ b/chirpd/logging_setup.py
@@ -16,7 +16,8 @@ Public surface:
 Redaction rule (NFR-S5, hard constraint): no user prompt text, chat messages,
 note content, embed input text, or transcript text ever reaches the log. Logged
 metadata is limited to op name, model alias, request id, token counts, durations,
-and error classifications. A forbidden-looking field that slips in via ``extra=``
+operation results (``result=spawned|stopped|...``), and error classifications. A
+forbidden-looking field that slips in via ``extra=``
 is rendered ``<redacted>`` by the formatter and triggers exactly one
 ``err_type=RedactionViolation`` warning line (emitted by a logger-level filter, so
 it fires once per record regardless of how many handlers are attached). Example::
@@ -47,7 +48,7 @@ DEFAULT_LOG_DIR_FALLBACK: Final[Path] = Path.home() / _FALLBACK_LOG_SUBPATH
 
 LOGFMT_REQUIRED_FIELDS: Final[tuple[str, ...]] = ("ts", "level", "component", "msg")
 LOGFMT_OPTIONAL_FIELDS: Final[frozenset[str]] = frozenset(
-    {"req_id", "op", "model", "duration_ms", "tokens", "err_code", "err_type"}
+    {"req_id", "op", "model", "duration_ms", "tokens", "err_code", "err_type", "result"}
 )
 
 FORBIDDEN_EXTRA_KEY_PATTERN: Final[re.Pattern[str]] = re.compile(
@@ -242,6 +243,7 @@ def log_op_event(
     tokens: int | None = None,
     err_code: str | None = None,
     err_type: str | None = None,
+    result: str | None = None,
     **extra: object,
 ) -> None:
     """Emit an op-level log line — the only sanctioned op emitter in ``chirpd/``.
@@ -268,6 +270,7 @@ def log_op_event(
         "tokens": tokens,
         "err_code": err_code,
         "err_type": err_type,
+        "result": result,
     }
     fields.update({key: value for key, value in optional.items() if value is not None})
     logger.log(level, msg, extra=fields)

--- a/llm/cli/daemon.py
+++ b/llm/cli/daemon.py
@@ -422,7 +422,7 @@ def stop(
         _emit_json(
             {
                 "action": "stop",
-                "running": not result["killed"],
+                "running": result["running"],
                 "was_running": True,
                 "killed": result["killed"],
                 "error": error,
@@ -455,7 +455,7 @@ def restart(
             _emit_json(
                 {
                     "action": "restart",
-                    "running": not stop_result["killed"],
+                    "running": stop_result["running"],
                     "old_pid": old_pid,
                     "new_pid": None,
                     "error": error,
@@ -584,7 +584,13 @@ def _attempt_stop(socket_path: Path) -> dict[str, Any]:
     """Bring the daemon down via SIGTERM (SIGKILL escalation). Never prints/exits.
 
     Keys: ``ok``, ``was_running``, ``pid`` (the pid found, for ``restart`` to
-    report as ``old_pid``), ``killed`` (SIGKILL had to escalate), ``error``.
+    report as ``old_pid``), ``killed`` (SIGKILL had to escalate), ``running``
+    (the daemon's true post-attempt state), ``error``.
+
+    The pid read from ``model.status`` is trusted for the lifetime of this call.
+    In the (alpha-acceptable) worst case the daemon exits and the OS recycles its
+    pid before the 5 s escalation fires, so SIGKILL could land on an unrelated
+    same-user process; the window is small and stop is operator-initiated.
     """
     running, pid = _probe_running(socket_path)
     if not running:
@@ -593,6 +599,7 @@ def _attempt_stop(socket_path: Path) -> dict[str, Any]:
             "was_running": False,
             "pid": None,
             "killed": False,
+            "running": False,
             "error": None,
         }
 
@@ -605,21 +612,46 @@ def _attempt_stop(socket_path: Path) -> dict[str, Any]:
             "was_running": True,
             "pid": pid,
             "killed": False,
+            "running": False,
             "error": None,
         }
 
-    killed = False
+    timeout_message = f"daemon did not stop within {int(_STOP_TIMEOUT_S)} seconds"
     if pid is not None and _pid_alive(pid):
         killed = _signal_pid(pid, signal.SIGKILL)
+        suffix = " — sent SIGKILL" if killed else ""
+        return {
+            "ok": False,
+            "was_running": True,
+            "pid": pid,
+            "killed": killed,
+            "running": False,
+            "error": {
+                "code": _ERR_STOP_TIMEOUT,
+                "message": f"{timeout_message}{suffix}",
+            },
+        }
+
+    # No live pid to signal: the daemon may still be holding the socket (we just
+    # have no pid to kill) or it may have exited just past the poll deadline.
+    # Re-probe instead of inferring state — and never claim a SIGKILL we did not
+    # send.
+    if not _socket_accepting(socket_path):
+        return {
+            "ok": True,
+            "was_running": True,
+            "pid": pid,
+            "killed": False,
+            "running": False,
+            "error": None,
+        }
     return {
         "ok": False,
         "was_running": True,
         "pid": pid,
-        "killed": killed,
-        "error": {
-            "code": _ERR_STOP_TIMEOUT,
-            "message": f"daemon did not stop within {int(_STOP_TIMEOUT_S)} seconds — sent SIGKILL",
-        },
+        "killed": False,
+        "running": True,
+        "error": {"code": _ERR_STOP_TIMEOUT, "message": timeout_message},
     }
 
 

--- a/llm/cli/daemon.py
+++ b/llm/cli/daemon.py
@@ -11,15 +11,35 @@ and renders the merged snapshot — a Rich table on a TTY, a single JSON documen
 when ``--json`` is passed or stdout is piped. It has no side effect beyond the
 read ops it issues (which may lazy-spawn a daemon, the one side effect any chirp
 command that needs the daemon performs).
+
+``start`` / ``stop`` / ``restart`` manage the daemon process explicitly. ``start``
+spawns ``chirpd`` via :func:`subprocess.Popen` and polls the socket; ``stop`` and
+``restart`` shut the daemon down.
+
+**Shutdown mechanism (story 5.3 task 1).** CHIRPD-CORE ships a *signal-based*
+shutdown, not a wire ``shutdown`` op: ``chirpd/__main__.py`` installs ``SIGTERM`` /
+``SIGINT`` handlers that cancel the asyncio serve task and exit cleanly (option
+(b) in the story). ``stop`` therefore reads the daemon ``pid`` from ``model.status``
+and sends ``SIGTERM`` (escalating to ``SIGKILL`` only if the socket does not vacate
+within the timeout). There is no ``LLMClient.shutdown()`` method to use. Because
+``stop`` must never *spawn* a daemon just to ask it to die, it probes with
+``model_status_sync(spawn_if_absent=False)`` (AC-4); the daemon ``pid`` comes from
+``model.status``, not ``health`` (``health`` carries only uptime/version).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
+import signal
+import socket as socketlib
+import subprocess
 import sys
 import time
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import IO, Any
 
 import typer
@@ -28,8 +48,9 @@ from rich.console import Console
 from rich.table import Table
 
 from chirpd.logging_setup import configure_logging, log_op_event
+from config.settings import CHIRP_DAEMON_SOCKET_ENV
 from llm.cli._console import console, stdout_console
-from llm.client import LLMClient
+from llm.client import LLMClient, resolve_socket_path
 from llm.exceptions import LLMDaemonUnreachable, LLMError
 from llm.protocol import new_request_id
 
@@ -290,4 +311,408 @@ def _log_status(req_id: str, start_ns: int, *, daemon_running: bool) -> None:
         req_id=req_id,
         op="status",
         duration_ms=duration_ms,
+    )
+
+
+# --- lifecycle: start / stop / restart (story 5.3) --------------------------
+
+_SOCKET_POLL_INTERVAL_S = 0.05
+_START_TIMEOUT_S = 5.0
+_STOP_TIMEOUT_S = 5.0
+_RESTART_SETTLE_S = 0.1
+_LOG_HINT = "~/Library/Logs/chirp/chirpd.log"
+
+_ERR_NOT_ON_PATH = "DAEMON_NOT_ON_PATH"
+_ERR_START_TIMEOUT = "DAEMON_START_TIMEOUT"
+_ERR_UNREACHABLE = "DAEMON_UNREACHABLE"
+_ERR_STOP_TIMEOUT = "DAEMON_STOP_TIMEOUT"
+
+
+@daemon_app.command("start")
+def start(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON to stdout."
+    ),
+) -> None:
+    """Spawn the daemon process. No-op if already running."""
+    use_json = _should_use_json(json_output)
+    _ensure_logging()
+    start_ns = time.perf_counter_ns()
+    socket_path = resolve_socket_path()
+
+    result = _attempt_start(socket_path)
+
+    if result["ok"]:
+        outcome = "already_running" if result["already"] else "spawned"
+        _log_lifecycle("daemon_start", start_ns, result=outcome)
+        if use_json:
+            _emit_json(
+                {
+                    "action": "start",
+                    "running": True,
+                    "pid": result["pid"],
+                    "spawned": result["spawned"],
+                }
+            )
+        elif result["already"]:
+            console.print("daemon is already running", markup=False, soft_wrap=True)
+        else:
+            stdout_console.print(
+                f"daemon started (pid={result['pid']})",
+                markup=False,
+                highlight=False,
+                soft_wrap=True,
+            )
+        return
+
+    error = result["error"]
+    _log_lifecycle("daemon_start", start_ns, result="failed")
+    if use_json:
+        _emit_json(
+            {
+                "action": "start",
+                "running": False,
+                "pid": None,
+                "spawned": result["spawned"],
+                "error": error,
+            }
+        )
+    else:
+        console.print(error["message"], style="red", markup=False, soft_wrap=True)
+    raise typer.Exit(code=_start_exit_code(error))
+
+
+@daemon_app.command("stop")
+def stop(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON to stdout."
+    ),
+) -> None:
+    """Stop the daemon process. No-op if not running."""
+    use_json = _should_use_json(json_output)
+    _ensure_logging()
+    start_ns = time.perf_counter_ns()
+    socket_path = resolve_socket_path()
+
+    result = _attempt_stop(socket_path)
+
+    if result["ok"]:
+        outcome = "stopped" if result["was_running"] else "not_running"
+        _log_lifecycle("daemon_stop", start_ns, result=outcome)
+        if use_json:
+            _emit_json(
+                {
+                    "action": "stop",
+                    "running": False,
+                    "was_running": result["was_running"],
+                    "killed": False,
+                }
+            )
+        elif result["was_running"]:
+            stdout_console.print("daemon stopped", markup=False, soft_wrap=True)
+        else:
+            console.print("daemon is not running", markup=False, soft_wrap=True)
+        return
+
+    error = result["error"]
+    _log_lifecycle(
+        "daemon_stop", start_ns, result="killed" if result["killed"] else "failed"
+    )
+    if use_json:
+        _emit_json(
+            {
+                "action": "stop",
+                "running": not result["killed"],
+                "was_running": True,
+                "killed": result["killed"],
+                "error": error,
+            }
+        )
+    else:
+        console.print(error["message"], style="red", markup=False, soft_wrap=True)
+    raise typer.Exit(code=1)
+
+
+@daemon_app.command("restart")
+def restart(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON to stdout."
+    ),
+) -> None:
+    """Stop then start the daemon. Starts a fresh instance if not running."""
+    use_json = _should_use_json(json_output)
+    _ensure_logging()
+    start_ns = time.perf_counter_ns()
+    socket_path = resolve_socket_path()
+
+    stop_result = _attempt_stop(socket_path)
+    old_pid = stop_result["pid"]
+
+    if not stop_result["ok"]:
+        error = stop_result["error"]
+        _log_lifecycle("daemon_restart", start_ns, result="stop_failed")
+        if use_json:
+            _emit_json(
+                {
+                    "action": "restart",
+                    "running": not stop_result["killed"],
+                    "old_pid": old_pid,
+                    "new_pid": None,
+                    "error": error,
+                }
+            )
+        else:
+            console.print(error["message"], style="red", markup=False, soft_wrap=True)
+        raise typer.Exit(code=1)
+
+    was_running = stop_result["was_running"]
+    if was_running:
+        # Give the asyncio server time to unlink the socket and release the flock
+        # before a fresh chirpd races to bind the same path (see Dev notes).
+        time.sleep(_RESTART_SETTLE_S)
+    elif not use_json:
+        console.print(
+            "daemon is not running — starting fresh instance...",
+            markup=False,
+            soft_wrap=True,
+        )
+
+    start_result = _attempt_start(socket_path)
+
+    if start_result["ok"]:
+        _log_lifecycle("daemon_restart", start_ns, result="ok")
+        if use_json:
+            _emit_json(
+                {
+                    "action": "restart",
+                    "running": True,
+                    "old_pid": old_pid,
+                    "new_pid": start_result["pid"],
+                }
+            )
+        else:
+            stdout_console.print(
+                f"daemon restarted (pid={start_result['pid']})",
+                markup=False,
+                highlight=False,
+                soft_wrap=True,
+            )
+        return
+
+    error = start_result["error"]
+    _log_lifecycle("daemon_restart", start_ns, result="start_failed")
+    if was_running:
+        message = f"daemon was stopped but did not restart — check {_LOG_HINT}"
+        exit_code = 1
+    else:
+        message = error["message"]
+        exit_code = _start_exit_code(error)
+    if use_json:
+        _emit_json(
+            {
+                "action": "restart",
+                "running": False,
+                "old_pid": old_pid,
+                "new_pid": None,
+                "error": {"code": error["code"], "message": message},
+            }
+        )
+    else:
+        console.print(message, style="red", markup=False, soft_wrap=True)
+    raise typer.Exit(code=exit_code)
+
+
+def _attempt_start(socket_path: Path) -> dict[str, Any]:
+    """Bring the daemon up. Returns an outcome dict; never prints or exits.
+
+    Keys: ``ok``, ``pid``, ``spawned``, ``already``, ``error`` (a
+    ``{"code", "message"}`` dict on failure, else ``None``).
+    """
+    running, pid = _probe_running(socket_path)
+    if running:
+        return {
+            "ok": True,
+            "pid": pid,
+            "spawned": False,
+            "already": True,
+            "error": None,
+        }
+
+    chirpd_path = shutil.which("chirpd")
+    if chirpd_path is None:
+        return {
+            "ok": False,
+            "pid": None,
+            "spawned": False,
+            "already": False,
+            "error": {
+                "code": _ERR_NOT_ON_PATH,
+                "message": "chirpd binary not found on PATH — is chirp installed correctly?",
+            },
+        }
+
+    _spawn_chirpd(chirpd_path, socket_path)
+
+    if not _wait_for_socket(socket_path, present=True, timeout=_START_TIMEOUT_S):
+        return {
+            "ok": False,
+            "pid": None,
+            "spawned": False,
+            "already": False,
+            "error": {
+                "code": _ERR_START_TIMEOUT,
+                "message": f"daemon failed to start within {int(_START_TIMEOUT_S)} seconds — check {_LOG_HINT}",
+            },
+        }
+
+    running, pid = _probe_running(socket_path)
+    if not running:
+        return {
+            "ok": False,
+            "pid": None,
+            "spawned": True,
+            "already": False,
+            "error": {
+                "code": _ERR_UNREACHABLE,
+                "message": f"daemon started but is not reachable — check {_LOG_HINT}",
+            },
+        }
+    return {"ok": True, "pid": pid, "spawned": True, "already": False, "error": None}
+
+
+def _attempt_stop(socket_path: Path) -> dict[str, Any]:
+    """Bring the daemon down via SIGTERM (SIGKILL escalation). Never prints/exits.
+
+    Keys: ``ok``, ``was_running``, ``pid`` (the pid found, for ``restart`` to
+    report as ``old_pid``), ``killed`` (SIGKILL had to escalate), ``error``.
+    """
+    running, pid = _probe_running(socket_path)
+    if not running:
+        return {
+            "ok": True,
+            "was_running": False,
+            "pid": None,
+            "killed": False,
+            "error": None,
+        }
+
+    if pid is not None:
+        _signal_pid(pid, signal.SIGTERM)
+
+    if _wait_for_socket(socket_path, present=False, timeout=_STOP_TIMEOUT_S):
+        return {
+            "ok": True,
+            "was_running": True,
+            "pid": pid,
+            "killed": False,
+            "error": None,
+        }
+
+    killed = False
+    if pid is not None and _pid_alive(pid):
+        killed = _signal_pid(pid, signal.SIGKILL)
+    return {
+        "ok": False,
+        "was_running": True,
+        "pid": pid,
+        "killed": killed,
+        "error": {
+            "code": _ERR_STOP_TIMEOUT,
+            "message": f"daemon did not stop within {int(_STOP_TIMEOUT_S)} seconds — sent SIGKILL",
+        },
+    }
+
+
+def _probe_running(socket_path: Path) -> tuple[bool, int | None]:
+    """Return ``(running, pid)`` without ever lazy-spawning the daemon (AC-4).
+
+    ``pid`` rides on the ``model.status`` payload; ``spawn_if_absent=False`` makes
+    an absent daemon raise :class:`LLMDaemonUnreachable` rather than be spawned.
+    """
+    try:
+        payload = LLMClient(socket_path=socket_path).model_status_sync(
+            spawn_if_absent=False
+        )
+    except LLMDaemonUnreachable:
+        return False, None
+    pid = payload.get("pid")
+    return True, int(pid) if pid is not None else None
+
+
+def _spawn_chirpd(chirpd_path: str, socket_path: Path) -> None:
+    """Detach a new ``chirpd`` bound to ``socket_path`` (no parent stdio inheritance)."""
+    env = os.environ.copy()
+    env[CHIRP_DAEMON_SOCKET_ENV] = str(socket_path)
+    subprocess.Popen(
+        [chirpd_path],
+        env=env,
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def _wait_for_socket(socket_path: Path, *, present: bool, timeout: float) -> bool:
+    """Poll until the socket's accept state matches ``present``, or ``timeout``.
+
+    ``present=True`` waits for the socket to start accepting connections (start);
+    ``present=False`` waits for it to stop (stop). Returns True if the transition
+    occurred within ``timeout`` seconds, False on timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        if _socket_accepting(socket_path) == present:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(_SOCKET_POLL_INTERVAL_S)
+
+
+def _socket_accepting(socket_path: Path) -> bool:
+    """True if a unix socket at ``socket_path`` accepts a connection right now."""
+    probe = socketlib.socket(socketlib.AF_UNIX, socketlib.SOCK_STREAM)
+    try:
+        probe.connect(str(socket_path))
+    except OSError:
+        return False
+    finally:
+        probe.close()
+    return True
+
+
+def _signal_pid(pid: int, sig: int) -> bool:
+    """Send ``sig`` to ``pid``; True if delivered, False if the process was gone."""
+    try:
+        os.kill(pid, sig)
+    except ProcessLookupError:
+        return False
+    except PermissionError:  # pragma: no cover — daemon is always same-user
+        return False
+    return True
+
+
+def _pid_alive(pid: int) -> bool:
+    return _signal_pid(pid, 0)
+
+
+def _start_exit_code(error: dict[str, Any]) -> int:
+    # AC-10: a post-spawn unreachable daemon is the rare exit-3 case; all other
+    # start failures (missing binary, spawn timeout) are operational exit-1.
+    return 3 if error["code"] == _ERR_UNREACHABLE else 1
+
+
+def _emit_json(payload: dict[str, Any]) -> None:
+    sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+
+
+def _log_lifecycle(op: str, start_ns: int, *, result: str) -> None:
+    duration_ms = max(int((time.perf_counter_ns() - start_ns) / 1_000_000), 0)
+    log_op_event(
+        _logger,
+        logging.INFO,
+        f"{op}: {result}",
+        req_id=new_request_id(),
+        op=op,
+        duration_ms=duration_ms,
+        result=result,
     )

--- a/llm/cli/daemon.py
+++ b/llm/cli/daemon.py
@@ -326,6 +326,7 @@ _ERR_NOT_ON_PATH = "DAEMON_NOT_ON_PATH"
 _ERR_START_TIMEOUT = "DAEMON_START_TIMEOUT"
 _ERR_UNREACHABLE = "DAEMON_UNREACHABLE"
 _ERR_STOP_TIMEOUT = "DAEMON_STOP_TIMEOUT"
+_ERR_SPAWN_FAILED = "DAEMON_SPAWN_FAILED"
 
 
 @daemon_app.command("start")
@@ -358,7 +359,7 @@ def start(
             console.print("daemon is already running", markup=False, soft_wrap=True)
         else:
             stdout_console.print(
-                f"daemon started (pid={result['pid']})",
+                f"daemon started (pid={_format_pid(result['pid'])})",
                 markup=False,
                 highlight=False,
                 soft_wrap=True,
@@ -492,7 +493,7 @@ def restart(
             )
         else:
             stdout_console.print(
-                f"daemon restarted (pid={start_result['pid']})",
+                f"daemon restarted (pid={_format_pid(start_result['pid'])})",
                 markup=False,
                 highlight=False,
                 soft_wrap=True,
@@ -551,13 +552,25 @@ def _attempt_start(socket_path: Path) -> dict[str, Any]:
             },
         }
 
-    _spawn_chirpd(chirpd_path, socket_path)
+    try:
+        _spawn_chirpd(chirpd_path, socket_path)
+    except OSError as exc:
+        return {
+            "ok": False,
+            "pid": None,
+            "spawned": False,
+            "already": False,
+            "error": {
+                "code": _ERR_SPAWN_FAILED,
+                "message": f"failed to spawn chirpd ({chirpd_path}): {exc}",
+            },
+        }
 
     if not _wait_for_socket(socket_path, present=True, timeout=_START_TIMEOUT_S):
         return {
             "ok": False,
             "pid": None,
-            "spawned": False,
+            "spawned": True,
             "already": False,
             "error": {
                 "code": _ERR_START_TIMEOUT,
@@ -625,7 +638,9 @@ def _attempt_stop(socket_path: Path) -> dict[str, Any]:
             "was_running": True,
             "pid": pid,
             "killed": killed,
-            "running": False,
+            # SIGKILL delivery is not synchronous with the socket closing, so
+            # report the actually-observed state rather than assuming "down".
+            "running": _socket_accepting(socket_path),
             "error": {
                 "code": _ERR_STOP_TIMEOUT,
                 "message": f"{timeout_message}{suffix}",
@@ -725,6 +740,11 @@ def _signal_pid(pid: int, sig: int) -> bool:
 
 def _pid_alive(pid: int) -> bool:
     return _signal_pid(pid, 0)
+
+
+def _format_pid(pid: int | None) -> str:
+    """Render a pid for user-facing text — ``model.status`` may omit it."""
+    return str(pid) if pid is not None else "unknown"
 
 
 def _start_exit_code(error: dict[str, Any]) -> int:

--- a/llm/client.py
+++ b/llm/client.py
@@ -138,10 +138,10 @@ class LLMClient:
         self.daemon_lazy_spawned = False
         self.daemon_respawned = False
 
-    async def health(self) -> dict[str, Any]:
+    async def health(self, *, spawn_if_absent: bool = True) -> dict[str, Any]:
         envelope = {"id": new_request_id(), "op": OP_HEALTH}
         ready_payload: dict[str, Any] | None = None
-        async for event in self._request(envelope):
+        async for event in self._request(envelope, spawn_if_absent=spawn_if_absent):
             if event.get("event") == EVENT_READY:
                 ready_payload = event
         if ready_payload is None:
@@ -150,8 +150,8 @@ class LLMClient:
             )
         return ready_payload
 
-    def health_sync(self) -> dict[str, Any]:
-        return _run_sync(self.health())
+    def health_sync(self, *, spawn_if_absent: bool = True) -> dict[str, Any]:
+        return _run_sync(self.health(spawn_if_absent=spawn_if_absent))
 
     async def model_list(self, *, spawn_if_absent: bool = True) -> list[dict[str, Any]]:
         envelope = {"id": new_request_id(), "op": OP_MODEL_LIST}
@@ -220,10 +220,10 @@ class LLMClient:
     def model_unload_sync(self, alias: str) -> dict[str, Any]:
         return _run_sync(self.model_unload(alias))
 
-    async def model_status(self) -> dict[str, Any]:
+    async def model_status(self, *, spawn_if_absent: bool = True) -> dict[str, Any]:
         envelope = {"id": new_request_id(), "op": OP_MODEL_STATUS}
         status_payload: dict[str, Any] | None = None
-        async for event in self._request(envelope):
+        async for event in self._request(envelope, spawn_if_absent=spawn_if_absent):
             if event.get("event") == EVENT_STATUS:
                 status_payload = event
         if status_payload is None:
@@ -232,8 +232,8 @@ class LLMClient:
             )
         return status_payload
 
-    def model_status_sync(self) -> dict[str, Any]:
-        return _run_sync(self.model_status())
+    def model_status_sync(self, *, spawn_if_absent: bool = True) -> dict[str, Any]:
+        return _run_sync(self.model_status(spawn_if_absent=spawn_if_absent))
 
     def chat_stream(
         self,

--- a/tests/chirpd/test_logging_setup.py
+++ b/tests/chirpd/test_logging_setup.py
@@ -178,6 +178,20 @@ def test_log_op_event_rejects_unknown_keys(bad_key: str) -> None:
         )
 
 
+def test_log_op_event_emits_result_field(tmp_path: Path) -> None:
+    """``result`` (added by story 5.3) passes through to the rendered line."""
+    configure_logging(log_dir=tmp_path)
+    log_op_event(
+        logging.getLogger(CHIRP_LOGGER),
+        logging.INFO,
+        "daemon_start: spawned",
+        req_id="r-1",
+        op="daemon_start",
+        result="spawned",
+    )
+    assert "result=spawned" in _read_log(tmp_path)
+
+
 def test_log_op_event_truncates_long_msg(tmp_path: Path) -> None:
     configure_logging(log_dir=tmp_path)
     long_msg = "x" * 500

--- a/tests/llm/test_cli_daemon.py
+++ b/tests/llm/test_cli_daemon.py
@@ -488,6 +488,50 @@ def test_start_fails_when_chirpd_not_on_path(
     popen.assert_not_called()
 
 
+def test_start_handles_spawn_oserror(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, LLMDaemonUnreachable("absent"))
+    popen = _patch_spawn(monkeypatch)
+    popen.side_effect = OSError("exec format error")
+
+    result = runner.invoke(daemon_module.daemon_app, ["start", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["running"] is False
+    assert payload["spawned"] is False
+    assert set(payload["error"]) == {"code", "message"}
+
+
+def test_start_timeout_reports_spawned_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A spawn was attempted, so the timeout failure must not claim spawned=false
+    # (which AC-9 reserves for "was already running").
+    _patch_client(monkeypatch, LLMDaemonUnreachable("absent"))
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, False)
+
+    result = runner.invoke(daemon_module.daemon_app, ["start", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["spawned"] is True
+
+
+def test_start_message_pid_unknown_when_missing(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [LLMDaemonUnreachable("absent"), _status_payload_no_pid()],
+    )
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, True)
+
+    result = runner.invoke(daemon_module.daemon_app, ["start"])
+
+    assert result.exit_code == 0
+    assert "daemon started (pid=unknown)" in result.stdout
+
+
 # --- stop -------------------------------------------------------------------
 
 
@@ -544,6 +588,8 @@ def test_stop_json_sigkill_escalation(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_client(monkeypatch, _status_payload())
     _patch_wait(monkeypatch, False)
     _patch_kill(monkeypatch)
+    # Socket has vacated by the time we re-probe after SIGKILL.
+    monkeypatch.setattr(daemon_module, "_socket_accepting", lambda _p: False)
 
     result = runner.invoke(daemon_module.daemon_app, ["stop", "--json"])
 
@@ -552,6 +598,24 @@ def test_stop_json_sigkill_escalation(monkeypatch: pytest.MonkeyPatch) -> None:
     assert payload["killed"] is True
     assert payload["running"] is False
     assert set(payload["error"]) == {"code", "message"}
+
+
+def test_stop_json_sigkill_reports_running_when_socket_still_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # SIGKILL delivery is async: if the socket is still accepting on re-probe,
+    # `running` must reflect that truth rather than assume the daemon is down.
+    _patch_client(monkeypatch, _status_payload())
+    _patch_wait(monkeypatch, False)
+    _patch_kill(monkeypatch)
+    monkeypatch.setattr(daemon_module, "_socket_accepting", lambda _p: True)
+
+    result = runner.invoke(daemon_module.daemon_app, ["stop", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["killed"] is True
+    assert payload["running"] is True
 
 
 def test_stop_timeout_without_pid_does_not_claim_sigkill(
@@ -663,6 +727,27 @@ def test_restart_reports_partial_failure_when_start_fails(
 
     assert result.exit_code == 1
     assert "was stopped but did not restart" in result.stderr
+
+
+def test_restart_message_pid_unknown_when_missing(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            _status_payload_pid(111),  # stop probe: running (old pid)
+            LLMDaemonUnreachable("absent"),  # start probe: down after stop
+            _status_payload_no_pid(),  # post-spawn payload without a pid
+        ],
+    )
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, True)
+    _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["restart"])
+
+    assert result.exit_code == 0
+    assert "daemon restarted (pid=unknown)" in result.stdout
 
 
 # --- --json output ----------------------------------------------------------

--- a/tests/llm/test_cli_daemon.py
+++ b/tests/llm/test_cli_daemon.py
@@ -382,6 +382,12 @@ def _status_payload_pid(pid: int) -> dict[str, object]:
     return payload
 
 
+def _status_payload_no_pid() -> dict[str, object]:
+    payload = _status_payload()
+    del payload["pid"]
+    return payload
+
+
 def _patch_client(monkeypatch: pytest.MonkeyPatch, model_status: object) -> MagicMock:
     """Patch ``LLMClient`` so ``model_status_sync`` drives the running/pid probe.
 
@@ -532,6 +538,51 @@ def test_stop_does_not_lazy_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
     runner.invoke(daemon_module.daemon_app, ["stop"])
 
     assert client.model_status_sync.call_args.kwargs == {"spawn_if_absent": False}
+
+
+def test_stop_json_sigkill_escalation(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, _status_payload())
+    _patch_wait(monkeypatch, False)
+    _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["stop", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["killed"] is True
+    assert payload["running"] is False
+    assert set(payload["error"]) == {"code", "message"}
+
+
+def test_stop_timeout_without_pid_does_not_claim_sigkill(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    # Running daemon whose status payload carries no pid: SIGTERM/SIGKILL are
+    # impossible, so the message must not claim a SIGKILL was sent.
+    _patch_client(monkeypatch, _status_payload_no_pid())
+    _patch_wait(monkeypatch, False)
+    monkeypatch.setattr(daemon_module, "_socket_accepting", lambda _p: True)
+
+    result = runner.invoke(daemon_module.daemon_app, ["stop"])
+
+    assert result.exit_code == 1
+    assert "did not stop" in result.stderr
+    assert "SIGKILL" not in result.stderr
+
+
+def test_stop_timeout_without_pid_succeeds_when_socket_vacated(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    # No pid, the vacate poll missed it, but the socket no longer answers: the
+    # daemon did stop, so report success rather than a false SIGKILL failure.
+    _patch_client(monkeypatch, _status_payload_no_pid())
+    _patch_wait(monkeypatch, False)
+    monkeypatch.setattr(daemon_module, "_socket_accepting", lambda _p: False)
+
+    result = runner.invoke(daemon_module.daemon_app, ["stop"])
+
+    assert result.exit_code == 0
+    assert "daemon stopped" in result.stdout
 
 
 # --- restart ----------------------------------------------------------------

--- a/tests/llm/test_cli_daemon.py
+++ b/tests/llm/test_cli_daemon.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 import io
 import json
 import re
+import signal
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -358,3 +362,383 @@ def test_status_help_mentions_loaded_models_and_idle() -> None:
     assert "--json" in help_text
     assert "loaded models" in help_text
     assert "idle" in help_text
+
+
+# ===========================================================================
+# Lifecycle: start / stop / restart (story 5.3)
+#
+# CHIRPD-CORE ships signal-based shutdown (no wire ``shutdown`` op), so ``stop``
+# is mocked at ``os.kill`` and ``_wait_for_socket`` rather than a client
+# ``shutdown()`` method. The daemon ``pid`` rides on ``model.status``, and the
+# non-spawning probe is ``model_status_sync(spawn_if_absent=False)``.
+# ===========================================================================
+
+CHIRPD_PATH = "/usr/local/bin/chirpd"
+
+
+def _status_payload_pid(pid: int) -> dict[str, object]:
+    payload = _status_payload()
+    payload["pid"] = pid
+    return payload
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, model_status: object) -> MagicMock:
+    """Patch ``LLMClient`` so ``model_status_sync`` drives the running/pid probe.
+
+    ``model_status`` may be a payload dict (always running), an exception
+    instance (always unreachable), or a list used as ``side_effect`` to sequence
+    successive probes (e.g. absent then present across a spawn).
+    """
+    client = MagicMock()
+    if isinstance(model_status, list | Exception):
+        client.model_status_sync.side_effect = model_status
+    else:
+        client.model_status_sync.return_value = model_status
+    monkeypatch.setattr(daemon_module, "LLMClient", MagicMock(return_value=client))
+    return client
+
+
+def _patch_spawn(
+    monkeypatch: pytest.MonkeyPatch, *, which: str | None = CHIRPD_PATH
+) -> MagicMock:
+    monkeypatch.setattr(daemon_module.shutil, "which", lambda _name: which)
+    popen = MagicMock()
+    monkeypatch.setattr(daemon_module.subprocess, "Popen", popen)
+    return popen
+
+
+def _patch_wait(
+    monkeypatch: pytest.MonkeyPatch, result: bool | Callable[..., bool]
+) -> None:
+    if callable(result):
+        fn = result
+    else:
+
+        def fn(_socket_path: Any, *, present: bool, timeout: float) -> bool:
+            return result
+
+    monkeypatch.setattr(daemon_module, "_wait_for_socket", fn)
+
+
+def _patch_kill(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    kill = MagicMock()
+    monkeypatch.setattr(daemon_module.os, "kill", kill)
+    return kill
+
+
+# --- start ------------------------------------------------------------------
+
+
+def test_start_noop_when_daemon_running(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(monkeypatch, _status_payload())
+    popen = _patch_spawn(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["start"])
+
+    assert result.exit_code == 0
+    assert "already running" in result.stderr
+    popen.assert_not_called()
+
+
+def test_start_spawns_when_daemon_absent(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(monkeypatch, [LLMDaemonUnreachable("absent"), _status_payload()])
+    popen = _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, True)
+
+    result = runner.invoke(daemon_module.daemon_app, ["start"])
+
+    assert result.exit_code == 0
+    assert "daemon started (pid=12345)" in result.stdout
+    assert popen.call_args.args[0] == [CHIRPD_PATH]
+
+
+def test_start_fails_when_socket_never_accepts(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(monkeypatch, LLMDaemonUnreachable("absent"))
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, False)
+
+    result = runner.invoke(daemon_module.daemon_app, ["start"])
+
+    assert result.exit_code == 1
+    assert "failed to start within 5 seconds" in result.stderr
+
+
+def test_start_fails_when_chirpd_not_on_path(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(monkeypatch, LLMDaemonUnreachable("absent"))
+    popen = _patch_spawn(monkeypatch, which=None)
+
+    result = runner.invoke(daemon_module.daemon_app, ["start"])
+
+    assert result.exit_code == 1
+    assert "not found on PATH" in result.stderr
+    popen.assert_not_called()
+
+
+# --- stop -------------------------------------------------------------------
+
+
+def test_stop_noop_when_daemon_not_running(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(monkeypatch, LLMDaemonUnreachable("absent"))
+    kill = _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["stop"])
+
+    assert result.exit_code == 0
+    assert "not running" in result.stderr
+    kill.assert_not_called()
+
+
+def test_stop_succeeds_via_sigterm(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(monkeypatch, _status_payload())
+    _patch_wait(monkeypatch, True)
+    kill = _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["stop"])
+
+    assert result.exit_code == 0
+    assert "daemon stopped" in result.stdout
+    kill.assert_any_call(12345, signal.SIGTERM)
+
+
+def test_stop_escalates_to_sigkill_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(monkeypatch, _status_payload())
+    _patch_wait(monkeypatch, False)
+    kill = _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["stop"])
+
+    assert result.exit_code == 1
+    assert "sent SIGKILL" in result.stderr
+    kill.assert_any_call(12345, signal.SIGKILL)
+
+
+def test_stop_does_not_lazy_spawn(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _patch_client(monkeypatch, LLMDaemonUnreachable("absent"))
+
+    runner.invoke(daemon_module.daemon_app, ["stop"])
+
+    assert client.model_status_sync.call_args.kwargs == {"spawn_if_absent": False}
+
+
+# --- restart ----------------------------------------------------------------
+
+
+def test_restart_when_not_running_just_starts(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            LLMDaemonUnreachable("absent"),  # stop probe: not running
+            LLMDaemonUnreachable("absent"),  # start probe: still absent
+            _status_payload(),  # post-spawn pid
+        ],
+    )
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, True)
+
+    result = runner.invoke(daemon_module.daemon_app, ["restart"])
+
+    assert result.exit_code == 0
+    assert "starting fresh instance" in result.stderr
+
+
+def test_restart_when_running_stops_then_starts(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            _status_payload_pid(111),  # stop probe: running (old pid)
+            LLMDaemonUnreachable("absent"),  # start probe: now down
+            _status_payload_pid(222),  # post-spawn pid (new)
+        ],
+    )
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, True)
+    _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["restart"])
+
+    assert result.exit_code == 0
+    assert "daemon restarted (pid=222)" in result.stdout
+
+
+def test_restart_aborts_on_stop_failure(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(monkeypatch, _status_payload_pid(111))
+    popen = _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, False)  # socket never vacates → stop fails
+    _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["restart"])
+
+    assert result.exit_code == 1
+    assert "sent SIGKILL" in result.stderr
+    popen.assert_not_called()  # start path must not run
+
+
+def test_restart_reports_partial_failure_when_start_fails(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            _status_payload_pid(111),  # stop probe: running
+            LLMDaemonUnreachable("absent"),  # start probe: down after stop
+        ],
+    )
+    _patch_spawn(monkeypatch)
+    # stop's wait (present=False) succeeds; start's wait (present=True) times out.
+    _patch_wait(monkeypatch, lambda _p, *, present, timeout: not present)
+    _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["restart"])
+
+    assert result.exit_code == 1
+    assert "was stopped but did not restart" in result.stderr
+
+
+# --- --json output ----------------------------------------------------------
+
+
+def test_json_output_start_spawned(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, [LLMDaemonUnreachable("absent"), _status_payload()])
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, True)
+
+    result = runner.invoke(daemon_module.daemon_app, ["start", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "start"
+    assert payload["spawned"] is True
+    assert payload["running"] is True
+    assert payload["pid"] == 12345
+
+
+def test_json_output_stop_was_running(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(monkeypatch, _status_payload())
+    _patch_wait(monkeypatch, True)
+    _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["stop", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "stop"
+    assert payload["was_running"] is True
+    assert payload["killed"] is False
+    assert payload["running"] is False
+
+
+def test_json_output_restart(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            _status_payload_pid(111),
+            LLMDaemonUnreachable("absent"),
+            _status_payload_pid(222),
+        ],
+    )
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, True)
+    _patch_kill(monkeypatch)
+
+    result = runner.invoke(daemon_module.daemon_app, ["restart", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "restart"
+    assert payload["old_pid"] == 111
+    assert payload["new_pid"] == 222
+
+
+def test_json_output_failure_includes_error_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(monkeypatch, LLMDaemonUnreachable("absent"))
+    _patch_spawn(monkeypatch, which=None)
+
+    result = runner.invoke(daemon_module.daemon_app, ["start", "--json"])
+
+    assert result.exit_code != 0
+    payload = json.loads(result.stdout)
+    assert payload["running"] is False
+    assert set(payload["error"]) == {"code", "message"}
+
+
+# --- _wait_for_socket / _socket_accepting helpers ---------------------------
+
+
+def test_wait_for_socket_returns_true_on_immediate_match(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(daemon_module, "_socket_accepting", lambda _p: True)
+    assert (
+        daemon_module._wait_for_socket(tmp_path / "s.sock", present=True, timeout=1.0)
+        is True
+    )
+
+
+def test_wait_for_socket_returns_false_on_timeout(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(daemon_module, "_socket_accepting", lambda _p: False)
+    assert (
+        daemon_module._wait_for_socket(tmp_path / "s.sock", present=True, timeout=0.0)
+        is False
+    )
+
+
+def test_socket_accepting_false_for_absent_path(tmp_path: Path) -> None:
+    assert daemon_module._socket_accepting(tmp_path / "missing.sock") is False
+
+
+# --- diagnostic logging -----------------------------------------------------
+
+
+def test_log_event_emitted_for_each_command(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    log_mock = MagicMock()
+    monkeypatch.setattr(daemon_module, "log_op_event", log_mock)
+
+    _patch_client(monkeypatch, _status_payload())
+    _patch_spawn(monkeypatch)
+    runner.invoke(daemon_module.daemon_app, ["start"])
+
+    _patch_client(monkeypatch, LLMDaemonUnreachable("absent"))
+    runner.invoke(daemon_module.daemon_app, ["stop"])
+
+    _patch_client(
+        monkeypatch,
+        [
+            LLMDaemonUnreachable("absent"),
+            LLMDaemonUnreachable("absent"),
+            _status_payload(),
+        ],
+    )
+    _patch_spawn(monkeypatch)
+    _patch_wait(monkeypatch, True)
+    runner.invoke(daemon_module.daemon_app, ["restart"])
+
+    ops = [call.kwargs["op"] for call in log_mock.call_args_list]
+    assert "daemon_start" in ops
+    assert "daemon_stop" in ops
+    assert "daemon_restart" in ops

--- a/tests/llm/test_client.py
+++ b/tests/llm/test_client.py
@@ -502,7 +502,9 @@ def test_health_sync_invokes_async_health(
     temp_socket_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _stub_health(self: LLMClient) -> dict[str, Any]:
+    async def _stub_health(
+        self: LLMClient, *, spawn_if_absent: bool = True
+    ) -> dict[str, Any]:
         return {"status": "ok", "uptime_seconds": 0.0, "version": "test"}
 
     monkeypatch.setattr(LLMClient, "health", _stub_health)


### PR DESCRIPTION
## Story 5.3 — `chirp daemon start | stop | restart`

Adds manual daemon lifecycle controls to `daemon_app` (FR40–FR42), complementing lazy-spawn for the cases where you want explicit control (warm the daemon before a script, free RAM, or reload `models.toml`).

### What's here
- **`start`** — idempotent spawn; no-op if already running. Polls the socket up to 5s, confirms via a non-spawning probe.
- **`stop`** — signal-based shutdown (SIGTERM → SIGKILL escalation after 5s); idempotent; no graceful drain (alpha simplification, per PRD).
- **`restart`** — stop + start, with fresh-start and partial-failure handling.
- `--json` on all three; one `op=daemon_* … result=…` logfmt line per command (new `result` optional field wired into `chirpd/logging_setup.py`).

### Contract reconciliation (CHIRPD-CORE drift)
The story's interface assumptions were reconciled to the shipped contract: shutdown is signal-based (no wire `shutdown` op / `LLMClient.shutdown()`), `pid` rides on `model.status`, and non-spawning probes use a new backward-compatible `spawn_if_absent` kwarg on `health()`/`model_status()`. Documented in `llm/cli/daemon.py`'s docstring.

### Review
Ran a BMAD adversarial review loop (2 rounds) before opening. Round 1 surfaced 2 should-fix items in `_attempt_stop`'s SIGKILL-escalation edge — the "sent SIGKILL" message could be emitted when no SIGKILL was sent, and the JSON `running` field was inferred from `killed` rather than the true state. Both fixed (commit `b16ea18`): `_attempt_stop` now returns a truthful `running` field (re-probing the socket on the no-pid path), the message is conditional on an actual kill, and 3 tests were added for those branches. Round 2 verdict: CLEAN.

### Verification
- `uv run pytest tests/llm/test_cli_daemon.py` — 55 passed
- `uv run ruff check .` — clean
- `uv run mypy llm/cli/daemon.py llm/client.py chirpd/logging_setup.py` — clean

### Deferred
Task 7 manual smoke tests (two-terminal in-flight-during-stop) require a real Apple-Silicon daemon — left for manual QA per the project's policy on not unit-testing real-process paths.