### PR TITLE
feat(cli): chirp daemon enable | disable (story 5.4)

### DIFF
--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.4-daemon-enable-disable.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.4-daemon-enable-disable.md
@@ -1,6 +1,6 @@
 # Story 5.4 — `chirp daemon enable | disable`: LaunchAgent install/uninstall via `chirpd/launchd.py`
 
-- **Status:** review
+- **Status:** done
 - **Epic:** [EPIC-DAEMON-LIFECYCLE](../epic.md)
 - **Depends on:** 5.3 (Typer subapp file and command-helper patterns); EPIC-CHIRPD-CORE (`chirpd` console script registered in `pyproject.toml [project.scripts]`)
 - **Blocks:** 5.6 (Typer registration); EPIC-INIT-AND-MIGRATION's LaunchAgent-opt-in story (which imports `install_launch_agent()` from this story's `chirpd/launchd.py`)
@@ -318,3 +318,5 @@ This story also delivers `chirpd/launchd.py` — a small module with two **reusa
 ### Change Log
 
 - 2026-06-04 — Story 5.4 implemented: `chirpd/launchd.py` LaunchAgent module + `chirp daemon enable | disable` CLI. 1329 tests pass; `ruff check .` clean; `mypy chirpd/launchd.py llm/cli/daemon.py chirpd/logging_setup.py` clean; `chirpd/launchd.py` at 99% unit coverage. AC-15 manual macOS checklist deferred to PR sign-off.
+- 2026-06-04 — Adversarial review loop (2 rounds → CLEAN): ground-truth `chirpd_path` read back from the plist (AC-8), uninstall verification-failure error names the already-removed plist, atomic-write `.tmp` cleanup, plus JSON-failure/edge-case tests. Coverage to 100%.
+- 2026-06-04 — Opened PR #80; CI green. Addressed Copilot review (commit `cf77b28`): `_run_launchctl` wraps `FileNotFoundError`/`TimeoutExpired` into the typed error surface; `is_launch_agent_installed` honors its never-raises contract and requires non-empty `launchctl` stdout; `install_launch_agent` creates the launchd log dir (fresh-machine start fix); `_safe_is_installed` broadened. 1343 tests pass; all review threads resolved. Status → done (AC-15 manual macOS checklist still pending human sign-off before merge).

--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.4-daemon-enable-disable.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.4-daemon-enable-disable.md
@@ -1,6 +1,6 @@
 # Story 5.4 — `chirp daemon enable | disable`: LaunchAgent install/uninstall via `chirpd/launchd.py`
 
-- **Status:** Draft
+- **Status:** review
 - **Epic:** [EPIC-DAEMON-LIFECYCLE](../epic.md)
 - **Depends on:** 5.3 (Typer subapp file and command-helper patterns); EPIC-CHIRPD-CORE (`chirpd` console script registered in `pyproject.toml [project.scripts]`)
 - **Blocks:** 5.6 (Typer registration); EPIC-INIT-AND-MIGRATION's LaunchAgent-opt-in story (which imports `install_launch_agent()` from this story's `chirpd/launchd.py`)
@@ -276,3 +276,45 @@ This story also delivers `chirpd/launchd.py` — a small module with two **reusa
   - `is_launch_agent_installed()` → use to skip the prompt if already set up.
   - `install_launch_agent()` → call after the user opts in; surface the same exception types (`LaunchAgentError`, `LaunchctlFailed`) to the init flow's error UX. The init flow may want to handle `LaunchAgentAlreadyInstalled` differently (silently consider it "already done" and continue, rather than treating it as an error).
 - **For story 5.2 (already shipped):** an optional follow-up — `chirp daemon status` may want to report whether a LaunchAgent is installed, e.g. an additional table row `launchagent  installed (auto-starts at login)`. This is a small enhancement, not a blocker; consider as a polish task if time allows.
+
+## Implementation task checklist
+
+- [x] 1. Create `chirpd/launchd.py` — module surface per AC-1 (constants, exception hierarchy, three public functions + `_build_plist`).
+- [x] 2. Implement `_build_plist` — pure function; PATH always captured, HF_HOME propagated only when set.
+- [x] 3. Implement `install_launch_agent` — atomic `.tmp` + `os.replace` write; `launchctl load -w`; verification probe; `force` unloads the old agent first.
+- [x] 4. Implement `uninstall_launch_agent` — `launchctl unload -w` then `unlink`; plist stays on disk if unload fails.
+- [x] 5. Implement `is_launch_agent_installed` — plist-on-disk AND `launchctl list` exit 0; no `launchctl` call when plist absent.
+- [x] 6. Add `chirpd_path` to `LOGFMT_OPTIONAL_FIELDS` **and** as an explicit forwarded param in `log_op_event`.
+- [x] 7. Add `enable` / `disable` CLI commands to `llm/cli/daemon.py` with exit codes, message rendering, and `--json` output.
+- [x] 8. Tests — `tests/chirpd/test_launchd.py` (17) + `tests/llm/test_cli_daemon.py` (15 added) + 1 in `tests/chirpd/test_logging_setup.py`.
+- [x] 9. Document the `KeepAlive` / version-mismatch interaction in the module docstring.
+- [ ] 10. Manual testing per AC-15 — **deferred to PR sign-off on a real Mac** (reboot + crash + version-mismatch paths are not unit-testable). Tracked as PR-description TODOs.
+
+## Dev Agent Record
+
+### Completion Notes
+
+- New module `chirpd/launchd.py` (79 statements, 99% unit coverage) delivers the full AC-1 surface. `_build_plist` produces the exact AC-2 payload (`KeepAlive = {SuccessfulExit: False}`, captured `PATH`, conditional `HF_HOME`, `ProcessType: Background`). `install_launch_agent` / `uninstall_launch_agent` / `is_launch_agent_installed` follow the AC-3/4/5 flows; `launchctl` is invoked through a single `_run_launchctl` helper (`capture_output`, `text`, 10 s timeout). The module imports cleanly off-Darwin; the mutating verbs raise `LaunchAgentError("LaunchAgent install is macOS-only")` and `is_launch_agent_installed()` returns `False`.
+- The module docstring (AC-9) documents the counterintuitive `KeepAlive {SuccessfulExit: false}` ↔ version-mismatch-`exit(0)` interaction, the PATH-propagation rationale, the stale-path re-`enable` refresh, and the reusable-from-`chirp init` contract.
+- `enable` / `disable` added to `llm/cli/daemon.py` as thin wrappers over `chirpd.launchd`, reusing the 5.2/5.3 helpers (`_should_use_json`, `_ensure_logging`, `_emit_json`, `_log_lifecycle`). Exit codes per AC-11: `0` success (incl. idempotent `disable` no-op), `1` for `LaunchAgentError`, `2` Typer usage. `--json` shapes match AC-8; `launchctl` stderr is surfaced verbatim via `_format_launchctl_error`. Live `--help` matches AC-12.
+- AC-10 diagnostic logging: `_log_lifecycle` extended with a `chirpd_path` kwarg. Per `[[project_daemon_lifecycle_contract_drift]]`, adding a field to `LOGFMT_OPTIONAL_FIELDS` alone silently drops the value — so `log_op_event` also gained an explicit `chirpd_path` param wired into the `optional` dict (same fix shape 5.3 used for `result`). Log results: `enable` → `installed | already_installed | launchctl_failed | missing_binary | error`; `disable` → `removed | not_installed | launchctl_failed | error`.
+
+### Reconciliations vs. story assumptions
+
+- **No `sprint-status.yaml`** exists in this repo, so story status is tracked in this file only (Draft → in-progress → review).
+- **`enable` JSON failure `installed` field** (AC-8 "current_state"): computed via a best-effort `is_launch_agent_installed()` wrapped in `_safe_is_installed()` (swallows `OSError`), only in the `--json` branch — keeps non-JSON failure paths from shelling out to `launchctl`.
+- **`missing_binary` vs generic `LaunchAgentError`**: the AC-1 surface has no dedicated missing-binary exception, so the CLI distinguishes the log `result` by message substring (`"not found on PATH"`); all other generic `LaunchAgentError`s (e.g. non-Darwin) log `result="error"`.
+- **AC-15 manual checklist** is intentionally not executed here: it would install a real LaunchAgent and require a reboot/crash on the maintainer's Mac. Deferred to PR sign-off, consistent with `[[feedback_unit_test_mocking]]` (the reboot/login path is the one genuinely un-unit-testable seam).
+
+### File List
+
+- `chirpd/launchd.py` — **new**. LaunchAgent install/uninstall/introspection + plist builder + typed error hierarchy.
+- `chirpd/logging_setup.py` — modified. Added `chirpd_path` to `LOGFMT_OPTIONAL_FIELDS` and as an explicit `log_op_event` param.
+- `llm/cli/daemon.py` — modified. Added `enable` / `disable` commands, `chirpd.launchd` imports, `_log_lifecycle` `chirpd_path` kwarg, and CLI render/JSON helpers; refreshed module docstring.
+- `tests/chirpd/test_launchd.py` — **new**. 17 unit tests (AC-13).
+- `tests/llm/test_cli_daemon.py` — modified. 15 enable/disable CLI tests (AC-14) + help-discipline.
+- `tests/chirpd/test_logging_setup.py` — modified. 1 test for the `chirpd_path` field passthrough.
+
+### Change Log
+
+- 2026-06-04 — Story 5.4 implemented: `chirpd/launchd.py` LaunchAgent module + `chirp daemon enable | disable` CLI. 1329 tests pass; `ruff check .` clean; `mypy chirpd/launchd.py llm/cli/daemon.py chirpd/logging_setup.py` clean; `chirpd/launchd.py` at 99% unit coverage. AC-15 manual macOS checklist deferred to PR sign-off.

--- a/chirpd/launchd.py
+++ b/chirpd/launchd.py
@@ -1,0 +1,252 @@
+"""LaunchAgent install / uninstall for the ``chirpd`` daemon (macOS only).
+
+This module owns the ``com.chirp.chirpd`` LaunchAgent: writing the plist into
+``~/Library/LaunchAgents/``, loading it via ``launchctl``, and reversing both on
+uninstall. The two public verbs — :func:`install_launch_agent` and
+:func:`uninstall_launch_agent` — plus the introspection helper
+:func:`is_launch_agent_installed` are **reusable**: ``chirp daemon enable`` /
+``disable`` are thin CLI wrappers (in ``llm/cli/daemon.py``), and
+EPIC-INIT-AND-MIGRATION's ``chirp init`` flow imports these functions directly
+rather than shelling out to the CLI.
+
+**The plist's ``KeepAlive`` policy is the single most counterintuitive part of
+this design.** The plist uses ``KeepAlive = {SuccessfulExit: False}``, which tells
+launchd to restart the daemon when it exits **non-zero** (a crash) but **not**
+when it exits **zero** (an intentional exit). The daemon exits ``0`` on a
+version mismatch (it detects a CLI running newer code and bows out cleanly), so
+launchd does **not** respawn it. That is correct: the post-mismatch daemon is
+running the wrong code, and the user's next ``chirp`` invocation lazy-spawns the
+new version from ``PATH``. A bare ``KeepAlive = True`` would respawn the stale
+daemon in a loop and defeat the lazy-upgrade design — hence the dict form.
+
+**PATH propagation.** ``EnvironmentVariables.PATH`` is captured from
+``os.environ["PATH"]`` at install time. launchd otherwise hands user agents a
+minimal default ``PATH`` (``/usr/bin:/bin:/usr/sbin:/sbin``) that lacks Homebrew,
+pyenv shims, and ``uv``'s tool bin — which can break ``mlx-lm``'s subprocess
+invocations. ``HF_HOME`` is propagated only when the user has it set (FR38).
+
+**Stale-path refresh.** The plist bakes in the absolute path to ``chirpd``
+resolved via ``shutil.which`` at install time. If the user later relocates their
+Python environment (deletes the venv, reinstalls via ``uv``), the plist points at
+a dead path; re-running ``chirp daemon enable`` (or :func:`install_launch_agent`
+with ``force=True``) refreshes it.
+
+The module imports cleanly on non-Darwin — there are no top-level ``launchctl``
+calls or platform-only imports — but the mutating functions raise
+:class:`LaunchAgentError` when invoked off macOS.
+"""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Final
+
+LAUNCH_AGENT_LABEL: Final[str] = "com.chirp.chirpd"
+LAUNCH_AGENT_PLIST_PATH: Final[Path] = (
+    Path.home() / "Library" / "LaunchAgents" / f"{LAUNCH_AGENT_LABEL}.plist"
+)
+LAUNCH_AGENT_LOG_PATH: Final[Path] = (
+    Path.home() / "Library" / "Logs" / "chirp" / "chirpd.log"
+)
+
+_LAUNCHCTL_TIMEOUT_S: Final[float] = 10.0
+_MACOS_ONLY_MESSAGE: Final[str] = "LaunchAgent install is macOS-only"
+
+
+class LaunchAgentError(Exception):
+    """Base class for every LaunchAgent failure surfaced to the CLI / init flow."""
+
+
+class LaunchAgentAlreadyInstalled(LaunchAgentError):
+    """A plist is already present and ``install_launch_agent`` was called without ``force``."""
+
+
+class LaunchAgentNotInstalled(LaunchAgentError):
+    """``uninstall_launch_agent`` was called but no plist is present."""
+
+
+class LaunchctlFailed(LaunchAgentError):
+    """A ``launchctl`` invocation returned non-zero (or an unexpected result).
+
+    Carries the exact command, return code, and ``stderr`` so the CLI can surface
+    launchctl's own diagnostic verbatim instead of a lossy paraphrase.
+    """
+
+    def __init__(self, command: list[str], returncode: int, stderr: str) -> None:
+        self.command = command
+        self.returncode = returncode
+        self.stderr = stderr
+        detail = stderr.strip()
+        suffix = f": {detail}" if detail else ""
+        super().__init__(f"{' '.join(command)} failed (exit {returncode}){suffix}")
+
+
+def _require_darwin() -> None:
+    if sys.platform != "darwin":
+        raise LaunchAgentError(_MACOS_ONLY_MESSAGE)
+
+
+def _run_launchctl(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run ``launchctl <args>`` capturing text output with a hard timeout."""
+    command = ["launchctl", *args]
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=_LAUNCHCTL_TIMEOUT_S,
+    )
+
+
+def _build_plist(chirpd_path: Path) -> dict[str, Any]:
+    """Build the plist payload for :func:`plistlib.dump`.
+
+    Private but tested directly. The two conditionals are the only branching:
+    ``PATH`` is always captured from the current environment, ``HF_HOME`` only
+    when set (omitted entirely otherwise).
+    """
+    environment: dict[str, str] = {"PATH": os.environ.get("PATH", "")}
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        environment["HF_HOME"] = hf_home
+
+    return {
+        "Label": LAUNCH_AGENT_LABEL,
+        "ProgramArguments": [str(chirpd_path)],
+        "RunAtLoad": True,
+        "KeepAlive": {"SuccessfulExit": False},
+        "StandardOutPath": str(LAUNCH_AGENT_LOG_PATH),
+        "StandardErrorPath": str(LAUNCH_AGENT_LOG_PATH),
+        "EnvironmentVariables": environment,
+        "ProcessType": "Background",
+    }
+
+
+def _write_plist_atomic(payload: dict[str, Any], path: Path) -> None:
+    """Write ``payload`` as an XML plist to ``path`` via a ``.tmp`` + ``os.replace``."""
+    tmp_path = path.with_name(path.name + ".tmp")
+    try:
+        with tmp_path.open("wb") as handle:
+            plistlib.dump(payload, handle, fmt=plistlib.FMT_XML)
+        os.replace(tmp_path, path)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def install_launch_agent(*, force: bool = False) -> Path:
+    """Resolve ``chirpd``, write the plist, and ``launchctl load -w`` it.
+
+    Returns the plist path on success. Raises :class:`LaunchAgentAlreadyInstalled`
+    if a plist is already present and ``force`` is False;
+    :class:`LaunchctlFailed` if ``launchctl`` reports non-zero (or the post-load
+    verification probe comes back empty); :class:`LaunchAgentError` off macOS or
+    when ``chirpd`` is not on ``PATH``.
+    """
+    _require_darwin()
+
+    plist_existed = LAUNCH_AGENT_PLIST_PATH.exists()
+    if plist_existed and not force:
+        raise LaunchAgentAlreadyInstalled(str(LAUNCH_AGENT_PLIST_PATH))
+
+    chirpd_path = shutil.which("chirpd")
+    if chirpd_path is None:
+        raise LaunchAgentError(
+            "chirpd binary not found on PATH — is chirp installed correctly?"
+        )
+
+    payload = _build_plist(Path(chirpd_path))
+    LAUNCH_AGENT_PLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _write_plist_atomic(payload, LAUNCH_AGENT_PLIST_PATH)
+
+    if force and plist_existed:
+        # Best-effort: the previously-installed agent may not actually be loaded,
+        # so a non-zero exit here is expected and ignored. `launchctl unload`
+        # identifies the agent by the Label inside the plist, so the
+        # freshly-written plist (same Label) unloads the running old agent.
+        _run_launchctl(["unload", str(LAUNCH_AGENT_PLIST_PATH)])
+
+    # ``-w`` marks the agent enabled so it persists across reboots; without it the
+    # agent loads now but a reboot silently drops it.
+    load = _run_launchctl(["load", "-w", str(LAUNCH_AGENT_PLIST_PATH)])
+    if load.returncode != 0:
+        raise LaunchctlFailed(load.args, load.returncode, load.stderr)
+
+    listing = _run_launchctl(["list", LAUNCH_AGENT_LABEL])
+    if listing.returncode != 0 or not listing.stdout.strip():
+        raise LaunchctlFailed(listing.args, listing.returncode, listing.stderr)
+
+    return LAUNCH_AGENT_PLIST_PATH
+
+
+def uninstall_launch_agent() -> None:
+    """``launchctl unload -w`` the agent, then delete the plist file.
+
+    Raises :class:`LaunchAgentNotInstalled` if no plist is present;
+    :class:`LaunchctlFailed` if ``unload`` reports non-zero — in which case the
+    plist is **left on disk** so the user can inspect and retry rather than land
+    in a half-removed state.
+    """
+    _require_darwin()
+
+    if not LAUNCH_AGENT_PLIST_PATH.exists():
+        raise LaunchAgentNotInstalled(str(LAUNCH_AGENT_PLIST_PATH))
+
+    unload = _run_launchctl(["unload", "-w", str(LAUNCH_AGENT_PLIST_PATH)])
+    if unload.returncode != 0:
+        raise LaunchctlFailed(unload.args, unload.returncode, unload.stderr)
+
+    LAUNCH_AGENT_PLIST_PATH.unlink()
+
+    # The agent should now be absent; a zero exit means it is somehow still
+    # loaded (macOS edge case) — surface it rather than silently report success.
+    # The plist is already removed at this point (per the AC-4 flow), so say so:
+    # `is_launch_agent_installed()` will now report False even though launchctl
+    # still lists the agent, and the user should not expect a retry to find it.
+    listing = _run_launchctl(["list", LAUNCH_AGENT_LABEL])
+    if listing.returncode == 0:
+        raise LaunchctlFailed(
+            listing.args,
+            listing.returncode,
+            "launchctl still lists the agent after unload; the plist at "
+            f"{LAUNCH_AGENT_PLIST_PATH} has already been removed — unload it "
+            f"manually with: launchctl remove {LAUNCH_AGENT_LABEL}",
+        )
+
+
+def installed_chirpd_path(plist_path: Path | None = None) -> str | None:
+    """Return the ``chirpd`` path recorded in the plist's ``ProgramArguments``.
+
+    Reads ground truth straight from the plist :func:`install_launch_agent` wrote,
+    so callers report the path **actually baked in** (AC-8 — the wrong-Python
+    diagnostic) rather than a re-resolution that could drift from it. Returns
+    ``None`` if the plist is absent, unreadable, or malformed.
+    """
+    target = plist_path if plist_path is not None else LAUNCH_AGENT_PLIST_PATH
+    try:
+        with target.open("rb") as handle:
+            payload = plistlib.load(handle)
+    except (OSError, plistlib.InvalidFileException):
+        return None
+    args = payload.get("ProgramArguments")
+    if isinstance(args, list) and args:
+        return str(args[0])
+    return None
+
+
+def is_launch_agent_installed() -> bool:
+    """True iff the plist file exists **and** ``launchctl list`` reports the label.
+
+    Returns False (never raises) off macOS or when the plist is absent — the
+    plist check short-circuits before any ``launchctl`` call.
+    """
+    if sys.platform != "darwin":
+        return False
+    if not LAUNCH_AGENT_PLIST_PATH.exists():
+        return False
+    listing = _run_launchctl(["list", LAUNCH_AGENT_LABEL])
+    return listing.returncode == 0

--- a/chirpd/launchd.py
+++ b/chirpd/launchd.py
@@ -92,14 +92,29 @@ def _require_darwin() -> None:
 
 
 def _run_launchctl(args: list[str]) -> subprocess.CompletedProcess[str]:
-    """Run ``launchctl <args>`` capturing text output with a hard timeout."""
+    """Run ``launchctl <args>`` capturing text output with a hard timeout.
+
+    Normalizes the two ways the call itself can fail into the module's typed
+    surface so they never escape as raw ``subprocess`` exceptions: a missing
+    ``launchctl`` binary raises :class:`LaunchAgentError`, and a hung call that
+    blows the timeout raises :class:`LaunchctlFailed` (returncode ``-1``).
+    """
     command = ["launchctl", *args]
-    return subprocess.run(
-        command,
-        capture_output=True,
-        text=True,
-        timeout=_LAUNCHCTL_TIMEOUT_S,
-    )
+    try:
+        return subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=_LAUNCHCTL_TIMEOUT_S,
+        )
+    except FileNotFoundError as err:
+        raise LaunchAgentError(
+            "launchctl not found — LaunchAgent management requires macOS"
+        ) from err
+    except subprocess.TimeoutExpired as err:
+        raise LaunchctlFailed(
+            command, -1, f"launchctl timed out after {_LAUNCHCTL_TIMEOUT_S:g}s"
+        ) from err
 
 
 def _build_plist(chirpd_path: Path) -> dict[str, Any]:
@@ -161,6 +176,11 @@ def install_launch_agent(*, force: bool = False) -> Path:
 
     payload = _build_plist(Path(chirpd_path))
     LAUNCH_AGENT_PLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    # launchd opens StandardOut/ErrorPath itself and does NOT create missing
+    # parent dirs — on a fresh machine the daemon would fail to start unless the
+    # log dir already exists (the Python logging handler from story 5.1 only runs
+    # after the process is up, too late for launchd's own redirect).
+    LAUNCH_AGENT_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
     _write_plist_atomic(payload, LAUNCH_AGENT_PLIST_PATH)
 
     if force and plist_existed:
@@ -248,5 +268,12 @@ def is_launch_agent_installed() -> bool:
         return False
     if not LAUNCH_AGENT_PLIST_PATH.exists():
         return False
-    listing = _run_launchctl(["list", LAUNCH_AGENT_LABEL])
-    return listing.returncode == 0
+    try:
+        listing = _run_launchctl(["list", LAUNCH_AGENT_LABEL])
+    except LaunchAgentError:
+        # Honor the never-raises contract: a missing binary or a launchctl
+        # timeout means we cannot confirm the agent is loaded → not installed.
+        return False
+    # exit 0 with empty stdout is the same unexpected state install rejects, so
+    # require launchctl to actually echo the agent's plist back.
+    return listing.returncode == 0 and bool(listing.stdout.strip())

--- a/chirpd/logging_setup.py
+++ b/chirpd/logging_setup.py
@@ -48,7 +48,17 @@ DEFAULT_LOG_DIR_FALLBACK: Final[Path] = Path.home() / _FALLBACK_LOG_SUBPATH
 
 LOGFMT_REQUIRED_FIELDS: Final[tuple[str, ...]] = ("ts", "level", "component", "msg")
 LOGFMT_OPTIONAL_FIELDS: Final[frozenset[str]] = frozenset(
-    {"req_id", "op", "model", "duration_ms", "tokens", "err_code", "err_type", "result"}
+    {
+        "req_id",
+        "op",
+        "model",
+        "duration_ms",
+        "tokens",
+        "err_code",
+        "err_type",
+        "result",
+        "chirpd_path",
+    }
 )
 
 FORBIDDEN_EXTRA_KEY_PATTERN: Final[re.Pattern[str]] = re.compile(
@@ -244,6 +254,7 @@ def log_op_event(
     err_code: str | None = None,
     err_type: str | None = None,
     result: str | None = None,
+    chirpd_path: str | None = None,
     **extra: object,
 ) -> None:
     """Emit an op-level log line — the only sanctioned op emitter in ``chirpd/``.
@@ -271,6 +282,7 @@ def log_op_event(
         "err_code": err_code,
         "err_type": err_type,
         "result": result,
+        "chirpd_path": chirpd_path,
     }
     fields.update({key: value for key, value in optional.items() if value is not None})
     logger.log(level, msg, extra=fields)

--- a/llm/cli/daemon.py
+++ b/llm/cli/daemon.py
@@ -16,6 +16,11 @@ command that needs the daemon performs).
 spawns ``chirpd`` via :func:`subprocess.Popen` and polls the socket; ``stop`` and
 ``restart`` shut the daemon down.
 
+``enable`` / ``disable`` (5.4) install and remove the ``com.chirp.chirpd``
+LaunchAgent so the daemon auto-starts at login. These commands are thin wrappers:
+the real work — plist generation, ``launchctl load``/``unload``, the typed error
+surface — lives in :mod:`chirpd.launchd`, which ``chirp init`` also imports.
+
 **Shutdown mechanism (story 5.3 task 1).** CHIRPD-CORE ships a *signal-based*
 shutdown, not a wire ``shutdown`` op: ``chirpd/__main__.py`` installs ``SIGTERM`` /
 ``SIGINT`` handlers that cancel the asyncio serve task and exit cleanly (option
@@ -47,6 +52,17 @@ from rich import box
 from rich.console import Console
 from rich.table import Table
 
+from chirpd.launchd import (
+    LAUNCH_AGENT_PLIST_PATH,
+    LaunchAgentAlreadyInstalled,
+    LaunchAgentError,
+    LaunchAgentNotInstalled,
+    LaunchctlFailed,
+    install_launch_agent,
+    installed_chirpd_path,
+    is_launch_agent_installed,
+    uninstall_launch_agent,
+)
 from chirpd.logging_setup import configure_logging, log_op_event
 from config.settings import CHIRP_DAEMON_SOCKET_ENV
 from llm.cli._console import console, stdout_console
@@ -757,7 +773,9 @@ def _emit_json(payload: dict[str, Any]) -> None:
     sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
 
 
-def _log_lifecycle(op: str, start_ns: int, *, result: str) -> None:
+def _log_lifecycle(
+    op: str, start_ns: int, *, result: str, chirpd_path: str | None = None
+) -> None:
     duration_ms = max(int((time.perf_counter_ns() - start_ns) / 1_000_000), 0)
     log_op_event(
         _logger,
@@ -767,4 +785,171 @@ def _log_lifecycle(op: str, start_ns: int, *, result: str) -> None:
         op=op,
         duration_ms=duration_ms,
         result=result,
+        chirpd_path=chirpd_path,
     )
+
+
+# --- LaunchAgent: enable / disable (story 5.4) ------------------------------
+
+
+@daemon_app.command("enable")
+def enable(
+    force: bool = typer.Option(
+        False, "--force", help="Reinstall even if a LaunchAgent is already present."
+    ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON to stdout."
+    ),
+) -> None:
+    """Install a LaunchAgent so chirpd starts at login and restarts on crash."""
+    use_json = _should_use_json(json_output)
+    _ensure_logging()
+    start_ns = time.perf_counter_ns()
+
+    try:
+        plist_path = install_launch_agent(force=force)
+    except LaunchAgentAlreadyInstalled as err:
+        _log_lifecycle(
+            "daemon_enable",
+            start_ns,
+            result="already_installed",
+            chirpd_path=shutil.which("chirpd"),
+        )
+        message = f"LaunchAgent already installed at {err}. Pass --force to reinstall."
+        _emit_enable_failure(err, message, use_json)
+        raise typer.Exit(code=1) from err
+    except LaunchctlFailed as err:
+        _log_lifecycle("daemon_enable", start_ns, result="launchctl_failed")
+        _emit_enable_failure(err, _format_launchctl_error(err), use_json)
+        raise typer.Exit(code=1) from err
+    except LaunchAgentError as err:
+        result = "missing_binary" if "not found on PATH" in str(err) else "error"
+        _log_lifecycle("daemon_enable", start_ns, result=result)
+        _emit_enable_failure(err, str(err), use_json)
+        raise typer.Exit(code=1) from err
+
+    # Report the path actually baked into the plist (AC-8), not a re-resolution.
+    chirpd_path = installed_chirpd_path(plist_path) or shutil.which("chirpd")
+    _log_lifecycle(
+        "daemon_enable", start_ns, result="installed", chirpd_path=chirpd_path
+    )
+    if use_json:
+        _emit_json(
+            {
+                "action": "enable",
+                "installed": True,
+                "plist_path": str(plist_path),
+                "chirpd_path": chirpd_path,
+            }
+        )
+    else:
+        stdout_console.print(
+            f"LaunchAgent installed at {plist_path}\nDaemon will auto-start at login.",
+            markup=False,
+            highlight=False,
+            soft_wrap=True,
+        )
+
+
+@daemon_app.command("disable")
+def disable(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit machine-readable JSON to stdout."
+    ),
+) -> None:
+    """Remove the LaunchAgent. Daemon will no longer auto-start at login."""
+    use_json = _should_use_json(json_output)
+    _ensure_logging()
+    start_ns = time.perf_counter_ns()
+
+    try:
+        uninstall_launch_agent()
+    except LaunchAgentNotInstalled:
+        # Idempotent: disabling a clean machine is a no-op, not an error (exit 0).
+        _log_lifecycle("daemon_disable", start_ns, result="not_installed")
+        if use_json:
+            _emit_json(
+                {"action": "disable", "installed": False, "was_installed": False}
+            )
+        else:
+            console.print(
+                "LaunchAgent is not installed; nothing to do.",
+                markup=False,
+                soft_wrap=True,
+            )
+        return
+    except LaunchctlFailed as err:
+        _log_lifecycle("daemon_disable", start_ns, result="launchctl_failed")
+        if use_json:
+            _emit_json(_disable_error_payload(err))
+        else:
+            console.print(
+                _format_launchctl_error(err), style="red", markup=False, soft_wrap=True
+            )
+        raise typer.Exit(code=1) from err
+    except LaunchAgentError as err:
+        _log_lifecycle("daemon_disable", start_ns, result="error")
+        if use_json:
+            _emit_json(_disable_error_payload(err))
+        else:
+            console.print(str(err), style="red", markup=False, soft_wrap=True)
+        raise typer.Exit(code=1) from err
+
+    _log_lifecycle("daemon_disable", start_ns, result="removed")
+    if use_json:
+        _emit_json({"action": "disable", "installed": False, "was_installed": True})
+    else:
+        stdout_console.print(
+            "LaunchAgent removed.\nDaemon will no longer auto-start at login.",
+            markup=False,
+            highlight=False,
+            soft_wrap=True,
+        )
+
+
+def _emit_enable_failure(err: LaunchAgentError, message: str, use_json: bool) -> None:
+    """Render an ``enable`` failure: JSON error object or a red stderr message."""
+    if use_json:
+        _emit_json(
+            {
+                "action": "enable",
+                "installed": _safe_is_installed(),
+                "error": _error_object(err),
+            }
+        )
+    else:
+        console.print(message, style="red", markup=False, soft_wrap=True)
+
+
+def _disable_error_payload(err: LaunchAgentError) -> dict[str, Any]:
+    return {
+        "action": "disable",
+        "installed": _safe_is_installed(),
+        "error": _error_object(err),
+    }
+
+
+def _error_object(err: LaunchAgentError) -> dict[str, Any]:
+    return {
+        "code": type(err).__name__,
+        "message": str(err),
+        "launchctl_stderr": getattr(err, "stderr", None),
+    }
+
+
+def _format_launchctl_error(err: LaunchctlFailed) -> str:
+    """Multi-line CLI rendering that preserves launchctl's own stderr verbatim."""
+    invocation = " ".join(err.command[:2]) if len(err.command) > 1 else err.command[0]
+    lines = [f"{invocation} failed (exit {err.returncode}):"]
+    stderr = (err.stderr or "").strip()
+    lines.extend(f"  {line}" for line in stderr.splitlines())
+    lines.append(f"plist at: {LAUNCH_AGENT_PLIST_PATH}")
+    return "\n".join(lines)
+
+
+def _safe_is_installed() -> bool:
+    """Best-effort current install state for JSON error payloads."""
+    try:
+        return is_launch_agent_installed()
+    except OSError:
+        return False

--- a/llm/cli/daemon.py
+++ b/llm/cli/daemon.py
@@ -951,5 +951,5 @@ def _safe_is_installed() -> bool:
     """Best-effort current install state for JSON error payloads."""
     try:
         return is_launch_agent_installed()
-    except OSError:
+    except (OSError, LaunchAgentError):
         return False

--- a/tests/chirpd/test_launchd.py
+++ b/tests/chirpd/test_launchd.py
@@ -222,6 +222,45 @@ def test_write_plist_atomic_cleans_up_tmp_on_failure(
     assert not target.exists()
 
 
+def test_install_creates_log_dir_for_launchd_redirect(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path, tmp_path: Path
+) -> None:
+    # launchd opens StandardOut/ErrorPath itself and won't create parents, so a
+    # fresh machine needs the log dir created at install time.
+    log_path = tmp_path / "Logs" / "chirp" / "chirpd.log"
+    monkeypatch.setattr(launchd, "LAUNCH_AGENT_LOG_PATH", log_path)
+    monkeypatch.setattr(launchd.shutil, "which", lambda _name: CHIRPD_PATH)
+    _patch_launchctl(monkeypatch, _success_handler)
+
+    launchd.install_launch_agent()
+
+    assert log_path.parent.is_dir()
+
+
+def test_run_launchctl_wraps_timeout_as_launchctl_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise subprocess.TimeoutExpired(cmd="launchctl", timeout=10.0)
+
+    monkeypatch.setattr(launchd.subprocess, "run", boom)
+
+    with pytest.raises(launchd.LaunchctlFailed, match="timed out"):
+        launchd._run_launchctl(["list", "com.chirp.chirpd"])
+
+
+def test_run_launchctl_wraps_missing_binary_as_launch_agent_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError("launchctl")
+
+    monkeypatch.setattr(launchd.subprocess, "run", boom)
+
+    with pytest.raises(launchd.LaunchAgentError, match="launchctl not found"):
+        launchd._run_launchctl(["list", "com.chirp.chirpd"])
+
+
 # --- uninstall_launch_agent -------------------------------------------------
 
 
@@ -290,9 +329,40 @@ def test_is_launch_agent_installed_true_when_both_present(
 ) -> None:
     plist_path.parent.mkdir(parents=True)
     plist_path.write_text("present")
-    _patch_launchctl(monkeypatch, lambda command: _completed(command, returncode=0))
+    _patch_launchctl(
+        monkeypatch,
+        lambda command: _completed(command, returncode=0, stdout="{ ... };\n"),
+    )
 
     assert launchd.is_launch_agent_installed() is True
+
+
+def test_is_launch_agent_installed_false_when_list_exit_zero_but_empty(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    # exit 0 with empty stdout is an unexpected state — treat as not installed.
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("present")
+    _patch_launchctl(
+        monkeypatch, lambda command: _completed(command, returncode=0, stdout="")
+    )
+
+    assert launchd.is_launch_agent_installed() is False
+
+
+def test_is_launch_agent_installed_false_when_launchctl_times_out(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    # Honors the never-raises contract even when the probe times out.
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("present")
+
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise subprocess.TimeoutExpired(cmd="launchctl", timeout=10.0)
+
+    monkeypatch.setattr(launchd.subprocess, "run", boom)
+
+    assert launchd.is_launch_agent_installed() is False
 
 
 def test_is_launch_agent_installed_false_when_plist_missing(

--- a/tests/chirpd/test_launchd.py
+++ b/tests/chirpd/test_launchd.py
@@ -1,0 +1,380 @@
+"""Tests for ``chirpd/launchd.py`` (story 5.4 — LaunchAgent install/uninstall).
+
+The ``launchctl`` seam is subprocess-driven (not permission/device-driven), so it
+mocks cleanly: :func:`subprocess.run` is patched to return canned
+``CompletedProcess`` results and the module-level ``LAUNCH_AGENT_PLIST_PATH`` is
+redirected into ``tmp_path``. No test touches the real ``~/Library/LaunchAgents``
+or shells out to ``launchctl``. ``sys.platform`` is forced to ``"darwin"`` so the
+suite runs identically on CI Linux.
+"""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from chirpd import launchd
+
+CHIRPD_PATH = "/usr/local/bin/chirpd"
+
+
+@pytest.fixture(autouse=True)
+def _force_darwin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the platform-gated functions as if on macOS, regardless of host OS."""
+    monkeypatch.setattr(launchd.sys, "platform", "darwin")
+
+
+@pytest.fixture
+def plist_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Redirect the module plist path into a temp dir (parent intentionally absent)."""
+    target = tmp_path / "LaunchAgents" / "com.chirp.chirpd.plist"
+    monkeypatch.setattr(launchd, "LAUNCH_AGENT_PLIST_PATH", target)
+    return target
+
+
+def _completed(
+    args: list[str], returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args, returncode, stdout=stdout, stderr=stderr)
+
+
+def _patch_launchctl(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[list[str]], subprocess.CompletedProcess[str]],
+) -> list[list[str]]:
+    """Patch ``subprocess.run``; ``handler(args) -> CompletedProcess``.
+
+    Returns a list that accumulates the ``launchctl`` sub-args of every call, so
+    tests can assert ordering (e.g. ``unload`` before ``load`` under ``--force``).
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(
+        command: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(command[1:])  # drop the leading "launchctl"
+        return handler(command)
+
+    monkeypatch.setattr(launchd.subprocess, "run", fake_run)
+    return calls
+
+
+def _success_handler(command: list[str]) -> subprocess.CompletedProcess[str]:
+    """``load``/``unload`` succeed; ``list`` reports the agent present."""
+    if command[1] == "list":
+        return _completed(command, returncode=0, stdout="{ ... };\n")
+    return _completed(command, returncode=0)
+
+
+# --- _build_plist -----------------------------------------------------------
+
+
+def test_build_plist_has_required_keys() -> None:
+    payload = launchd._build_plist(Path(CHIRPD_PATH))
+
+    assert payload["Label"] == "com.chirp.chirpd"
+    assert payload["ProgramArguments"] == [CHIRPD_PATH]
+    assert payload["RunAtLoad"] is True
+    assert payload["KeepAlive"] == {"SuccessfulExit": False}
+    assert payload["StandardOutPath"] == str(launchd.LAUNCH_AGENT_LOG_PATH)
+    assert payload["StandardErrorPath"] == str(launchd.LAUNCH_AGENT_LOG_PATH)
+    assert payload["ProcessType"] == "Background"
+
+
+def test_build_plist_propagates_path_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PATH", "/opt/homebrew/bin:/usr/bin")
+
+    payload = launchd._build_plist(Path(CHIRPD_PATH))
+
+    assert payload["EnvironmentVariables"]["PATH"] == "/opt/homebrew/bin:/usr/bin"
+
+
+def test_build_plist_propagates_hf_home_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HF_HOME", "/tmp/hf")
+
+    payload = launchd._build_plist(Path(CHIRPD_PATH))
+
+    assert payload["EnvironmentVariables"]["HF_HOME"] == "/tmp/hf"
+
+
+def test_build_plist_omits_hf_home_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HF_HOME", raising=False)
+
+    payload = launchd._build_plist(Path(CHIRPD_PATH))
+
+    assert "HF_HOME" not in payload["EnvironmentVariables"]
+
+
+# --- install_launch_agent ---------------------------------------------------
+
+
+def test_install_writes_plist_atomically(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    monkeypatch.setattr(launchd.shutil, "which", lambda _name: CHIRPD_PATH)
+    _patch_launchctl(monkeypatch, _success_handler)
+
+    returned = launchd.install_launch_agent()
+
+    assert returned == plist_path
+    assert plist_path.exists()
+    with plist_path.open("rb") as handle:
+        on_disk = plistlib.load(handle)
+    assert on_disk["Label"] == "com.chirp.chirpd"
+    assert on_disk["ProgramArguments"] == [CHIRPD_PATH]
+
+
+def test_install_raises_already_installed_without_force(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("stale")
+    monkeypatch.setattr(launchd.shutil, "which", lambda _name: CHIRPD_PATH)
+
+    with pytest.raises(launchd.LaunchAgentAlreadyInstalled):
+        launchd.install_launch_agent()
+
+
+def test_install_with_force_replaces_existing(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("stale-content")
+    monkeypatch.setattr(launchd.shutil, "which", lambda _name: CHIRPD_PATH)
+    calls = _patch_launchctl(monkeypatch, _success_handler)
+
+    launchd.install_launch_agent(force=True)
+
+    with plist_path.open("rb") as handle:
+        on_disk = plistlib.load(handle)
+    assert on_disk == launchd._build_plist(Path(CHIRPD_PATH))
+    # Force must unload the old agent before loading the freshly-written plist.
+    verbs = [args[0] for args in calls]
+    assert verbs.index("unload") < verbs.index("load")
+
+
+def test_install_raises_when_chirpd_missing(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    monkeypatch.setattr(launchd.shutil, "which", lambda _name: None)
+
+    with pytest.raises(launchd.LaunchAgentError, match="not found on PATH"):
+        launchd.install_launch_agent()
+
+
+def test_install_raises_launchctl_failed_on_nonzero(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    monkeypatch.setattr(launchd.shutil, "which", lambda _name: CHIRPD_PATH)
+
+    def handler(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[1] == "load":
+            return _completed(command, returncode=5, stderr="Load failed: 5: I/O error")
+        return _success_handler(command)
+
+    _patch_launchctl(monkeypatch, handler)
+
+    with pytest.raises(launchd.LaunchctlFailed) as excinfo:
+        launchd.install_launch_agent()
+
+    assert excinfo.value.returncode == 5
+    assert "Load failed: 5" in excinfo.value.stderr
+
+
+def test_install_raises_launchctl_failed_on_empty_list_output(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    monkeypatch.setattr(launchd.shutil, "which", lambda _name: CHIRPD_PATH)
+
+    def handler(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[1] == "list":
+            return _completed(command, returncode=0, stdout="")
+        return _completed(command, returncode=0)
+
+    _patch_launchctl(monkeypatch, handler)
+
+    with pytest.raises(launchd.LaunchctlFailed):
+        launchd.install_launch_agent()
+
+
+def test_write_plist_atomic_cleans_up_tmp_on_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    target = tmp_path / "com.chirp.chirpd.plist"
+
+    def boom(_src: object, _dst: object) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(launchd.os, "replace", boom)
+
+    with pytest.raises(OSError, match="replace failed"):
+        launchd._write_plist_atomic({"Label": "x"}, target)
+
+    assert not target.with_name(target.name + ".tmp").exists()
+    assert not target.exists()
+
+
+# --- uninstall_launch_agent -------------------------------------------------
+
+
+def test_uninstall_runs_unload_and_removes_plist(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("present")
+
+    def handler(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[1] == "list":
+            return _completed(command, returncode=1)  # agent gone
+        return _completed(command, returncode=0)
+
+    _patch_launchctl(monkeypatch, handler)
+
+    launchd.uninstall_launch_agent()
+
+    assert not plist_path.exists()
+
+
+def test_uninstall_raises_not_installed_when_no_plist(plist_path: Path) -> None:
+    with pytest.raises(launchd.LaunchAgentNotInstalled):
+        launchd.uninstall_launch_agent()
+
+
+def test_uninstall_raises_when_still_listed_after_unload(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    # unload returns 0 and the plist is unlinked, but `launchctl list` still
+    # reports the agent (macOS edge case) — surface it; the error names the
+    # already-removed plist so the user isn't left guessing.
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("present")
+    _patch_launchctl(monkeypatch, lambda command: _completed(command, returncode=0))
+
+    with pytest.raises(launchd.LaunchctlFailed, match="already been removed"):
+        launchd.uninstall_launch_agent()
+    assert not plist_path.exists()
+
+
+def test_uninstall_raises_launchctl_failed_on_nonzero(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("present")
+
+    def handler(command: list[str]) -> subprocess.CompletedProcess[str]:
+        if command[1] == "unload":
+            return _completed(command, returncode=3, stderr="Unload failed")
+        return _completed(command, returncode=0)
+
+    _patch_launchctl(monkeypatch, handler)
+
+    with pytest.raises(launchd.LaunchctlFailed):
+        launchd.uninstall_launch_agent()
+    # Plist must remain on disk so the user can inspect / retry.
+    assert plist_path.exists()
+
+
+# --- is_launch_agent_installed ----------------------------------------------
+
+
+def test_is_launch_agent_installed_true_when_both_present(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("present")
+    _patch_launchctl(monkeypatch, lambda command: _completed(command, returncode=0))
+
+    assert launchd.is_launch_agent_installed() is True
+
+
+def test_is_launch_agent_installed_false_when_plist_missing(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    called = False
+
+    def handler(command: list[str]) -> subprocess.CompletedProcess[str]:
+        nonlocal called
+        called = True
+        return _completed(command, returncode=0)
+
+    _patch_launchctl(monkeypatch, handler)
+
+    assert launchd.is_launch_agent_installed() is False
+    assert called is False  # launchctl must not run when the plist is absent
+
+
+def test_is_launch_agent_installed_false_when_launchctl_missing(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("present")
+    _patch_launchctl(monkeypatch, lambda command: _completed(command, returncode=1))
+
+    assert launchd.is_launch_agent_installed() is False
+
+
+# --- installed_chirpd_path --------------------------------------------------
+
+
+def test_installed_chirpd_path_reads_baked_value(
+    monkeypatch: pytest.MonkeyPatch, plist_path: Path
+) -> None:
+    monkeypatch.setattr(launchd.shutil, "which", lambda _name: CHIRPD_PATH)
+    _patch_launchctl(monkeypatch, _success_handler)
+    launchd.install_launch_agent()
+
+    assert launchd.installed_chirpd_path(plist_path) == CHIRPD_PATH
+    # Default arg resolves the module-level plist path (monkeypatched here too).
+    assert launchd.installed_chirpd_path() == CHIRPD_PATH
+
+
+def test_installed_chirpd_path_none_when_plist_missing(plist_path: Path) -> None:
+    assert launchd.installed_chirpd_path(plist_path) is None
+
+
+def test_installed_chirpd_path_none_when_plist_malformed(plist_path: Path) -> None:
+    plist_path.parent.mkdir(parents=True)
+    plist_path.write_text("not a plist")
+
+    assert launchd.installed_chirpd_path(plist_path) is None
+
+
+def test_installed_chirpd_path_none_when_program_arguments_absent(
+    plist_path: Path,
+) -> None:
+    plist_path.parent.mkdir(parents=True)
+    with plist_path.open("wb") as handle:
+        plistlib.dump({"Label": "com.chirp.chirpd"}, handle)
+
+    assert launchd.installed_chirpd_path(plist_path) is None
+
+
+def test_installed_chirpd_path_none_when_program_arguments_empty(
+    plist_path: Path,
+) -> None:
+    plist_path.parent.mkdir(parents=True)
+    with plist_path.open("wb") as handle:
+        plistlib.dump({"Label": "com.chirp.chirpd", "ProgramArguments": []}, handle)
+
+    assert launchd.installed_chirpd_path(plist_path) is None
+
+
+# --- non-Darwin guard -------------------------------------------------------
+
+
+def test_non_darwin_raises(monkeypatch: pytest.MonkeyPatch, plist_path: Path) -> None:
+    monkeypatch.setattr(launchd.sys, "platform", "linux")
+
+    with pytest.raises(launchd.LaunchAgentError, match="macOS-only"):
+        launchd.install_launch_agent()
+    with pytest.raises(launchd.LaunchAgentError, match="macOS-only"):
+        launchd.uninstall_launch_agent()
+    assert launchd.is_launch_agent_installed() is False

--- a/tests/chirpd/test_logging_setup.py
+++ b/tests/chirpd/test_logging_setup.py
@@ -192,6 +192,21 @@ def test_log_op_event_emits_result_field(tmp_path: Path) -> None:
     assert "result=spawned" in _read_log(tmp_path)
 
 
+def test_log_op_event_emits_chirpd_path_field(tmp_path: Path) -> None:
+    """``chirpd_path`` (added by story 5.4) passes through to the rendered line."""
+    configure_logging(log_dir=tmp_path)
+    log_op_event(
+        logging.getLogger(CHIRP_LOGGER),
+        logging.INFO,
+        "daemon_enable: installed",
+        req_id="r-1",
+        op="daemon_enable",
+        result="installed",
+        chirpd_path="/usr/local/bin/chirpd",
+    )
+    assert "chirpd_path=/usr/local/bin/chirpd" in _read_log(tmp_path)
+
+
 def test_log_op_event_truncates_long_msg(tmp_path: Path) -> None:
     configure_logging(log_dir=tmp_path)
     long_msg = "x" * 500

--- a/tests/llm/test_cli_daemon.py
+++ b/tests/llm/test_cli_daemon.py
@@ -22,6 +22,12 @@ import pytest
 from rich.console import Console
 from typer.testing import CliRunner
 
+from chirpd.launchd import (
+    LaunchAgentAlreadyInstalled,
+    LaunchAgentError,
+    LaunchAgentNotInstalled,
+    LaunchctlFailed,
+)
 from llm.cli import daemon as daemon_module
 from llm.exceptions import LLMDaemonUnreachable, LLMProtocolError
 
@@ -878,3 +884,274 @@ def test_log_event_emitted_for_each_command(
     assert "daemon_start" in ops
     assert "daemon_stop" in ops
     assert "daemon_restart" in ops
+
+
+# ===========================================================================
+# LaunchAgent: enable / disable (story 5.4)
+#
+# The ``chirpd.launchd`` functions are patched on the daemon module namespace;
+# the CLI layer is the unit under test (argument parsing, exit codes, message
+# rendering, JSON shape). No test touches ``launchctl`` or the real plist path.
+# ===========================================================================
+
+PLIST_PATH = Path("/Users/u/Library/LaunchAgents/com.chirp.chirpd.plist")
+
+
+def _patch_install(monkeypatch: pytest.MonkeyPatch, result: object) -> MagicMock:
+    mock = (
+        MagicMock(side_effect=result)
+        if isinstance(result, Exception)
+        else (MagicMock(return_value=result))
+    )
+    monkeypatch.setattr(daemon_module, "install_launch_agent", mock)
+    return mock
+
+
+def _patch_uninstall(monkeypatch: pytest.MonkeyPatch, result: object) -> MagicMock:
+    mock = (
+        MagicMock(side_effect=result)
+        if isinstance(result, Exception)
+        else (MagicMock(return_value=result))
+    )
+    monkeypatch.setattr(daemon_module, "uninstall_launch_agent", mock)
+    return mock
+
+
+# --- enable -----------------------------------------------------------------
+
+
+def test_enable_success(monkeypatch: pytest.MonkeyPatch, force_tty: None) -> None:
+    _patch_install(monkeypatch, PLIST_PATH)
+
+    result = runner.invoke(daemon_module.daemon_app, ["enable"])
+
+    assert result.exit_code == 0
+    assert "LaunchAgent installed at" in result.stdout
+    assert "auto-start at login" in result.stdout
+
+
+def test_enable_already_installed_without_force(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_install(monkeypatch, LaunchAgentAlreadyInstalled(str(PLIST_PATH)))
+
+    result = runner.invoke(daemon_module.daemon_app, ["enable"])
+
+    assert result.exit_code == 1
+    assert "already installed" in result.stderr
+    assert "--force" in result.stderr
+
+
+def test_enable_force_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    install = _patch_install(monkeypatch, PLIST_PATH)
+
+    runner.invoke(daemon_module.daemon_app, ["enable", "--force"])
+
+    assert install.call_args.kwargs == {"force": True}
+
+
+def test_enable_launchctl_failure_surfaces_stderr(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    err = LaunchctlFailed(
+        ["launchctl", "load", "-w", str(PLIST_PATH)],
+        returncode=5,
+        stderr="Load failed: 5: Input/output error",
+    )
+    _patch_install(monkeypatch, err)
+
+    result = runner.invoke(daemon_module.daemon_app, ["enable"])
+
+    assert result.exit_code == 1
+    assert "Load failed" in result.stderr
+    assert "exit 5" in result.stderr
+
+
+def test_enable_missing_chirpd_binary(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_install(
+        monkeypatch,
+        LaunchAgentError(
+            "chirpd binary not found on PATH — is chirp installed correctly?"
+        ),
+    )
+
+    result = runner.invoke(daemon_module.daemon_app, ["enable"])
+
+    assert result.exit_code == 1
+    assert "not found on PATH" in result.stderr
+
+
+def test_enable_json_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_install(monkeypatch, PLIST_PATH)
+    monkeypatch.setattr(daemon_module.shutil, "which", lambda _name: CHIRPD_PATH)
+
+    result = runner.invoke(daemon_module.daemon_app, ["enable", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "enable"
+    assert payload["installed"] is True
+    assert payload["plist_path"] == str(PLIST_PATH)
+    assert payload["chirpd_path"] == CHIRPD_PATH
+
+
+def test_enable_json_failure_includes_error_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    err = LaunchctlFailed(
+        ["launchctl", "load", "-w", str(PLIST_PATH)],
+        returncode=5,
+        stderr="Load failed: 5: Input/output error",
+    )
+    _patch_install(monkeypatch, err)
+    monkeypatch.setattr(daemon_module, "is_launch_agent_installed", lambda: False)
+
+    result = runner.invoke(daemon_module.daemon_app, ["enable", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["installed"] is False
+    assert payload["error"]["code"] == "LaunchctlFailed"
+    assert payload["error"]["launchctl_stderr"] == "Load failed: 5: Input/output error"
+
+
+def test_enable_json_already_installed_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_install(monkeypatch, LaunchAgentAlreadyInstalled(str(PLIST_PATH)))
+    monkeypatch.setattr(daemon_module, "is_launch_agent_installed", lambda: True)
+
+    result = runner.invoke(daemon_module.daemon_app, ["enable", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "LaunchAgentAlreadyInstalled"
+    # Non-launchctl errors carry no launchctl stderr — must be JSON null.
+    assert payload["error"]["launchctl_stderr"] is None
+
+
+# --- disable ----------------------------------------------------------------
+
+
+def test_disable_success(monkeypatch: pytest.MonkeyPatch, force_tty: None) -> None:
+    _patch_uninstall(monkeypatch, None)
+
+    result = runner.invoke(daemon_module.daemon_app, ["disable"])
+
+    assert result.exit_code == 0
+    assert "LaunchAgent removed" in result.stdout
+
+
+def test_disable_idempotent_when_not_installed(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _patch_uninstall(monkeypatch, LaunchAgentNotInstalled(str(PLIST_PATH)))
+
+    result = runner.invoke(daemon_module.daemon_app, ["disable"])
+
+    assert result.exit_code == 0
+    assert "not installed" in result.stderr
+
+
+def test_disable_launchctl_failure(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    err = LaunchctlFailed(
+        ["launchctl", "unload", "-w", str(PLIST_PATH)],
+        returncode=3,
+        stderr="Unload failed: 3: No such process",
+    )
+    _patch_uninstall(monkeypatch, err)
+
+    result = runner.invoke(daemon_module.daemon_app, ["disable"])
+
+    assert result.exit_code == 1
+    assert "Unload failed" in result.stderr
+
+
+def test_disable_json_idempotent_was_not_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_uninstall(monkeypatch, LaunchAgentNotInstalled(str(PLIST_PATH)))
+
+    result = runner.invoke(daemon_module.daemon_app, ["disable", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {"action": "disable", "installed": False, "was_installed": False}
+
+
+def test_disable_json_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_uninstall(monkeypatch, None)
+
+    result = runner.invoke(daemon_module.daemon_app, ["disable", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload == {"action": "disable", "installed": False, "was_installed": True}
+
+
+def test_disable_json_launchctl_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    err = LaunchctlFailed(
+        ["launchctl", "unload", "-w", str(PLIST_PATH)],
+        returncode=3,
+        stderr="Unload failed: 3: No such process",
+    )
+    _patch_uninstall(monkeypatch, err)
+    monkeypatch.setattr(daemon_module, "is_launch_agent_installed", lambda: True)
+
+    result = runner.invoke(daemon_module.daemon_app, ["disable", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.stdout)
+    assert payload["action"] == "disable"
+    assert payload["installed"] is True
+    assert payload["error"]["code"] == "LaunchctlFailed"
+    assert payload["error"]["launchctl_stderr"] == "Unload failed: 3: No such process"
+
+
+# --- diagnostic logging -----------------------------------------------------
+
+
+def test_log_event_emitted_for_enable_and_disable(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    log_mock = MagicMock()
+    monkeypatch.setattr(daemon_module, "log_op_event", log_mock)
+
+    _patch_install(monkeypatch, PLIST_PATH)
+    monkeypatch.setattr(daemon_module.shutil, "which", lambda _name: CHIRPD_PATH)
+    runner.invoke(daemon_module.daemon_app, ["enable"])
+
+    _patch_uninstall(monkeypatch, None)
+    runner.invoke(daemon_module.daemon_app, ["disable"])
+
+    ops = [call.kwargs["op"] for call in log_mock.call_args_list]
+    assert ops.count("daemon_enable") == 1
+    assert ops.count("daemon_disable") == 1
+    enable_call = next(
+        c for c in log_mock.call_args_list if c.kwargs["op"] == "daemon_enable"
+    )
+    assert enable_call.kwargs["chirpd_path"] == CHIRPD_PATH
+
+
+# --- help discipline --------------------------------------------------------
+
+
+def test_enable_help_text(force_tty: None) -> None:
+    result = runner.invoke(daemon_module.daemon_app, ["enable", "--help"])
+
+    help_text = _ANSI_RE.sub("", result.stdout)
+    assert result.exit_code == 0
+    assert "--force" in help_text
+    assert "--json" in help_text
+    assert "restarts on crash" in help_text
+
+
+def test_disable_help_text(force_tty: None) -> None:
+    result = runner.invoke(daemon_module.daemon_app, ["disable", "--help"])
+
+    help_text = _ANSI_RE.sub("", result.stdout)
+    assert result.exit_code == 0
+    assert "--json" in help_text
+    assert "no longer auto-start" in help_text


### PR DESCRIPTION
## Story 5.4 — `chirp daemon enable | disable`

Installs/removes the `com.chirp.chirpd` LaunchAgent so the daemon auto-starts at login and restarts on crash.

### What's here
- **`chirpd/launchd.py`** (new) — `install_launch_agent(*, force=False)`, `uninstall_launch_agent()`, `is_launch_agent_installed()`, `installed_chirpd_path()`, `_build_plist()`, plus the typed error hierarchy (`LaunchAgentError` → `AlreadyInstalled` / `NotInstalled` / `LaunchctlFailed`). Plist matches AC-2 exactly (`KeepAlive {SuccessfulExit: False}`, captured `PATH`, conditional `HF_HOME`, `ProcessType: Background`); atomic `.tmp` + `os.replace` write; `launchctl load -w` + verification probe. Imports cleanly off-macOS; mutating verbs raise off-Darwin. The module docstring documents the counterintuitive `KeepAlive`↔version-mismatch (`exit 0` → no respawn) interaction. Reusable directly from `chirp init` (EPIC-INIT-AND-MIGRATION).
- **`llm/cli/daemon.py`** — `enable` / `disable` as thin wrappers; exit codes per AC-11, `--json` shapes per AC-8, verbatim `launchctl` stderr passthrough, live `--help` per AC-12.
- **`chirpd/logging_setup.py`** — added `chirpd_path` to the logfmt allowlist **and** as an explicit `log_op_event` param.

### Review
Ran the BMAD adversarial review loop (2 rounds):
- **Round 1** (2 should-fix, 2 nice-to-have) → fixed: ground-truth `chirpd_path` read back from the plist (AC-8); uninstall verification-failure error now names the already-removed plist + gives a `launchctl remove` recovery hint; force-unload label comment; `_format_launchctl_error` degenerate-fallback cleanup; added `disable --json` failure test.
- **Round 2** → **CLEAN** (0 must-fix, 0 should-fix); applied 3 cheap nice-to-haves (empty-`ProgramArguments` test, already-installed JSON-error test, atomic-write `.tmp` cleanup).

### Tests / gates
- 1338 tests pass · `ruff check .` clean · `mypy` clean · `chirpd/launchd.py` at **100%** unit coverage.

### Manual checklist (AC-15) — TODO before merge (real Mac)
- [ ] Fresh `enable` → plist exists, `launchctl list` shows it, daemon running
- [ ] Reboot → agent still listed + daemon up after login
- [ ] `enable` again → exit 1 "already installed; pass --force"
- [ ] `enable --force` → reinstalls cleanly
- [ ] `disable` → plist gone; `disable` again → exit 0 "not installed"
- [ ] `kill -9` the daemon → launchd respawns within seconds
- [ ] Version-mismatch → daemon exits 0, launchd does NOT respawn; next CLI lazy-spawns
