### PR TITLE
feat(notes): route note generation through chirpd via llm.client (story 6.2)

### DIFF
--- a/_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.1-regression-corpus-capture.md
+++ b/_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.1-regression-corpus-capture.md
@@ -1,6 +1,6 @@
 # Story 6.1 — Regression corpus capture (precondition gate)
 
-- **Status:** Review
+- **Status:** Done
 - **Epic:** [EPIC-INTEGRATION-CUTOVER](../epic.md)
 - **Depends on:** —
 - **Blocks:** 6.2, 6.3, 6.4, 6.5, 6.6

--- a/_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.2-note-generator-cutover.md
+++ b/_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.2-note-generator-cutover.md
@@ -1,6 +1,6 @@
 # Story 6.2 — Cut over `notes/note_generator.py` to `llm.client`
 
-- **Status:** Draft
+- **Status:** Review
 - **Epic:** [EPIC-INTEGRATION-CUTOVER](../epic.md)
 - **Depends on:** 6.1 (regression corpus committed); EPIC-CHIRPD-CORE 3.6 (`client.chat` streaming + non-streaming surface available); EPIC-CHIRPD-CORE 3.4 (`llm.client` with lazy-spawn + version-mismatch handling); EPIC-MODEL-REGISTRY (a chat model registered as `default_chat` so the daemon can resolve `"default"`)
 - **Blocks:** 6.5 (fixture migration), 6.6 (regression run)
@@ -93,3 +93,82 @@ The Ollama path produces a single prompt string. The `chirp.llm` client takes a 
 - **Unit:** any existing `tests/notes/test_note_generator.py` cases that exercise the note-generation flow pass after the cutover. If they relied on patching `requests.post`, replace with patching `client.chat` for this story (transitional fixture; final fixture pattern lands in 6.5).
 - **Integration (manual):** end-to-end `chirp transcribe` on a recording from the regression corpus. The output `notes.md` parses as expected (front-matter present, sections present, no XML-tag bleed-through). Compare informally to the `notes_before.md` for the same slug — large differences are expected (different model class), but the structural shape should match.
 - **Negative path (manual):** stop `chirpd` (e.g., `pkill -f chirpd`) and run `chirp transcribe`. Expect a clear error from the client's `LLMDaemonUnreachable` (or the broader `LLMTransportError`), surfaced through the existing best-effort `except Exception` to a `notes.md` not generated for that record + a debug log entry. The CLI exits with the existing failure code for `notes/__init__.py`'s wrapper command. Then restart the daemon and re-run; the transcribe completes.
+
+## Dev Agent Record
+
+### Contract verification (real `llm.client` vs. story assumptions)
+
+Per the project pattern that cutover stories drift from the real CHIRPD-CORE
+contract, the `llm.client` API was verified against source before coding. Several
+story assumptions were stale; the story instructs to "match exactly what the
+client module exposes," so the implementation follows reality (and the already-
+shipped precedent in `notes_chat/prompting.py`):
+
+- **Client shape.** No module-level `client` singleton and no `client.chat(...,
+  stream=True)` returning deltas with `.text`. Reality: `LLMClient` is an async
+  class with sync wrappers. Note generation is synchronous, so `_call_llm` uses
+  `LLMClient().chat_stream_sync(messages, model="default", options=...)`, which
+  yields **plain `str`** token deltas (not objects). This mirrors
+  `notes_chat/prompting.py` exactly. The client is injectable via a new optional
+  `NoteGenerator(..., llm_client=...)` param for testing.
+- **Options / sampling (decision: max_tokens only).** The daemon splats `options`
+  straight into `mlx_lm.stream_generate(**options)`, which only honours
+  `max_tokens`; `temperature`/`top_p` are sampler-configured and would be dropped
+  (or error in `generate_step`). The shipped precedent passes **no** options.
+  Decision (confirmed with story owner): pass `options={"max_tokens":
+  settings.models.num_predict}` to preserve the 4096-token budget (mlx default is
+  256 — would truncate notes), and **omit** `temperature`/`top_p`. This is a
+  deliberate deviation from AC-2/AC-9's literal `temperature=0.3`/`top_p=0.9`.
+
+### AC deviations (all documented, none silent)
+
+- **AC-2 / AC-9 (temperature/top_p):** not sent (see above). The AC-9 test asserts
+  `options == {"max_tokens": 4096}` and that temp/top_p are absent.
+- **AC-7 (`num_predict` literal):** `notes/note_generator.py` still reads
+  `self.settings.models.num_predict` to build the `max_tokens` budget — required by
+  AC-4 ("pass the old `num_predict` value as `max_tokens`") and AC-9 ("`max_tokens`
+  equal to `settings.models.num_predict`"), and AC-4 explicitly keeps the settings
+  field. AC-7's grep is therefore read as "no Ollama call mechanics" (HTTP, option
+  keys, `ollama_url`) rather than a literal ban on the settings field. All of
+  `ollama`, `requests.`, `/api/generate`, `ollama_url` return zero matches; only the
+  sanctioned `num_predict` budget read remains.
+- **AC-8 fixture:** removed the obsolete `test_call_ollama_success` (it tested the
+  deleted `_call_ollama` + `requests.post`) and the dead `_make_streaming_response`
+  helper; the new tests mock at the `LLMClient` boundary via constructor injection.
+
+### Completion Notes
+
+- `notes/note_generator.py`: removed `import requests`; added `from llm.client
+  import LLMClient`; added injectable `llm_client` param; replaced `_call_ollama`
+  with `_call_llm` (streams via `chat_stream_sync`, same `↳ Generating…/Generated
+  N chunks` progress UX, joins+strips). `_generate_structured_notes` now calls
+  `_call_llm`. `SYSTEM_PROMPT`, prompt assembly, `_parse_xml_response`,
+  `_parse_fallback_response`, template render, and `_update_meta` untouched (AC-6).
+- Gates: `make test` 1400 passed; `make check` green. Coverage on the module is
+  preserved (the LLM path is still directly tested).
+- **AC-11 (manual smoke) — NOT yet run:** no `~/.chirp/models.toml` exists, so no
+  `default_chat` MLX model is registered. The operator must `chirp models add
+  <chat-repo>` + set it as `default_chat`, ensure `chirpd` is reachable, then run
+  `chirp transcribe` on a corpus recording and confirm `notes.md` shape + the
+  negative path (`pkill -f chirpd` → clean `LLMDaemonUnreachable`). Left for
+  operator verification before merge.
+
+### File List
+
+- `notes/note_generator.py` (modified — Ollama HTTP → `llm.client` cutover)
+- `tests/test_note_generator_llm_call.py` (new — AC-9 call-shape/return/error tests)
+- `tests/test_note_generator.py` (modified — dropped obsolete `_call_ollama` test +
+  dead streaming-response helper)
+- `_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.1-regression-corpus-capture.md`
+  (modified — Status → Done)
+- `_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.2-note-generator-cutover.md`
+  (this story file — Status, Dev Agent Record)
+
+### Change Log
+
+- 2026-06-09: Cut `notes/note_generator.py` note generation over from the Ollama
+  HTTP API to `llm.client` (`chat_stream_sync`, `model="default"`,
+  `max_tokens`-only options). Verified the real client contract first and
+  documented three AC deviations (temp/top_p omitted; `num_predict` field read
+  retained; obsolete Ollama test removed). `make test` 1400 / `make check` green.
+  AC-11 manual smoke pending a registered `default_chat` MLX model. Status → Review.

--- a/_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.2-note-generator-cutover.md
+++ b/_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.2-note-generator-cutover.md
@@ -44,7 +44,7 @@ The Ollama path produces a single prompt string. The `chirp.llm` client takes a 
 - **AC-4** `self.settings.models.ollama_url` and `self.settings.models.num_predict` are **no longer read** inside `_call_llm`. The old `num_predict` value is passed through as `max_tokens` in the `options` dict on `client.chat` — this preserves the existing "how many tokens may we generate" budget. `ollama_url` simply has no equivalent and is dropped. (The Pydantic settings fields `ollama_url` and `num_predict` are not removed by this story — they may still be read by other modules; the field cleanup is owned by EPIC-INIT-AND-MIGRATION.)
 - **AC-5** Exception handling mirrors the existing best-effort posture. The outer `try/except Exception` in `_generate_structured_notes` (current L348–353) is preserved: any `LLMError` (transport / protocol / model) raised by `client.chat` propagates up and is caught the same way `requests`-level errors were caught today. The downstream behavior (log at debug, return `None`, write nothing to disk for that record) is unchanged. No new user-facing prompts or recovery paths are added in this story.
 - **AC-6** XML parsing (`_parse_xml_response`, `_parse_fallback_response`) is untouched. The `SYSTEM_PROMPT` constant is untouched. The template engine call (`self.template_engine.render_meeting_section(...)`) is untouched. The `_update_meta` method is untouched (`whisper_model` and `llm_model` fields in `meta.toml` still record what the settings layer reports; the value of `settings.models.llm` is now an alias-into-`models.toml` rather than an Ollama tag — that semantic shift is invisible to this module).
-- **AC-7** `rg -n "ollama|requests\.|/api/generate|num_predict|ollama_url" notes/note_generator.py` returns zero matches.
+- **AC-7** `rg -n "ollama|requests\.|/api/generate|ollama_url" notes/note_generator.py` returns zero matches. (Corrected: `num_predict` was removed from the banned pattern because AC-4 and AC-9 explicitly require reading `settings.models.num_predict` to build the `max_tokens` budget — the original AC-7 contradicted them. The intent is "no Ollama HTTP/option-key mechanics," which holds.)
 - **AC-8** Existing tests under `tests/notes/` that exercise note generation pass after the cutover, with their fixtures temporarily continuing to mock at the `notes/note_generator.NoteGenerator._call_llm` boundary (or at `llm.client.chat`, implementer's choice — whichever is the smaller diff). Full fixture migration to `FakeBackend` is owned by story 6.5; this story commits a working state but does not need to write the canonical fixture pattern.
 - **AC-9** A new unit test `tests/notes/test_note_generator_llm_call.py` (or an addition to an existing `test_note_generator.py`) asserts:
   - `_call_llm` calls `client.chat` with `model="default"`, with `messages` containing a single user-role entry whose `content` starts with the `SYSTEM_PROMPT` constant.
@@ -111,27 +111,31 @@ shipped precedent in `notes_chat/prompting.py`):
   yields **plain `str`** token deltas (not objects). This mirrors
   `notes_chat/prompting.py` exactly. The client is injectable via a new optional
   `NoteGenerator(..., llm_client=...)` param for testing.
-- **Options / sampling (decision: max_tokens only).** The daemon splats `options`
-  straight into `mlx_lm.stream_generate(**options)`, which only honours
-  `max_tokens`; `temperature`/`top_p` are sampler-configured and would be dropped
-  (or error in `generate_step`). The shipped precedent passes **no** options.
+- **Options / sampling (decision: max_tokens only).** Primary basis: the daemon
+  splats `options` straight into `mlx_lm.stream_generate(**options)`, whose only
+  honoured generation kwarg is `max_tokens` (verified: signature is
+  `(model, tokenizer, prompt, max_tokens=256, **kwargs)`; sampling is configured
+  via a `sampler` object, so `temperature`/`top_p` would be ignored or error in
+  `generate_step`). Supporting: the migrated client path in
+  `notes_chat/prompting.py` (L86/L104) passes no options. (Note: the `num_predict`
+  options at `prompting.py` L381/L467 are the *legacy Ollama `requests.post`* path —
+  still present pending story 6.4 — where `num_predict` is the correct Ollama key,
+  not the client path. Adversarial review H-2 conflated the two; verified false.)
   Decision (confirmed with story owner): pass `options={"max_tokens":
   settings.models.num_predict}` to preserve the 4096-token budget (mlx default is
-  256 — would truncate notes), and **omit** `temperature`/`top_p`. This is a
-  deliberate deviation from AC-2/AC-9's literal `temperature=0.3`/`top_p=0.9`.
+  256 — would truncate notes), and **omit** `temperature`/`top_p`. Deliberate
+  deviation from AC-2/AC-9's literal `temperature=0.3`/`top_p=0.9`.
 
 ### AC deviations (all documented, none silent)
 
 - **AC-2 / AC-9 (temperature/top_p):** not sent (see above). The AC-9 test asserts
   `options == {"max_tokens": 4096}` and that temp/top_p are absent.
-- **AC-7 (`num_predict` literal):** `notes/note_generator.py` still reads
-  `self.settings.models.num_predict` to build the `max_tokens` budget — required by
-  AC-4 ("pass the old `num_predict` value as `max_tokens`") and AC-9 ("`max_tokens`
-  equal to `settings.models.num_predict`"), and AC-4 explicitly keeps the settings
-  field. AC-7's grep is therefore read as "no Ollama call mechanics" (HTTP, option
-  keys, `ollama_url`) rather than a literal ban on the settings field. All of
-  `ollama`, `requests.`, `/api/generate`, `ollama_url` return zero matches; only the
-  sanctioned `num_predict` budget read remains.
+- **AC-7 (`num_predict` literal) — story defect, corrected:** AC-7's original grep
+  banned `num_predict`, but AC-4/AC-9 require reading `settings.models.num_predict`
+  for the `max_tokens` budget — a direct contradiction (flagged by adversarial
+  review H-1). Resolved by correcting AC-7 to drop `num_predict` from the banned
+  pattern (intent preserved: no Ollama HTTP/option-key mechanics). `ollama`,
+  `requests.`, `/api/generate`, `ollama_url` all return zero matches.
 - **AC-8 fixture:** removed the obsolete `test_call_ollama_success` (it tested the
   deleted `_call_ollama` + `requests.post`) and the dead `_make_streaming_response`
   helper; the new tests mock at the `LLMClient` boundary via constructor injection.
@@ -172,3 +176,11 @@ shipped precedent in `notes_chat/prompting.py`):
   documented three AC deviations (temp/top_p omitted; `num_predict` field read
   retained; obsolete Ollama test removed). `make test` 1400 / `make check` green.
   AC-11 manual smoke pending a registered `default_chat` MLX model. Status → Review.
+- 2026-06-09: Addressed adversarial + code review (PR #85). Corrected the AC-7
+  story defect (banned `num_predict` vs AC-4/AC-9 requiring it). Made the error
+  test fire mid-iteration like the real client + added a partial-stream-then-error
+  case and a progress-reprint (≥20 token) case; removed the stale `ollama_url`
+  fixture field; trimmed the `_call_llm` comment to the non-obvious "why". Rejected
+  review H-2 after verifying `prompting.py`'s `num_predict` options are the legacy
+  Ollama path, not the client path. `make test` / `make check` green; module
+  coverage 72% (up from 61%).

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -5,11 +5,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import requests
 import tomli_w
 from rich.console import Console
 
 from config.settings import ChirpSettings
+from llm.client import LLMClient
 from notes.constants import DEFAULT_MEETING_NAME
 from notes.template_engine import TemplateEngine
 from utils.file_utils import META_FILENAME, NOTES_FILENAME, NoteRecord, list_notes
@@ -137,11 +137,17 @@ Always produce notes using the canonical tags below. Never invent content.
 
 
 class NoteGenerator:
-    def __init__(self, settings: ChirpSettings, console: Console | None = None) -> None:
+    def __init__(
+        self,
+        settings: ChirpSettings,
+        console: Console | None = None,
+        llm_client: LLMClient | None = None,
+    ) -> None:
         self.settings = settings
         self.template_engine = TemplateEngine(settings)
         self.popup_manager = PopupManager()
         self.console = console if console is not None else Console()
+        self._llm_client = llm_client
 
     def generate_for_records(
         self,
@@ -346,59 +352,40 @@ Transcript:
 Return ONLY the XML document, no additional text before or after."""
 
         try:
-            response = self._call_ollama(prompt)
+            response = self._call_llm(prompt)
             return self._parse_xml_response(response)
         except Exception as exc:  # noqa: BLE001 - topic extraction is best-effort; many failure modes
             logger.debug("Topic extraction failed: %s", exc)
             return None
 
-    def _call_ollama(self, prompt: str) -> str:
-        url = f"{self.settings.models.ollama_url}/api/generate"
-        num_predict = self.settings.models.num_predict
+    def _call_llm(self, prompt: str) -> str:
+        # Route note generation through chirpd via llm.client instead of the
+        # Ollama HTTP API. The transcript is sent as a single user message so
+        # the model's chat template wraps the existing SYSTEM_PROMPT + prompt
+        # verbatim, preserving the regression-corpus "before" prompt shape.
+        messages = [{"role": "user", "content": prompt}]
+        options = {"max_tokens": self.settings.models.num_predict}
+        client = self._llm_client or LLMClient()
 
-        payload = {
-            "model": self.settings.models.llm,
-            "prompt": prompt,
-            "stream": True,
-            "options": {"temperature": 0.3, "top_p": 0.9, "num_predict": num_predict},
-        }
-
-        import json
-
-        full_response: list[str] = []
+        deltas: list[str] = []
         chunk_count = 0
 
-        with requests.post(url, json=payload, timeout=300, stream=True) as response:
-            response.raise_for_status()
-
-            for line in response.iter_lines():
-                if not line:
-                    continue
-                try:
-                    chunk = json.loads(line)
-                except json.JSONDecodeError:
+        for token in client.chat_stream_sync(
+            messages, model="default", options=options
+        ):
+            if token:
+                deltas.append(token)
+                chunk_count += 1
+                if chunk_count % 20 == 0:
                     self.console.print(
-                        "[yellow]  ↳ Warning: skipped malformed stream chunk[/yellow]"
+                        f"[dim]  ↳ Generating... ({chunk_count} chunks)[/dim]",
+                        end="\r",
                     )
-                    continue
-
-                token = chunk.get("response", "")
-                if token:
-                    full_response.append(token)
-                    chunk_count += 1
-                    if chunk_count % 20 == 0:
-                        self.console.print(
-                            f"[dim]  ↳ Generating... ({chunk_count} chunks)[/dim]",
-                            end="\r",
-                        )
-
-                if chunk.get("done", False):
-                    break
 
         if chunk_count > 0:
             self.console.print(f"[dim]  ↳ Generated {chunk_count} chunks[/dim]       ")
 
-        return "".join(full_response).strip()
+        return "".join(deltas).strip()
 
     def _parse_xml_response(self, response: str) -> dict[str, Any] | None:
         try:

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -364,7 +364,11 @@ Return ONLY the XML document, no additional text before or after."""
         # captured against (story 6.6 compares against it).
         messages = [{"role": "user", "content": prompt}]
         options = {"max_tokens": self.settings.models.num_predict}
-        client = self._llm_client or LLMClient()
+        # Reuse one client across records in a batch — LLMClient() resolves the
+        # socket path on construction, so per-record instantiation is wasteful.
+        if self._llm_client is None:
+            self._llm_client = LLMClient()
+        client = self._llm_client
 
         deltas: list[str] = []
         chunk_count = 0

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -359,10 +359,9 @@ Return ONLY the XML document, no additional text before or after."""
             return None
 
     def _call_llm(self, prompt: str) -> str:
-        # Route note generation through chirpd via llm.client instead of the
-        # Ollama HTTP API. The transcript is sent as a single user message so
-        # the model's chat template wraps the existing SYSTEM_PROMPT + prompt
-        # verbatim, preserving the regression-corpus "before" prompt shape.
+        # Single user message so the chat template wraps SYSTEM_PROMPT + prompt
+        # verbatim — preserving the prompt shape the 6.1 regression baseline was
+        # captured against (story 6.6 compares against it).
         messages = [{"role": "user", "content": prompt}]
         options = {"max_tokens": self.settings.models.num_predict}
         client = self._llm_client or LLMClient()

--- a/tests/test_note_generator.py
+++ b/tests/test_note_generator.py
@@ -9,23 +9,6 @@ from notes.note_generator import NoteGenerator
 from utils.file_utils import NoteRecord
 
 
-def _make_streaming_response(text: str):
-    import json
-
-    lines = []
-    for char in text:
-        lines.append(json.dumps({"response": char, "done": False}).encode())
-    lines.append(json.dumps({"response": "", "done": True}).encode())
-
-    mock_response = Mock()
-    mock_response.status_code = 200
-    mock_response.raise_for_status = Mock()
-    mock_response.iter_lines = Mock(return_value=iter(lines))
-    mock_response.__enter__ = Mock(return_value=mock_response)
-    mock_response.__exit__ = Mock(return_value=False)
-    return mock_response
-
-
 @pytest.fixture
 def mock_settings():
     settings = Mock()
@@ -156,24 +139,6 @@ class TestNoteGenerator:
             assert result["decisions"] == []
             assert result["open_questions"] == []
             assert len(result["discussion_highlights"]) == 1
-
-    def test_call_ollama_success(self, mock_settings):
-        with (
-            patch("notes.note_generator.TemplateEngine"),
-            patch("notes.note_generator.PopupManager"),
-            patch("notes.note_generator.requests.post") as mock_post,
-        ):
-            mock_post.return_value = _make_streaming_response("Test response")
-
-            generator = NoteGenerator(mock_settings)
-            result = generator._call_ollama("test prompt")
-
-            assert result == "Test response"
-            mock_post.assert_called_once()
-            call_kwargs = mock_post.call_args
-            assert call_kwargs[1]["timeout"] == 300
-            payload = call_kwargs[1]["json"]
-            assert payload["options"]["num_predict"] == 4096
 
     def test_generate_for_record_writes_notes_and_updates_meta(
         self, mock_settings, tmp_path

--- a/tests/test_note_generator.py
+++ b/tests/test_note_generator.py
@@ -13,7 +13,6 @@ from utils.file_utils import NoteRecord
 def mock_settings():
     settings = Mock()
     models = Mock()
-    models.ollama_url = "http://localhost:11434"
     models.llm = "llama3.1:8b"
     models.whisper = "large-v3-turbo"
     models.num_predict = 4096

--- a/tests/test_note_generator_llm_call.py
+++ b/tests/test_note_generator_llm_call.py
@@ -13,12 +13,17 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from llm.exceptions import LLMModelError
+from llm.exceptions import LLMConnectionLost, LLMModelError
 from notes.note_generator import SYSTEM_PROMPT, NoteGenerator
 
 
 class FakeLLMClient:
-    """Stand-in for ``llm.client.LLMClient`` that records the chat call."""
+    """Stand-in for ``llm.client.LLMClient`` that records the chat call.
+
+    Like the real ``chat_stream_sync``, this returns an iterator immediately and
+    raises ``error`` *during* iteration (after yielding ``tokens``), so tests
+    exercise the same mid-stream failure path production hits.
+    """
 
     def __init__(
         self,
@@ -36,10 +41,21 @@ class FakeLLMClient:
         options: dict[str, Any] | None = None,
         keep_alive: int | None = None,
     ) -> Iterator[str]:
-        self.calls.append({"messages": messages, "model": model, "options": options})
-        if self.error is not None:
-            raise self.error
-        return iter(self.tokens)
+        self.calls.append(
+            {
+                "messages": messages,
+                "model": model,
+                "options": options,
+                "keep_alive": keep_alive,
+            }
+        )
+
+        def _stream() -> Iterator[str]:
+            yield from self.tokens
+            if self.error is not None:
+                raise self.error
+
+        return _stream()
 
 
 @pytest.fixture
@@ -90,8 +106,34 @@ def test_call_llm_passes_max_tokens_budget(mock_settings):
     assert "top_p" not in options
 
 
+def test_call_llm_reprints_progress_every_twenty_tokens(mock_settings):
+    client = FakeLLMClient(tokens=["x"] * 45)
+    generator = _make_generator(mock_settings, client)
+
+    result = generator._call_llm("prompt")
+
+    assert result == "x" * 45  # all 45 tokens aggregated, none dropped
+
+
 def test_generate_structured_notes_returns_none_on_llm_error(mock_settings):
     client = FakeLLMClient(error=LLMModelError("model fell over"))
+    generator = _make_generator(mock_settings, client)
+
+    result = generator._generate_structured_notes(
+        "a transcript that is comfortably longer than the fifty character floor",
+        "Some Title",
+    )
+
+    assert result is None
+
+
+def test_generate_structured_notes_returns_none_on_midstream_error(mock_settings):
+    # Daemon drops the connection after some tokens have already streamed; the
+    # partial result is discarded and the record yields no note.
+    client = FakeLLMClient(
+        tokens=["partial ", "content "],
+        error=LLMConnectionLost("daemon went away"),
+    )
     generator = _make_generator(mock_settings, client)
 
     result = generator._generate_structured_notes(

--- a/tests/test_note_generator_llm_call.py
+++ b/tests/test_note_generator_llm_call.py
@@ -1,0 +1,102 @@
+"""Tests for the note-generator LLM call site after the chirpd cutover (6.2).
+
+`_call_llm` routes note generation through `llm.client` instead of the Ollama
+HTTP API. These tests assert the call shape, the streamed-token aggregation,
+and that LLM errors propagate into the existing best-effort `return None` path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from llm.exceptions import LLMModelError
+from notes.note_generator import SYSTEM_PROMPT, NoteGenerator
+
+
+class FakeLLMClient:
+    """Stand-in for ``llm.client.LLMClient`` that records the chat call."""
+
+    def __init__(
+        self,
+        tokens: list[str] | None = None,
+        error: Exception | None = None,
+    ) -> None:
+        self.tokens = tokens or []
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    def chat_stream_sync(
+        self,
+        messages: list[dict[str, Any]],
+        model: str = "default",
+        options: dict[str, Any] | None = None,
+        keep_alive: int | None = None,
+    ) -> Iterator[str]:
+        self.calls.append({"messages": messages, "model": model, "options": options})
+        if self.error is not None:
+            raise self.error
+        return iter(self.tokens)
+
+
+@pytest.fixture
+def mock_settings():
+    settings = Mock()
+    models = Mock()
+    models.llm = "default_chat"
+    models.whisper = "large-v3-turbo"
+    models.num_predict = 4096
+    settings.models = models
+    return settings
+
+
+def _make_generator(settings, client):
+    with (
+        patch("notes.note_generator.TemplateEngine"),
+        patch("notes.note_generator.PopupManager"),
+    ):
+        return NoteGenerator(settings, llm_client=client)
+
+
+def test_call_llm_uses_default_model_and_single_user_message(mock_settings):
+    client = FakeLLMClient(tokens=["Hello", " ", "world", "  "])
+    generator = _make_generator(mock_settings, client)
+    prompt = f"{SYSTEM_PROMPT}\n\nTranscript:\nhello there"
+
+    result = generator._call_llm(prompt)
+
+    assert result == "Hello world"  # joined token stream, stripped
+    assert len(client.calls) == 1
+    call = client.calls[0]
+    assert call["model"] == "default"
+    assert call["messages"] == [{"role": "user", "content": prompt}]
+    assert call["messages"][0]["content"].startswith(SYSTEM_PROMPT)
+
+
+def test_call_llm_passes_max_tokens_budget(mock_settings):
+    client = FakeLLMClient(tokens=["ok"])
+    generator = _make_generator(mock_settings, client)
+
+    generator._call_llm("prompt")
+
+    options = client.calls[0]["options"]
+    assert options == {"max_tokens": 4096}
+    # temperature / top_p are intentionally not sent: the MLX backend splats
+    # options into mlx_lm.stream_generate, which only honours max_tokens.
+    assert "temperature" not in options
+    assert "top_p" not in options
+
+
+def test_generate_structured_notes_returns_none_on_llm_error(mock_settings):
+    client = FakeLLMClient(error=LLMModelError("model fell over"))
+    generator = _make_generator(mock_settings, client)
+
+    result = generator._generate_structured_notes(
+        "a transcript that is comfortably longer than the fifty character floor",
+        "Some Title",
+    )
+
+    assert result is None


### PR DESCRIPTION
## What

Cuts `notes/note_generator.py` over from the **Ollama HTTP API** to **`llm.client`** (chirpd), so note generation during `chirp transcribe` works without a separately-installed Ollama daemon — while notes keep the same XML structure, prompt template, and front-matter (EPIC-INTEGRATION-CUTOVER, story 6.2). Depends on the now-merged 6.1 regression corpus.

- Removes `import requests`; replaces `_call_ollama` (+ its NDJSON streaming loop) with `_call_llm`, which streams via `LLMClient().chat_stream_sync(messages, model="default", options={"max_tokens": …})` and joins the string deltas. Same `↳ Generating… / Generated N chunks` progress UX.
- Single user-role message carries `SYSTEM_PROMPT` + transcript **verbatim** — preserving the exact prompt shape the 6.1 "before" baseline was captured against (keeps story 6.6's comparison honest).
- `LLMClient` is injectable on `NoteGenerator` for testing.
- `SYSTEM_PROMPT`, `_parse_xml_response`, template render, and `meta.toml` writing are **untouched** (AC-6).

Net −48 LOC in the module (the daemon client is simpler than the `requests` stream loop).

## ⚠️ Contract verification + AC deviations (please sanity-check)

I verified the **real** `llm.client` before coding — these cutover stories drift from the spec, and this one did in three places. All documented in the story's Dev Agent Record:

1. **Client API shape** — the story assumed `from llm.client import client; client.chat(stream=True)` with `delta.text`. Reality (and the shipped `notes_chat/prompting.py` precedent): `LLMClient().chat_stream_sync(...)` yielding **plain `str`** tokens. Used that.
2. **Options = `max_tokens` only** — the daemon splats options into `mlx_lm.stream_generate(**options)`, which only honors `max_tokens`; `temperature`/`top_p` can't be honored (sampler-configured) so they're omitted (precedent passes none). `max_tokens` is set from the existing budget so notes don't truncate at mlx's 256 default. Deviates from AC-2/AC-9's literal temp/top_p.
3. **AC-7 vs `num_predict`** — the field is still read for the budget (AC-4 keeps it / AC-9 asserts it); AC-7's grep is read as "no Ollama *mechanics*". `ollama` / `requests.` / `/api/generate` / `ollama_url` are all gone.

## Testing

- `make test` — **1400 passed**; `make check` — green.
- New `tests/test_note_generator_llm_call.py` (AC-9): asserts call shape (`model="default"`, single user message starting with `SYSTEM_PROMPT`), `max_tokens` budget, joined+stripped return, and `LLMModelError` → `_generate_structured_notes` returns `None`.
- Removed the obsolete `_call_ollama`/`requests.post` test + dead helper (AC-8).
- **AC-11 (manual smoke) NOT run:** no `default_chat` MLX model is registered (`~/.chirp/models.toml` absent). Needs `chirp models add <chat-repo>` + a running daemon to verify end-to-end + the `pkill -f chirpd` negative path.

(Also flips story 6.1 → Done.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)