### PR TITLE
feat(cli): chirp daemon logs with -f/--follow and -n (story 5.5)

### DIFF
--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.5-daemon-logs.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.5-daemon-logs.md
@@ -1,6 +1,6 @@
 # Story 5.5 — `chirp daemon logs` with `-f` / `--follow` and `-n`
 
-- **Status:** Draft
+- **Status:** review
 - **Epic:** [EPIC-DAEMON-LIFECYCLE](../epic.md)
 - **Depends on:** 5.1 (log file path and rotation behavior locked at `~/Library/Logs/chirp/chirpd.log` with `.1` for the prior generation)
 - **Blocks:** 5.6 (Typer registration)
@@ -209,3 +209,33 @@ This command is intentionally simple. It does **not** filter by `req_id`, color-
 
 - **`daemon_app` now hosts seven commands** (`status`, `start`, `stop`, `restart`, `enable`, `disable`, `logs`). Story 5.6 registers the lot into `chirp/cli.py` as a hidden subgroup. No further commands are planned for MVP.
 - **`resolve_log_path()` is the canonical "where do logs live" helper.** Any future command or doctor check needing this path imports it from `chirpd/logging_setup.py` rather than hardcoding.
+
+## Dev Agent Record
+
+### Implementation plan
+
+- Added `resolve_log_path(log_dir=None)` to `chirpd/logging_setup.py` as the single source of truth for the log location, and refactored `configure_logging` to build its `log_file` through it (writer + reader now share one path resolver — AC-2, task 1).
+- Implemented `logs` on `daemon_app` in `llm/cli/daemon.py` with the four-way branch (cat / `-n` tail / `-f` follow / `-n -f` dump-then-follow) plus the missing-file notice (tasks 2, 5).
+- `_follow_log_file` follows by name with inode-change re-open (`tail -F` semantics, AC-5/AC-11). The seek-to-EOF only fires when the file already existed at start; if the loop had to wait for the file to appear, it reads the fresh file from offset 0 so the first line the user is waiting for is not skipped (AC-8 rationale).
+- `_tail_last_n_lines` uses a bounded `deque(maxlen=n)`; `_cat_log_file` streams line-by-line with a final flush (tasks 3–5).
+- Poll cadences live in module constants `_FOLLOW_POLL_INTERVAL_SECONDS` / `_WAIT_FILE_POLL_INTERVAL_SECONDS` so tests can shrink them (AC-12).
+- Diagnostic line emitted at command start via `log_op_event` with `op=daemon_logs duration_ms=0 result=cat|tail|follow|missing` (AC-13, task 6).
+
+### Completion notes
+
+- All 17 ACs satisfied. The follow-loop tests run `_follow_log_file` / the `logs` command body on a background thread, observe a patched `sys.stdout` `StringIO` live, and stop the loop by making the patched `time.sleep` raise `KeyboardInterrupt` — the same exit path a real `^C` takes (AC-7), which also exercises the clean-exit code 0.
+- The load-bearing rotation test (AC-11) renames `chirpd.log` → `chirpd.log.1`, writes a fresh `chirpd.log`, and asserts the follow loop picks up the post-rotation line via the inode-change path.
+- `uv run pytest tests/llm/test_cli_daemon.py tests/llm/test_cli_daemon_logs.py` → 92 passed. `tests/chirpd/ tests/llm/` → 567 passed (no regressions from the `logging_setup` refactor). `uv run ruff check .` clean; `uv run mypy llm/cli/daemon.py chirpd/logging_setup.py` clean (AC-17).
+- `chirp daemon logs --help` verified live — matches AC-15 (Rich-rendered like the other daemon commands), no JSON mention (AC-10).
+- **Manual smoke tests (task 8) not executed:** they require a live daemon (`chirpd`) and a real ~11 MB forced rotation on disk. The rotation-resilience contract they target is pinned by the AC-11 automated test on a `tmp_path` filesystem. Flagging for the reviewer to run against a real daemon if desired.
+
+### File List
+
+- `chirpd/logging_setup.py` — added `resolve_log_path()`; `configure_logging` now resolves `log_file` through it.
+- `llm/cli/daemon.py` — added the `logs` command and helpers (`_logs_result`, `_cat_log_file`, `_tail_last_n_lines`, `_follow_log_file`, `_wait_for_log_file`, `_log_daemon_logs`), the two poll-interval constants, the `deque` import, and the `resolve_log_path` import.
+- `tests/llm/test_cli_daemon_logs.py` — new test module (15 tests covering AC-2 through AC-15).
+
+### Change Log
+
+- 2026-06-04: Implemented story 5.5 (`chirp daemon logs` with `-f`/`--follow` and `-n`). Added the reader-side log command and the shared `resolve_log_path()` helper.
+- 2026-06-05: Adversarial review loop (2 rounds → CLEAN). Round 1 fixed: negative `-n` now a Typer exit-2 usage error via `min=1` (AC-14, was an uncaught `ValueError`/exit 1); follow-mode `OSError` (and the `-n -f` dump) now surface the friendly `couldn't read log file` exit-1 message, and the rotation re-open catches `OSError` to retry rather than crash. Added tests for both. Round 2 returned CLEAN; documented the accepted dump→follow micro-race in `-n -f` mode (shared with `tail -n N -f`). Deferred nice-to-have: the follow tests' fixed settle-sleeps could be replaced with an observable-state handshake (needs production hooks; low flake risk today).

--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.5-daemon-logs.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.5-daemon-logs.md
@@ -1,6 +1,6 @@
 # Story 5.5 — `chirp daemon logs` with `-f` / `--follow` and `-n`
 
-- **Status:** review
+- **Status:** done
 - **Epic:** [EPIC-DAEMON-LIFECYCLE](../epic.md)
 - **Depends on:** 5.1 (log file path and rotation behavior locked at `~/Library/Logs/chirp/chirpd.log` with `.1` for the prior generation)
 - **Blocks:** 5.6 (Typer registration)
@@ -239,3 +239,4 @@ This command is intentionally simple. It does **not** filter by `req_id`, color-
 
 - 2026-06-04: Implemented story 5.5 (`chirp daemon logs` with `-f`/`--follow` and `-n`). Added the reader-side log command and the shared `resolve_log_path()` helper.
 - 2026-06-05: Adversarial review loop (2 rounds → CLEAN). Round 1 fixed: negative `-n` now a Typer exit-2 usage error via `min=1` (AC-14, was an uncaught `ValueError`/exit 1); follow-mode `OSError` (and the `-n -f` dump) now surface the friendly `couldn't read log file` exit-1 message, and the rotation re-open catches `OSError` to retry rather than crash. Added tests for both. Round 2 returned CLEAN; documented the accepted dump→follow micro-race in `-n -f` mode (shared with `tail -n N -f`). Deferred nice-to-have: the follow tests' fixed settle-sleeps could be replaced with an observable-state handshake (needs production hooks; low flake risk today).
+- 2026-06-05: PR [#81](https://github.com/Code-and-Sorts/chirp-ai-note-app/pull/81) opened; addressed all 8 automated review comments (CodeQL, code-quality, Copilot): `_logs_result` reports `missing` (not `tail`) when `-n` runs against an absent log; follow loop tracks inode via `os.fstat(fh.fileno())` on both the initial open and the post-rotation re-open (closes an `open()`/`stat()` race); `-n/--lines` annotated `int | None`; explanatory comments on the `KeyboardInterrupt` pass; test helper re-raises control-flow exceptions and captures only `Exception`. All CI green, all review threads resolved. Status → done.

--- a/chirpd/logging_setup.py
+++ b/chirpd/logging_setup.py
@@ -169,6 +169,18 @@ def _default_log_dir() -> Path:
     return Path.home() / subpath
 
 
+def resolve_log_path(log_dir: Path | None = None) -> Path:
+    """Return the full path to ``chirpd.log`` — the canonical log location.
+
+    Single source of truth shared between the writer (``configure_logging``) and
+    any reader (``chirp daemon logs``): ``~/Library/Logs/chirp/chirpd.log`` on
+    Darwin, ``~/.cache/chirp/chirpd.log`` elsewhere. Pass ``log_dir`` to override
+    the directory (tests, non-default installs).
+    """
+    target_dir = log_dir if log_dir is not None else _default_log_dir()
+    return target_dir / LOG_FILE_NAME
+
+
 def configure_logging(
     *,
     log_dir: Path | None = None,
@@ -187,8 +199,8 @@ def configure_logging(
     if not isinstance(numeric_level, int):
         raise ValueError(f"unknown log level {level!r}")
 
-    target_dir = log_dir if log_dir is not None else _default_log_dir()
-    log_file = target_dir / LOG_FILE_NAME
+    log_file = resolve_log_path(log_dir)
+    target_dir = log_file.parent
 
     try:
         target_dir.mkdir(parents=True, exist_ok=True)

--- a/llm/cli/daemon.py
+++ b/llm/cli/daemon.py
@@ -43,6 +43,7 @@ import socket as socketlib
 import subprocess
 import sys
 import time
+from collections import deque
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import IO, Any
@@ -63,7 +64,7 @@ from chirpd.launchd import (
     is_launch_agent_installed,
     uninstall_launch_agent,
 )
-from chirpd.logging_setup import configure_logging, log_op_event
+from chirpd.logging_setup import configure_logging, log_op_event, resolve_log_path
 from config.settings import CHIRP_DAEMON_SOCKET_ENV
 from llm.cli._console import console, stdout_console
 from llm.client import LLMClient, resolve_socket_path
@@ -953,3 +954,160 @@ def _safe_is_installed() -> bool:
         return is_launch_agent_installed()
     except (OSError, LaunchAgentError):
         return False
+
+
+# --- logs (story 5.5) -------------------------------------------------------
+
+# Read from module scope so tests can shrink them; production values keep the
+# follow loop responsive (200 ms) without burning CPU and poll for a not-yet-
+# existing log file once a second (AC-12).
+_FOLLOW_POLL_INTERVAL_SECONDS = 0.2
+_WAIT_FILE_POLL_INTERVAL_SECONDS = 1.0
+
+
+@daemon_app.command("logs")
+def logs(
+    follow: bool = typer.Option(
+        False,
+        "-f",
+        "--follow",
+        help="Follow the log file for new output. Re-opens across rotation.",
+    ),
+    lines: int = typer.Option(
+        None,
+        "-n",
+        "--lines",
+        min=1,
+        help="Show only the last N lines (or last N before following with -f).",
+    ),
+) -> None:
+    """Print the daemon log file. Tail with -f; show last N with -n."""
+    _ensure_logging()
+    path = resolve_log_path()
+    _log_daemon_logs(_logs_result(follow=follow, lines=lines, path=path))
+
+    try:
+        if follow:
+            # A fresh install may not have a log file yet; the follow loop waits
+            # for it to appear, so dump the tail only when there is something to.
+            # The follow loop then re-opens and seeks to a freshly-measured EOF,
+            # so a line the daemon writes in the microsecond gap between the dump
+            # and the seek is in neither — the same benign race `tail -n N -f`
+            # carries. Accepted: the alternative (threading the dump's end offset
+            # into the follow loop) tangles with the rotation re-open path.
+            if lines is not None and path.exists():
+                _tail_last_n_lines(path, lines)
+            _follow_log_file(path, start_at_end=True)
+            return
+
+        if not path.exists():
+            print(
+                f"no log file at {path} yet. logs are written when the daemon runs.",
+                file=sys.stderr,
+            )
+            return
+
+        if lines is not None:
+            _tail_last_n_lines(path, lines)
+        else:
+            _cat_log_file(path)
+    except OSError as err:
+        print(f"couldn't read log file: {err}", file=sys.stderr)
+        raise typer.Exit(code=1) from err
+
+
+def _logs_result(*, follow: bool, lines: int | None, path: Path) -> str:
+    """Classify the run for the diagnostic log line: cat|tail|follow|missing."""
+    if follow:
+        return "follow"
+    if lines is not None:
+        return "tail"
+    return "cat" if path.exists() else "missing"
+
+
+def _cat_log_file(path: Path) -> None:
+    """Stream the whole file to stdout byte-for-byte (no whole-file read)."""
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            sys.stdout.write(line)
+    sys.stdout.flush()
+
+
+def _tail_last_n_lines(path: Path, n: int) -> None:
+    """Write the last ``n`` lines to stdout, keeping only ``n`` in memory."""
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        tail = deque(fh, maxlen=n)
+    for line in tail:
+        sys.stdout.write(line)
+    sys.stdout.flush()
+
+
+def _follow_log_file(path: Path, *, start_at_end: bool) -> None:
+    """Follow the log file, re-opening across rotation (``tail -F`` semantics).
+
+    Waits for the file to appear (AC-8), then reads new lines as they land. When
+    the file's inode changes — rotation swapped ``chirpd.log`` for a fresh one —
+    re-opens by name and reads the new file from the start so the first post-
+    rotation lines are not lost. Exits cleanly on Ctrl-C (AC-7).
+    """
+    try:
+        # Seek past existing content only when the file is already there. If we
+        # had to wait for it to appear, the file is fresh and the first line is
+        # exactly what the user wants to watch arrive (AC-8 rationale).
+        seek_to_end = start_at_end and path.exists()
+        _wait_for_log_file(path)
+        fh = path.open("r", encoding="utf-8", errors="replace")
+        inode = path.stat().st_ino
+        if seek_to_end:
+            fh.seek(0, os.SEEK_END)
+        try:
+            while True:
+                line = fh.readline()
+                if line:
+                    sys.stdout.write(line)
+                    sys.stdout.flush()
+                    continue
+                time.sleep(_FOLLOW_POLL_INTERVAL_SECONDS)
+                try:
+                    new_inode = path.stat().st_ino
+                except FileNotFoundError:
+                    # The file vanished mid-rotation; keep polling for its return.
+                    continue
+                if new_inode != inode:
+                    try:
+                        new_fh = path.open("r", encoding="utf-8", errors="replace")
+                    except OSError:
+                        # Lost the race between stat and open (the fresh file is
+                        # not openable yet) — hold the current handle and retry.
+                        continue
+                    fh.close()
+                    fh = new_fh
+                    inode = new_inode
+        finally:
+            fh.close()
+    except KeyboardInterrupt:
+        pass
+
+
+def _wait_for_log_file(path: Path) -> None:
+    """Block until ``path`` exists, announcing the wait once (AC-8)."""
+    announced = False
+    while not path.exists():
+        if not announced:
+            print(f"waiting for log file at {path}...", file=sys.stderr)
+            announced = True
+        time.sleep(_WAIT_FILE_POLL_INTERVAL_SECONDS)
+
+
+def _log_daemon_logs(result: str) -> None:
+    # AC-13: emitted at command start (not exit), so duration_ms is 0 by design —
+    # a ``-f`` run may never "finish" for a duration to measure.
+    log_op_event(
+        _logger,
+        logging.INFO,
+        f"daemon logs: {result}",
+        req_id=new_request_id(),
+        op="daemon_logs",
+        duration_ms=0,
+        result=result,
+    )

--- a/llm/cli/daemon.py
+++ b/llm/cli/daemon.py
@@ -973,7 +973,7 @@ def logs(
         "--follow",
         help="Follow the log file for new output. Re-opens across rotation.",
     ),
-    lines: int = typer.Option(
+    lines: int | None = typer.Option(
         None,
         "-n",
         "--lines",
@@ -1020,9 +1020,11 @@ def _logs_result(*, follow: bool, lines: int | None, path: Path) -> str:
     """Classify the run for the diagnostic log line: cat|tail|follow|missing."""
     if follow:
         return "follow"
-    if lines is not None:
-        return "tail"
-    return "cat" if path.exists() else "missing"
+    # A missing file short-circuits to the notice before any cat/tail happens, so
+    # report "missing" even when -n was passed — the tail never ran.
+    if not path.exists():
+        return "missing"
+    return "tail" if lines is not None else "cat"
 
 
 def _cat_log_file(path: Path) -> None:
@@ -1057,7 +1059,11 @@ def _follow_log_file(path: Path, *, start_at_end: bool) -> None:
         seek_to_end = start_at_end and path.exists()
         _wait_for_log_file(path)
         fh = path.open("r", encoding="utf-8", errors="replace")
-        inode = path.stat().st_ino
+        # Read the inode off the open handle, not the name: if rotation slips in
+        # between open() and the stat, a name-based stat would describe the new
+        # file while fh still points at the old one, and the loop would never
+        # detect the swap. os.fstat keeps inode and handle consistent.
+        inode = os.fstat(fh.fileno()).st_ino
         if seek_to_end:
             fh.seek(0, os.SEEK_END)
         try:
@@ -1082,10 +1088,12 @@ def _follow_log_file(path: Path, *, start_at_end: bool) -> None:
                         continue
                     fh.close()
                     fh = new_fh
-                    inode = new_inode
+                    # Track the inode of the handle we now hold (see above).
+                    inode = os.fstat(fh.fileno()).st_ino
         finally:
             fh.close()
     except KeyboardInterrupt:
+        # An interactive ^C during follow is a clean exit, not an error (AC-7).
         pass
 
 

--- a/tests/llm/test_cli_daemon_logs.py
+++ b/tests/llm/test_cli_daemon_logs.py
@@ -1,0 +1,370 @@
+"""Tests for ``chirp daemon logs`` (story 5.5).
+
+The reader-side counterpart to ``chirpd.logging_setup``: ``configure_logging`` is
+neutralized and ``resolve_log_path`` is redirected at a ``tmp_path`` file so no
+test touches the real ``~/Library/Logs/chirp/chirpd.log``. The follow-loop tests
+drive ``_follow_log_file`` (or the ``logs`` command body) on a background thread,
+observe a patched ``sys.stdout`` ``StringIO`` live, and stop the loop by making
+the patched ``time.sleep`` raise ``KeyboardInterrupt`` — the same exit path a
+real ``^C`` takes (AC-7).
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from chirpd.logging_setup import LOG_FILE_NAME, resolve_log_path
+from llm.cli import daemon as daemon_module
+
+runner = CliRunner()
+
+# Captured before any test patches ``time.sleep``, so the test-side poll/settle
+# helpers keep sleeping for real even while the follow loop's sleep is rigged.
+_REAL_SLEEP = time.sleep
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+@pytest.fixture(autouse=True)
+def _silence_logging(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep ``logs`` from configuring the real chirpd log handler."""
+    monkeypatch.setattr(daemon_module, "configure_logging", MagicMock())
+
+
+@pytest.fixture(autouse=True)
+def _fast_poll(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Shrink the follow/wait cadences so threaded tests finish fast (AC-12)."""
+    monkeypatch.setattr(daemon_module, "_FOLLOW_POLL_INTERVAL_SECONDS", 0.01)
+    monkeypatch.setattr(daemon_module, "_WAIT_FILE_POLL_INTERVAL_SECONDS", 0.01)
+
+
+@pytest.fixture
+def log_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``resolve_log_path`` at a tmp file; return that path (may not exist)."""
+    path = tmp_path / LOG_FILE_NAME
+    monkeypatch.setattr(daemon_module, "resolve_log_path", lambda *a, **k: path)
+    return path
+
+
+def _wait_until(predicate: Callable[[], bool], timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        _REAL_SLEEP(0.005)
+    return predicate()
+
+
+def _patch_stoppable_sleep(
+    monkeypatch: pytest.MonkeyPatch, stop: threading.Event
+) -> None:
+    """Make the follow loop's ``time.sleep`` raise ``KeyboardInterrupt`` on stop."""
+
+    def fake_sleep(_seconds: float) -> None:
+        _REAL_SLEEP(0.005)
+        if stop.is_set():
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(daemon_module.time, "sleep", fake_sleep)
+
+
+def _run_in_thread(
+    target: Callable[[], Any],
+) -> tuple[threading.Thread, dict[str, Any]]:
+    captured: dict[str, Any] = {}
+
+    def run() -> None:
+        try:
+            target()
+        except BaseException as exc:  # noqa: BLE001 — surfaced to the assertion
+            captured["exc"] = exc
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    return thread, captured
+
+
+# --- resolve_log_path (AC-2) ------------------------------------------------
+
+
+def test_resolve_log_path_appends_log_file_name(tmp_path: Path) -> None:
+    assert resolve_log_path(tmp_path) == tmp_path / LOG_FILE_NAME
+
+
+# --- default / -n behavior (AC-3, AC-4) -------------------------------------
+
+
+def test_logs_default_cats_full_file(log_path: Path) -> None:
+    content = "".join(f"line{i}\n" for i in range(1, 6))
+    log_path.write_text(content, encoding="utf-8")
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs"])
+
+    assert result.exit_code == 0
+    assert result.stdout == content
+
+
+def test_logs_with_n_shows_last_n_lines(log_path: Path) -> None:
+    lines = [f"line{i}\n" for i in range(1, 101)]
+    log_path.write_text("".join(lines), encoding="utf-8")
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs", "-n", "10"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "".join(lines[-10:])
+
+
+def test_logs_with_n_larger_than_file_shows_all(log_path: Path) -> None:
+    content = "a\nb\nc\n"
+    log_path.write_text(content, encoding="utf-8")
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs", "-n", "100"])
+
+    assert result.exit_code == 0
+    assert result.stdout == content
+
+
+def test_logs_handles_partial_final_line(log_path: Path) -> None:
+    log_path.write_text("line1\nline2 without newline", encoding="utf-8")
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs"])
+
+    assert result.exit_code == 0
+    assert "line1" in result.stdout
+    assert "line2 without newline" in result.stdout
+
+
+# --- missing file (AC-8) ----------------------------------------------------
+
+
+def test_logs_missing_file_default_prints_notice(log_path: Path) -> None:
+    result = runner.invoke(daemon_module.daemon_app, ["logs"])
+
+    assert result.exit_code == 0
+    assert "no log file" in result.stderr
+    assert str(log_path) in result.stderr
+    assert result.stdout == ""
+
+
+def test_logs_missing_file_with_follow_waits(
+    log_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stop = threading.Event()
+    _patch_stoppable_sleep(monkeypatch, stop)
+    out, err = io.StringIO(), io.StringIO()
+    monkeypatch.setattr(daemon_module.sys, "stdout", out)
+    monkeypatch.setattr(daemon_module.sys, "stderr", err)
+
+    thread, captured = _run_in_thread(
+        lambda: daemon_module.logs(follow=True, lines=None)
+    )
+    _REAL_SLEEP(0.05)  # let the loop announce the wait before the file appears
+    log_path.write_text("first\n", encoding="utf-8")
+
+    assert _wait_until(lambda: "first" in out.getvalue())
+    stop.set()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    assert "waiting for log file" in err.getvalue()
+    assert "first" in out.getvalue()
+    assert "exc" not in captured
+
+
+# --- follow (AC-5, AC-6, AC-7) ----------------------------------------------
+
+
+def test_logs_follow_picks_up_appended_lines(
+    log_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_path.write_text("line1\n", encoding="utf-8")
+    stop = threading.Event()
+    _patch_stoppable_sleep(monkeypatch, stop)
+    out = io.StringIO()
+    monkeypatch.setattr(daemon_module.sys, "stdout", out)
+
+    thread, captured = _run_in_thread(
+        lambda: daemon_module._follow_log_file(log_path, start_at_end=True)
+    )
+    _REAL_SLEEP(0.05)  # let the loop open + seek to EOF before we append
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write("line2\n")
+        fh.flush()
+
+    assert _wait_until(lambda: "line2" in out.getvalue())
+    stop.set()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    assert "line2" in out.getvalue()
+    assert "line1" not in out.getvalue()  # started at EOF, so prior content skipped
+    assert "exc" not in captured
+
+
+def test_logs_follow_with_n_dumps_then_follows(
+    log_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_path.write_text("".join(f"line{i}\n" for i in range(1, 6)), encoding="utf-8")
+    stop = threading.Event()
+    _patch_stoppable_sleep(monkeypatch, stop)
+    out = io.StringIO()
+    monkeypatch.setattr(daemon_module.sys, "stdout", out)
+
+    thread, captured = _run_in_thread(lambda: daemon_module.logs(follow=True, lines=3))
+    assert _wait_until(lambda: "line5" in out.getvalue())
+    assert out.getvalue().startswith("line3\nline4\nline5\n")  # last 3 first
+
+    _REAL_SLEEP(0.05)  # let the follow loop seek to EOF after the dump
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write("line6\n")
+        fh.flush()
+
+    assert _wait_until(lambda: "line6" in out.getvalue())
+    stop.set()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    assert "exc" not in captured
+
+
+def test_logs_follow_across_rotation(
+    log_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The load-bearing AC-11 test: the follow loop must re-open by name when the
+    # inode changes under it (chirpd.log → chirpd.log.1 + fresh chirpd.log).
+    log_path.write_text("a1\na2\na3\n", encoding="utf-8")
+    stop = threading.Event()
+    _patch_stoppable_sleep(monkeypatch, stop)
+    out = io.StringIO()
+    monkeypatch.setattr(daemon_module.sys, "stdout", out)
+
+    thread, captured = _run_in_thread(
+        lambda: daemon_module._follow_log_file(log_path, start_at_end=True)
+    )
+    _REAL_SLEEP(0.05)  # let the loop seek to EOF
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write("a4\n")
+        fh.flush()
+    assert _wait_until(lambda: "a4" in out.getvalue())
+
+    rotated = log_path.with_name(log_path.name + ".1")
+    log_path.rename(rotated)
+    log_path.write_text("b1\n", encoding="utf-8")
+
+    assert _wait_until(lambda: "b1" in out.getvalue())
+    stop.set()
+    thread.join(timeout=2.0)
+
+    assert not thread.is_alive()
+    assert "exc" not in captured
+
+
+def test_logs_ctrl_c_exits_cleanly(
+    log_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_path.write_text("x\n", encoding="utf-8")
+
+    def raise_keyboard_interrupt(_seconds: float) -> None:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(daemon_module.time, "sleep", raise_keyboard_interrupt)
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs", "-f"])
+
+    assert result.exit_code == 0
+    assert "Traceback" not in result.stdout
+
+
+# --- exit codes (AC-14) -----------------------------------------------------
+
+
+def test_logs_ioerror_exits_1(log_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    log_path.write_text("x\n", encoding="utf-8")
+
+    def boom(_path: Path) -> None:
+        raise OSError("disk error")
+
+    monkeypatch.setattr(daemon_module, "_cat_log_file", boom)
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs"])
+
+    assert result.exit_code == 1
+    assert "couldn't read log file" in result.stderr
+
+
+def test_logs_follow_ioerror_exits_1(log_path: Path) -> None:
+    # A path that exists but cannot be opened for reading (a directory) makes the
+    # follow loop's open() raise OSError — it must surface as the friendly exit-1
+    # message, not an uncaught traceback.
+    log_path.mkdir()
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs", "-f"])
+
+    assert result.exit_code == 1
+    assert "couldn't read log file" in result.stderr
+
+
+def test_logs_negative_n_is_usage_error(log_path: Path) -> None:
+    # AC-14: negative -n is a Typer usage error (exit 2), not a crash.
+    log_path.write_text("a\nb\nc\n", encoding="utf-8")
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs", "-n", "-5"])
+
+    assert result.exit_code == 2
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+# --- diagnostic logging (AC-13) ---------------------------------------------
+
+
+def test_logs_emits_diagnostic_log_event(
+    log_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_path.write_text("hi\n", encoding="utf-8")
+    log_mock = MagicMock()
+    monkeypatch.setattr(daemon_module, "log_op_event", log_mock)
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs"])
+
+    assert result.exit_code == 0
+    assert log_mock.call_count == 1
+    _, kwargs = log_mock.call_args
+    assert kwargs["op"] == "daemon_logs"
+    assert kwargs["result"] == "cat"
+    assert kwargs["duration_ms"] == 0
+
+
+def test_logs_diagnostic_result_missing_when_no_file(
+    log_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    log_mock = MagicMock()
+    monkeypatch.setattr(daemon_module, "log_op_event", log_mock)
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs"])
+
+    assert result.exit_code == 0
+    assert log_mock.call_args.kwargs["result"] == "missing"
+
+
+# --- help discipline (AC-10, AC-15) -----------------------------------------
+
+
+def test_logs_help_text(monkeypatch: pytest.MonkeyPatch) -> None:
+    result = runner.invoke(daemon_module.daemon_app, ["logs", "--help"])
+
+    help_text = _ANSI_RE.sub("", result.stdout)
+    assert result.exit_code == 0
+    assert "--follow" in help_text
+    assert "--lines" in help_text
+    assert "Tail with -f" in help_text
+    assert "json" not in help_text.lower()  # AC-10: no JSON mention

--- a/tests/llm/test_cli_daemon_logs.py
+++ b/tests/llm/test_cli_daemon_logs.py
@@ -86,7 +86,9 @@ def _run_in_thread(
     def run() -> None:
         try:
             target()
-        except BaseException as exc:  # noqa: BLE001 — surfaced to the assertion
+        except (KeyboardInterrupt, SystemExit, GeneratorExit):
+            raise
+        except Exception as exc:  # noqa: BLE001 — surfaced to the assertion
             captured["exc"] = exc
 
     thread = threading.Thread(target=run, daemon=True)
@@ -353,6 +355,21 @@ def test_logs_diagnostic_result_missing_when_no_file(
     result = runner.invoke(daemon_module.daemon_app, ["logs"])
 
     assert result.exit_code == 0
+    assert log_mock.call_args.kwargs["result"] == "missing"
+
+
+def test_logs_diagnostic_result_missing_when_no_file_with_n(
+    log_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # -n on a machine that has not produced a log yet prints the notice and never
+    # tails, so the diagnostic must say "missing", not "tail".
+    log_mock = MagicMock()
+    monkeypatch.setattr(daemon_module, "log_op_event", log_mock)
+
+    result = runner.invoke(daemon_module.daemon_app, ["logs", "-n", "10"])
+
+    assert result.exit_code == 0
+    assert "no log file" in result.stderr
     assert log_mock.call_args.kwargs["result"] == "missing"
 
 


### PR DESCRIPTION
## Summary

Implements **story 5.5** — the reader-side `chirp daemon logs` command on `daemon_app` (FR45). Diagnostic-tail UX so a user hitting "Run \`chirp daemon logs\` for details" can read the daemon log without learning \`tail -f\` or knowing where the log lives.

- **Default (no flags)** — cats the log file to stdout, byte-for-byte, streaming (AC-3).
- **`-n N`** — last N lines via a bounded `deque(maxlen=N)` (AC-4). Negative `-n` is a Typer exit-2 usage error (AC-14).
- **`-f` / `--follow`** — follows new output, re-opening **by name** across rotation (`chirpd.log` → `chirpd.log.1` + fresh file) via inode-change detection — `tail -F` semantics, not naive `tail -f` (AC-5, AC-11).
- **`-n N -f`** — dumps the last N, then follows from EOF (AC-6).
- **Ctrl-C** exits 0, not 130 (AC-7). **Missing file** prints an informational notice (exit 0) or, under `-f`, waits for the file to appear (AC-8). **IOErrors** surface `couldn't read log file: <err>` at exit 1 (AC-14).
- **No `--json`** (AC-10); stdout stays clean for `| grep` / `| awk` (AC-9). Diagnostic logfmt line emitted at command start (`op=daemon_logs`, AC-13).

Also adds **`chirpd.logging_setup.resolve_log_path()`** as the single source of truth for the log location, shared by the writer (`configure_logging`) and this reader — no duplicated path string (AC-2).

## Tests

New `tests/llm/test_cli_daemon_logs.py` (17 tests, AC-2…AC-15), including the load-bearing rotation test (AC-11) which renames the log, writes a fresh one, and asserts the follow loop picks up the post-rotation line through the inode-change path. The follow-loop tests run on a background thread, observe a patched stdout live, and stop via a `time.sleep`-delivered `KeyboardInterrupt` (the same exit path real `^C` takes).

- `uv run pytest tests/llm/test_cli_daemon.py tests/llm/test_cli_daemon_logs.py tests/chirpd/test_logging_setup.py` → 123 passed
- `uv run ruff check .` clean · `uv run mypy llm/cli/daemon.py chirpd/logging_setup.py` clean

## Review

Ran an adversarial review loop (2 rounds → CLEAN):
- **Round 1** fixed: negative `-n` was an uncaught `ValueError`/exit 1 → now Typer exit-2 via `min=1`; follow-mode `OSError` (and the `-n -f` dump) now surface the friendly exit-1 message; rotation re-open catches `OSError` to retry rather than crash. Tests added for both.
- **Round 2** → CLEAN. Documented the accepted dump→follow micro-race in `-n -f` mode (shared with `tail -n N -f`).

## Not run

Manual smoke tests (story task 8) require a live `chirpd` and a real ~11 MB forced rotation on disk — not run here; the rotation contract is pinned by the AC-11 automated test.

Handoff: `daemon_app` now hosts seven commands; story 5.6 wires it into `chirp/cli.py` as a hidden subgroup.