### PR TITLE
feat(cli): register hidden chirp daemon subapp (story 5.6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Chirp is a Typer-based CLI in `chirp/cli.py`. Runtime domains live in sibling pa
 
 ## Coding Style & Naming Conventions
 **Formatting:** Ruff enforces 88-char lines, double quotes, and import sorting. Use absolute imports and keep stdlib / third-party / first-party groups clean.
-**Naming:** Public CLI commands are `record`, `transcribe`, `notes`, `ask`, `search`, `init`, and `about`. Hidden maintenance commands such as `config`, `devices`, and `index` exist, but they are not the primary user workflow.
+**Naming:** Public CLI commands are `record`, `transcribe`, `notes`, `ask`, `search`, `init`, and `about`. Hidden maintenance commands such as `config`, `devices`, `index`, and `daemon` exist, but they are not the primary user workflow.
 **Types:** Add type hints where practical; mypy checks `chirp`, `config`, `notes`, `notes_chat`, `recorder`, `transcriber`, and `utils`.
 **Errors:** Prefer domain exceptions from `chirp.exceptions` and user-facing messages that explain the next recovery step.
 **Comments:** Keep them rare; prefer clearer names and smaller helpers over explanatory comments.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,4 +17,4 @@ Use `AGENTS.md` as the canonical contributor guide for this repository.
 ## Current CLI Surface
 
 - Visible commands: `record`, `transcribe`, `notes`, `ask`, `search`, `init`, `about`
-- Hidden maintenance commands: `config`, `devices`, `index`
+- Hidden maintenance commands: `config`, `devices`, `index`, `daemon`

--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.6-typer-registration.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.6-typer-registration.md
@@ -1,6 +1,6 @@
 # Story 5.6 — Hidden Typer registration in `chirp/cli.py`
 
-- **Status:** Review
+- **Status:** done
 - **Epic:** [EPIC-DAEMON-LIFECYCLE](../epic.md)
 - **Depends on:** 5.2, 5.3, 5.4, 5.5 (all seven subcommands must be real and tested before they're surfaced behind `chirp daemon ...`)
 - **Blocks:** —
@@ -178,6 +178,7 @@ This is intentionally a small, contained story — one Typer-registration line i
 ### Change Log
 
 - 2026-06-05 — Wired `daemon_app` into `chirp/cli.py` as a hidden subapp; updated `CLAUDE.md`/`AGENTS.md` surface lists; added top-level dispatch tests. Status: Draft → Review.
+- 2026-06-05 — Review loop clean (1 round). Opened PR #82. Addressed CodeQL/code-quality mixed-import findings by unifying `tests/test_cli_commands.py` to a single `import chirp.cli` style. CI green; all review threads resolved. Status: Review → done.
 
 ## Wrap-up
 

--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.6-typer-registration.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.6-typer-registration.md
@@ -1,6 +1,6 @@
 # Story 5.6 — Hidden Typer registration in `chirp/cli.py`
 
-- **Status:** Draft
+- **Status:** Review
 - **Epic:** [EPIC-DAEMON-LIFECYCLE](../epic.md)
 - **Depends on:** 5.2, 5.3, 5.4, 5.5 (all seven subcommands must be real and tested before they're surfaced behind `chirp daemon ...`)
 - **Blocks:** —
@@ -138,6 +138,46 @@ This is intentionally a small, contained story — one Typer-registration line i
 - **Unit:** the AC-8 tests. ~5 cases.
 - **Manual:** the AC-11 / implementation-task-4 checklist. Confirms the user-facing UX.
 - **Coverage:** `chirp/cli.py` is a thin dispatch file. Coverage doesn't measurably move from this story.
+
+## Dev Agent Record
+
+### Tasks
+
+- [x] 1. Add the import and registration in `chirp/cli.py` (AC-1).
+- [x] 2. Confirm the existing hidden-command pattern and match it (AC-1, AC-2).
+- [x] 3. Update `CLAUDE.md` (and `AGENTS.md` surface line) per AC-9.
+- [x] 4. Run the manual `--help` smoke checklist (AC-2, AC-3, AC-4, AC-11).
+- [x] 5. Add the AC-8 tests and confirm the visible surface is unchanged (AC-6, AC-8).
+- [x] 6. Validate doc updates against live CLI help (AGENTS.md rule).
+
+### Completion Notes
+
+- **AC-1** `daemon_app` registered via `app.add_typer(..., name="daemon", hidden=True)` in `chirp/cli.py`, alongside the other subapp registrations. The existing hidden commands `config`/`devices`/`index` are flat `@app.command(hidden=True)` commands; `daemon` is correctly a hidden *group* (`add_typer`), so it shares the hidden tier without crowding the flat completions. A short comment documents the hidden-maintenance intent.
+- **AC-2 / AC-6** `chirp --help` Commands panel shows exactly the 7 visible commands; `daemon`, `config`, `devices`, `index` are all absent. Verified live and asserted by `test_visible_commands_unchanged`.
+- **AC-3 / AC-4 / AC-11** `chirp daemon --help` lists all seven subcommands with their story-5.2–5.5 docstrings (unchanged). All seven `chirp daemon <sub> --help` invocations render cleanly. The summaries read well in the grouped listing — no docstring edits needed.
+- **AC-5 (confirmed, no wrapper added — see divergence note).** There is no "outer Typer wrapper": the entry point is `chirp.cli:app` directly (`pyproject` `[project.scripts]`). Each daemon command catches its own typed exceptions inside the command body with the correct exit codes — `status`: `LLMDaemonUnreachable`→3, `LLMError`→1; `start`/`stop`/`restart`: own operational codes; `enable`/`disable`: `LaunchAgentError`/subclasses→1, idempotent `disable`→0. No typed exception escapes a command body, so the hypothetical backstop never fires. Building a brand-new global exception wrapper would change the behaviour of every command (record/ask/etc.) and is out of scope for this one-line wire-up story; the per-command mapping already satisfies the PRD §Scripting Support exit-code contract for the daemon surface. The AC-3 example's `LLMModelError`→4 case does not arise from the daemon read ops (`health`/`model.status`); exit-4 mapping lives where generation/load runs in `llm/cli/models.py`.
+- **AC-7 (confirmed).** The top-level app sets `add_completion=False`, so `--install-completion` is intentionally disabled app-wide (a pre-existing decision, untouched here). Once a user types `chirp daemon`, subcommand resolution works (Typer default); hidden groups are not auto-suggested, which is the desired behaviour. No completion code is added or changed by this story.
+- **AC-8** Five tests added to `tests/test_cli_commands.py::TestDaemonRegistration` (top-level dispatch), complementing the existing subapp-level suites.
+- **AC-9** `CLAUDE.md` "Current CLI Surface" and the `AGENTS.md` hidden-command prose both updated to include `daemon`.
+- **AC-10** `uv run pytest` over the daemon-lifecycle surface (185 tests) passes; `uv run ruff check .` clean; `uv run mypy chirp llm chirpd` clean; full suite (1366 tests) collects with no import breakage.
+
+### Divergence notes (story spec vs. live codebase)
+
+- **Test file naming.** The story names `tests/test_cli.py`; that file does not exist. Top-level CLI tests live in `tests/test_cli_commands.py`, so the AC-8 tests were added there (and `tests/test_cli_startup.py` covers import-lightness). There were no pre-existing `config`/`devices`/`index` hidden-command tests to mirror — the new `TestDaemonRegistration` class establishes the pattern.
+- **AC-10 file list.** Mapped the story's `tests/test_cli.py` → `tests/test_cli_commands.py` and additionally ran `tests/llm/test_cli_daemon_logs.py` (story 5.5's suite, omitted from the story's command line).
+- **AC-5 "outer wrapper".** No such wrapper exists; resolved by confirming the per-command catches rather than introducing new global error-handling surface (see Completion Notes).
+
+### File List
+
+- `chirp/cli.py` — modified: import `daemon_app`; register it as a hidden Typer subapp.
+- `CLAUDE.md` — modified: add `daemon` to the hidden maintenance commands list.
+- `AGENTS.md` — modified: add `daemon` to the hidden-command prose line.
+- `tests/test_cli_commands.py` — modified: add `TestDaemonRegistration` (5 AC-8 tests).
+- `_bmad-output/planning-artifacts/epic-daemon-lifecycle/stories/5.6-typer-registration.md` — modified: status, Dev Agent Record.
+
+### Change Log
+
+- 2026-06-05 — Wired `daemon_app` into `chirp/cli.py` as a hidden subapp; updated `CLAUDE.md`/`AGENTS.md` surface lists; added top-level dispatch tests. Status: Draft → Review.
 
 ## Wrap-up
 

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -18,6 +18,7 @@ from typer.core import TyperGroup
 import audio_capture
 from chirp.exceptions import AudioDeviceError, ConfigurationError, RecordingError
 from config.settings import ChirpSettings, get_settings
+from llm.cli.daemon import daemon_app
 from llm.cli.models import app as models_app
 from utils.file_utils import NoteRecord, list_notes
 
@@ -528,6 +529,16 @@ notes_app = typer.Typer(help="Browse, view, edit, or delete your notes")
 app.add_typer(notes_app, name="notes", rich_help_panel=MAIN_PANEL)
 
 app.add_typer(models_app, name="models", rich_help_panel=MODELS_PANEL)
+
+# Hidden maintenance group: happy-path users never need the daemon, so it stays
+# out of `chirp --help` and is surfaced only via `chirp daemon --help`. Mirrors
+# the hidden flat commands `config`, `devices`, and `index` defined below.
+app.add_typer(
+    daemon_app,
+    name="daemon",
+    help="Daemon lifecycle and diagnostics (hidden).",
+    hidden=True,
+)
 
 
 class NoteNotFound(Exception):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -439,6 +439,94 @@ class TestNotesDelete:
         assert (tmp_path / "safe-2026-04-20").exists()
 
 
+class TestDaemonRegistration:
+    """Story 5.6: the daemon subapp is wired in hidden and dispatches end-to-end.
+
+    These exercise the *top-level* ``chirp`` app, complementing
+    ``tests/llm/test_cli_daemon*.py`` which drive the subapp directly.
+    """
+
+    _SUBCOMMANDS = ("status", "start", "stop", "restart", "enable", "disable", "logs")
+
+    def test_daemon_subapp_is_hidden_in_top_help(self):
+        from typer.testing import CliRunner
+
+        import chirp.cli
+
+        result = CliRunner().invoke(chirp.cli.app, ["--help"])
+        assert result.exit_code == 0
+        assert "daemon" not in result.stdout
+
+    def test_visible_commands_unchanged(self):
+        from typer.testing import CliRunner
+
+        import chirp.cli
+
+        result = CliRunner().invoke(chirp.cli.app, ["--help"])
+        assert result.exit_code == 0
+        for command in chirp.cli.VISIBLE_COMMAND_ORDER:
+            assert command in result.stdout
+        for hidden in ("daemon", "config", "devices", "index"):
+            assert hidden not in result.stdout
+
+    def test_daemon_subapp_help_lists_all_seven_subcommands(self):
+        from typer.testing import CliRunner
+
+        import chirp.cli
+
+        result = CliRunner().invoke(chirp.cli.app, ["daemon", "--help"])
+        assert result.exit_code == 0
+        for subcommand in self._SUBCOMMANDS:
+            assert subcommand in result.stdout
+
+    def test_chirp_daemon_status_dispatch(self, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from typer.testing import CliRunner
+
+        import chirp.cli
+        from llm.cli import daemon as daemon_module
+
+        client = MagicMock()
+        client.daemon_lazy_spawned = False
+        client.daemon_respawned = False
+        client.health_sync.return_value = {
+            "status": "ok",
+            "uptime_seconds": 12.0,
+            "version": "0.7.0",
+        }
+        client.model_status_sync.return_value = {
+            "pid": 4242,
+            "rss_bytes": 1024,
+            "last_request_at": None,
+            "models": [],
+        }
+        monkeypatch.setattr(daemon_module, "configure_logging", MagicMock())
+        monkeypatch.setattr(daemon_module, "LLMClient", MagicMock(return_value=client))
+
+        result = CliRunner().invoke(chirp.cli.app, ["daemon", "status"])
+        assert result.exit_code == 0
+        assert '"running": true' in result.stdout
+
+    def test_chirp_daemon_logs_dispatch(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+
+        from typer.testing import CliRunner
+
+        import chirp.cli
+        from llm.cli import daemon as daemon_module
+
+        log_file = tmp_path / "chirpd.log"
+        log_file.write_text("first line\nsecond line\n", encoding="utf-8")
+        monkeypatch.setattr(daemon_module, "configure_logging", MagicMock())
+        monkeypatch.setattr(daemon_module, "resolve_log_path", lambda *a, **k: log_file)
+
+        result = CliRunner().invoke(chirp.cli.app, ["daemon", "logs"])
+        assert result.exit_code == 0
+        assert "first line" in result.stdout
+        assert "second line" in result.stdout
+
+
 class TestNotesReviewPatches:
     def _runner(self, tmp_path, monkeypatch):
         from typer.testing import CliRunner

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -341,29 +341,29 @@ class TestNotesResolveAndTagFilter:
         assert "matches 2 notes" in result.stdout
 
     def test_resolve_full_id(self, tmp_path, monkeypatch):
-        from chirp.cli import _resolve_note
+        import chirp.cli
         from utils.file_utils import list_notes
 
         _write_note(tmp_path, "alpha-2026-04-20", "Alpha", "x")
         _write_note(tmp_path, "beta-2026-04-21", "Beta", "x")
         records = [r for r in list_notes(tmp_path) if r.notes is not None]
 
-        record = _resolve_note(records, "alpha-2026-04-20")
+        record = chirp.cli._resolve_note(records, "alpha-2026-04-20")
         assert record.slug == "alpha-2026-04-20"
 
     def test_resolve_unique_prefix(self, tmp_path, monkeypatch):
-        from chirp.cli import _resolve_note
+        import chirp.cli
         from utils.file_utils import list_notes
 
         _write_note(tmp_path, "alpha-2026-04-20", "Alpha", "x")
         _write_note(tmp_path, "beta-2026-04-21", "Beta", "x")
         records = [r for r in list_notes(tmp_path) if r.notes is not None]
 
-        record = _resolve_note(records, "alpha")
+        record = chirp.cli._resolve_note(records, "alpha")
         assert record.slug == "alpha-2026-04-20"
 
     def test_resolve_integer_id_uses_newest_first(self, tmp_path, monkeypatch):
-        from chirp.cli import NoteNotFound, _resolve_note
+        import chirp.cli
         from utils.file_utils import list_notes
 
         # `list_notes` sorts oldest-first; the newest-first index 1 should
@@ -394,11 +394,11 @@ class TestNotesResolveAndTagFilter:
             )
         records = [r for r in list_notes(tmp_path) if r.notes is not None]
 
-        assert _resolve_note(records, "1").slug == "newer"
-        assert _resolve_note(records, "2").slug == "older"
+        assert chirp.cli._resolve_note(records, "1").slug == "newer"
+        assert chirp.cli._resolve_note(records, "2").slug == "older"
 
-        with pytest.raises(NoteNotFound):
-            _resolve_note(records, "99")
+        with pytest.raises(chirp.cli.NoteNotFound):
+            chirp.cli._resolve_note(records, "99")
 
 
 class TestNotesDelete:


### PR DESCRIPTION
## Summary

Final wire-up story for **EPIC-DAEMON-LIFECYCLE**. Registers `daemon_app` (built across stories 5.2–5.5 in `llm/cli/daemon.py`) into the top-level CLI as a **hidden** Typer subapp, so `chirp daemon <subcommand>` is reachable at the shell while `daemon` stays out of `chirp --help`. Until now the subapp was only reachable via `CliRunner`/`python -m`.

- `chirp/cli.py` — import `daemon_app` + `app.add_typer(daemon_app, name="daemon", hidden=True, ...)`, alongside the other subapp registrations.
- `tests/test_cli_commands.py` — new `TestDaemonRegistration` (5 tests): hidden-in-top-help, visible-surface-unchanged, group lists all seven subcommands, plus top-level `status`/`logs` dispatch smoke tests.
- `CLAUDE.md` / `AGENTS.md` — add `daemon` to the hidden maintenance command lists.

## Acceptance criteria

All AC-1 … AC-11 satisfied. Verified live:
- `chirp --help` → exactly the 7 visible commands; `daemon`/`config`/`devices`/`index` absent (AC-2/AC-6).
- `chirp daemon --help` → all 7 subcommands with their 5.2–5.5 docstrings (AC-3); each `chirp daemon <sub> --help` renders (AC-4/AC-11).
- Module-level daemon import stays light — no `pyaudio`/`faster_whisper`/`chromadb`/`torch` pulled (`test_cli_startup.py` guard green).

### Documented divergences (story spec vs. live code)
- **AC-5** references an "outer Typer wrapper" that does not exist (entry point is `chirp.cli:app` directly). Each daemon command already maps its typed exceptions to exit codes inside the body (status→3/1, start/stop/restart→operational, enable/disable→1/idempotent-0); nothing escapes, so no global wrapper was added (out of scope for a wire-up, would alter every command). Confirmed rather than built.
- The story named `tests/test_cli.py` (nonexistent); tests were added to the real `tests/test_cli_commands.py`.

Both are recorded in the story's Dev Agent Record → Divergence notes.

## Testing
- `uv run pytest` over the daemon-lifecycle surface: **185 passed**; full suite **1366 collected, no import breakage**.
- `uv run ruff check .` clean; `uv run mypy chirp llm chirpd` clean.

## Review
Adversarial BMAD review loop: **1 round, verdict CLEAN** — no must-fix/should-fix findings; 2 nice-to-haves consciously skipped (one matches AC-1's prescribed code; one is the disclosed AC-10 file-name divergence).