### PR TITLE
feat(init): drop Ollama flow; add Apple-Silicon gate and daemon-readiness checks (story 7.1)

### DIFF
--- a/_bmad-output/planning-artifacts/epic-init-and-migration/stories/7.1-init-drop-ollama-add-arm64-and-daemon-checks.md
+++ b/_bmad-output/planning-artifacts/epic-init-and-migration/stories/7.1-init-drop-ollama-add-arm64-and-daemon-checks.md
@@ -1,6 +1,6 @@
 # Story 7.1 — `chirp init`: drop Ollama branches; add Apple-Silicon and daemon-readiness checks
 
-- **Status:** Draft
+- **Status:** Review — implemented on branch `feat/story-7.1-init-apple-silicon-daemon-checks`. All ACs verified except the fresh-box/Intel manual smokes (AC-11/AC-12), which need hardware this machine can't simulate; the healthy-box `--recheck` and `--switch-model` smokes ran live against the real daemon. See **Dev Agent Record**.
 - **Epic:** [EPIC-INIT-AND-MIGRATION](../epic.md)
 - **Depends on:** EPIC-CHIRPD-CORE (vertical slice complete — `llm.client.health()` reachable, lazy-spawn works); EPIC-MODEL-REGISTRY (`llm.registry.read_registry()` exists; `chirp models add` exists on PATH so the next-step prompt points at a real command)
 - **Blocks:** 7.2 (recheck migration plan layers on top of the new verify shape); 7.3 (LaunchAgent prompt runs at the tail of the new flow)
@@ -140,3 +140,29 @@ Files to touch (validated against current `main` plus the assumed EPIC-CHIRPD-CO
 - **Manual Intel fail-fast (per AC-12):** run on an Intel Mac OR install an x86_64 Python under Rosetta on an Apple Silicon Mac, run `chirp init`, observe exit code `7` (`echo $?`).
 - **Manual `--switch-model`:** with two chat aliases registered, run `chirp init --switch-model`, pick the second, confirm `models.toml`'s `default_chat` flipped (via `chirp models list` or `cat ~/Library/Application\ Support/chirp/models.toml`).
 - **Manual `--recheck`:** run `chirp init --recheck` on a healthy box, confirm the verify table prints and no install or finalize work runs.
+
+## Dev Agent Record
+
+### Completion Notes
+
+- **AC-1** `_require_apple_silicon` runs before `--switch-model` and `verify()`; non-arm64 prints the single-line constraint + Rosetta hint and returns `EXIT_NOT_APPLE_SILICON = 7`. Test asserts no verify table, no `health_sync` call, no filesystem mutation.
+- **AC-2/AC-3/AC-4** `verify()` rows in order: homebrew, ffmpeg, `chirpd` (via `LLMClient().health_sync()` — lazy import, client owns lazy-spawn), `default chat model` (via `llm.registry.read_registry()`), screen-recording. No Ollama row, no `model:` rows, no `requests` import.
+  - **As-built deviation:** the daemon's health ready-payload key is `version`, not the story's assumed `daemon_version` (verified against the live daemon: `{'event': 'ready', 'status': 'ok', 'version': '0.0.1a0', ...}`); `_daemon_ready` reads `version`.
+  - **As-built deviation:** `read_registry()` returns an *empty Registry* on a missing models.toml (it never raises `FileNotFoundError`) and raises `LLMMalformedResponse`/`LLMModelNotFound` (both `LLMError`) on corrupt/unsupported files. `_default_chat_registered` handles both shapes — empty/unset → non-blocking hint row; `(FileNotFoundError, LLMError)` caught for safety.
+- **AC-5** `install_missing` drops the Ollama brew tasks; a failed `chirpd` row surfaces its detail + `chirp daemon logs` pointer and returns `False` (nothing to brew-install for a packaged daemon).
+- **AC-6** Phase 3/4 picker+pull deleted; `pull_and_finalize` → `_finalize_paths` (config/chroma/notes dirs + nest-ready panel). `_merge_config` repurposed: writes only user keys, never model tags (model selection lives in models.toml); corrupt-file backup behavior preserved; only called when config.toml is absent, keeping re-runs mtime-stable.
+- **AC-7** `_run_switch_model` lists registered chat aliases (sorted, current default starred), flips via `set_default_for_role` + `write_registry` directly — same functions `chirp models default` wraps, no subprocess. Empty registry → `chirp models add` hint, exit 0. Blank input keeps current (exit 0); user abort (Ctrl-C/EOF) exits 1.
+- **AC-8** All eight named tests present plus extras (daemon-unreachable mapping, missing-registry-file, blank/invalid switch-model input, decline-install, helper-level branches) — 38 tests, none spawn a real daemon or write a real models.toml.
+- **AC-9** `rg -n "ollama|requests\." chirp/init_flow.py` → zero matches.
+- **AC-10** `make check` clean; full suite 1422 passed; `chirp --help` / `chirp init --help` ollama-free; coverage on `chirp/init_flow.py` **97%** (≥90% gate).
+- **AC-11 (partial)** Healthy-box live smoke: `uv run chirp init --recheck` → all five rows green (`chirpd · healthy · v0.0.1a0`, `default chat: qwen2.5-7b-instruct-4bit`), exit 0. `echo "" | chirp init --switch-model` lists both registered aliases with the default starred, keeps current, exit 0. True fresh-box (`pip install` on a clean Mac) smoke deferred to operator.
+- **AC-12** Not executable on this arm64 machine; the Intel path is covered by `test_run_init_fails_fast_on_intel` (exit 7, no table, no filesystem writes).
+
+### File List
+
+- `chirp/init_flow.py` (rewritten — gate + chirpd/registry checks, Ollama plumbing deleted)
+- `tests/test_init_flow.py` (rewritten — Ollama tests deleted, AC-8 suite + helper coverage added)
+
+## Change Log
+
+- 2026-06-11: Story 7.1 implemented — `chirp init` drops all Ollama branches; Apple-Silicon gate (exit 7), `chirpd` health row, registry-backed default-chat row and `--switch-model`. Status → Review.

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -987,7 +987,15 @@ def init(
     ),
 ):
     """First-run setup & model picker"""
-    from chirp.init_flow import run_init
+    from chirp.init_flow import require_apple_silicon, run_init
+
+    # Gate before get_settings(): loading settings creates a default
+    # config.toml when missing, and a non-arm64 machine must exit without
+    # touching the filesystem (story 7.1 AC-1). run_init re-checks the gate
+    # for callers that bypass the CLI.
+    code = require_apple_silicon(console)
+    if code is not None:
+        raise typer.Exit(code)
 
     settings = get_settings()
     code = run_init(settings, console, recheck=recheck, switch_model=switch_model)

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -1,6 +1,6 @@
-"""`chirp init` — smart 3-phase first-run setup.
+"""`chirp init` — smart first-run setup: an architecture gate plus three phases.
 
-Phase 0 (gate): require Apple Silicon. Everything downstream (the bundled
+Gate: require Apple Silicon. Everything downstream (the bundled
 chirpd daemon, MLX inference) is arm64-only, so a non-arm64 machine fails
 fast with exit code 7 before any other work.
 
@@ -67,8 +67,10 @@ def _run(args: list[str], timeout: float = 10.0) -> tuple[int, str]:
     try:
         proc = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
         return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
-    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-        return 127, str(exc)
+    except FileNotFoundError as exc:
+        return 127, str(exc)  # shell convention: command not found
+    except subprocess.TimeoutExpired as exc:
+        return 124, str(exc)  # shell convention: timed out (cf. timeout(1))
 
 
 def _require_apple_silicon(console: Console) -> int | None:
@@ -147,9 +149,16 @@ def _default_chat_registered() -> DependencyStatus:
 
     try:
         registry = read_registry()
-    except (FileNotFoundError, LLMError):
+    except FileNotFoundError:
         return DependencyStatus(
             "default chat model", False, _MODELS_ADD_HINT, required=False
+        )
+    except LLMError as exc:
+        # Malformed/unsupported models.toml is a real problem, not a fresh
+        # install — surface the registry's own message instead of the
+        # models-add hint.
+        return DependencyStatus(
+            "default chat model", False, f"registry unreadable: {exc}", required=False
         )
     alias = registry.default_chat
     if alias and alias in registry.models:
@@ -360,8 +369,13 @@ def _run_switch_model(settings: ChirpSettings, console: Console) -> int:
         chat_aliases = sorted(
             alias for alias, entry in registry.models.items() if entry.role == "chat"
         )
-    except (FileNotFoundError, LLMError):
+    except FileNotFoundError:
         chat_aliases = []
+    except LLMError as exc:
+        # A malformed models.toml is not "no model registered" — switching
+        # would silently no-op with a misleading hint. Surface and fail.
+        console.print(f" [red]model registry unreadable: {exc}[/red]")
+        return 1
     if not chat_aliases:
         console.print(
             f" [yellow]no chat model registered yet.[/yellow] run: "

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -1,20 +1,25 @@
-"""`chirp init` — smart 4-phase first-run setup.
+"""`chirp init` — smart 3-phase first-run setup.
 
-Phase 1: verify homebrew, ffmpeg, Ollama, and the configured models. Print a
+Phase 0 (gate): require Apple Silicon. Everything downstream (the bundled
+chirpd daemon, MLX inference) is arm64-only, so a non-arm64 machine fails
+fast with exit code 7 before any other work.
+
+Phase 1: verify homebrew, ffmpeg, daemon readiness (via `llm.client`'s
+health handshake, which lazy-spawns chirpd), the registered default chat
+model (via `llm.registry`), and the screen-recording permission. Print a
 check table and ask whether to install what's missing.
 
-Phase 2: install missing dependencies via Homebrew (macOS only) and start
-Ollama.
+Phase 2: install missing dependencies via Homebrew (macOS only) and rebuild
+the capture_audio helper when needed. The daemon is part of the pip package
+and is never "installed" here; model registration is the user's own
+`chirp models add` step.
 
-Phase 3: let the user pick chat + embedding models from a short list, with
-sensible defaults (``llama3.1:8b``, ``nomic-embed-text``).
-
-Phase 4: ``ollama pull`` the models with progress bars, persist the config,
-and initialize ChromaDB.
+Phase 3: finalize — create the config/chroma/notes directories and print
+the "your nest is ready" panel.
 
 Re-running is idempotent: each phase is skipped cleanly when nothing is
-missing. ``--recheck`` stops after phase 1; ``--switch-model`` jumps to
-phase 3.
+missing. ``--recheck`` stops after phase 1; ``--switch-model`` flips the
+registry's default chat alias.
 """
 
 from __future__ import annotations
@@ -31,18 +36,19 @@ from typing import Any
 
 import tomli_w
 from rich.console import Console
-from rich.progress import (
-    BarColumn,
-    Progress,
-    SpinnerColumn,
-    TaskProgressColumn,
-    TextColumn,
-    TimeRemainingColumn,
-)
 from rich.text import Text
 
 import audio_capture
 from config.settings import ChirpSettings
+
+EXIT_NOT_APPLE_SILICON = 7
+
+# Single source of truth for the recommended first model — story 7.2's
+# migration plan and the README sweep (7.5) reference these constants.
+RECOMMENDED_CHAT_REPO = "mlx-community/gemma-4-4b-it-4bit"
+SMALLER_CHAT_REPO = "mlx-community/gemma-4-e2b-it-8bit"
+
+_MODELS_ADD_HINT = f"not configured — run 'chirp models add {RECOMMENDED_CHAT_REPO}'"
 
 
 @dataclass
@@ -51,26 +57,6 @@ class DependencyStatus:
     installed: bool
     detail: str
     required: bool = True
-
-
-@dataclass
-class ModelOption:
-    tag: str
-    size: str
-    note: str
-
-
-CHAT_MODELS = [
-    ModelOption("llama3.1:8b", "4.7 GB", "recommended"),
-    ModelOption("qwen2.5:7b", "4.4 GB", "faster"),
-    ModelOption("phi3:mini", "2.3 GB", "low RAM"),
-]
-
-EMBEDDING_MODELS = [
-    ModelOption("nomic-embed-text", "274 MB", "recommended"),
-    ModelOption("mxbai-embed-large", "669 MB", "higher recall"),
-    ModelOption("all-minilm", "46 MB", "lightweight"),
-]
 
 
 def _which(cmd: str) -> str | None:
@@ -83,6 +69,22 @@ def _run(args: list[str], timeout: float = 10.0) -> tuple[int, str]:
         return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
     except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
         return 127, str(exc)
+
+
+def _require_apple_silicon(console: Console) -> int | None:
+    """Phase 0 gate — returns EXIT_NOT_APPLE_SILICON on non-arm64, else None."""
+    machine = platform.machine()
+    if machine == "arm64":
+        return None
+    console.print(
+        f" [red]chirp requires Apple Silicon (M1/M2/M3/M4 or newer). "
+        f"Detected: {machine}.[/red]"
+    )
+    console.print(
+        " [dim]if this Mac is Apple Silicon, you're likely running an x86_64 "
+        "Python under Rosetta — install an arm64 Python and reinstall chirp.[/dim]"
+    )
+    return EXIT_NOT_APPLE_SILICON
 
 
 def _brew_installed() -> DependencyStatus:
@@ -110,52 +112,51 @@ def _ffmpeg_installed() -> DependencyStatus:
     return DependencyStatus("ffmpeg", True, detail)
 
 
-def _ollama_installed() -> DependencyStatus:
-    path = _which("ollama")
-    if not path:
-        return DependencyStatus("Ollama", False, "not found — runs your local models")
-    import requests
+def _daemon_ready() -> DependencyStatus:
+    """Probe daemon readiness through `llm.client`'s health handshake.
+
+    The client owns lazy-spawn and the version handshake — no daemon-process
+    logic lives here (architecture §Cross-Component Dependencies). Imports are
+    lazy so a broken `llm` module can't make init un-importable.
+    """
+    from llm.client import LLMClient
+    from llm.exceptions import LLMDaemonSpawnFailed, LLMTransportError
 
     try:
-        resp = requests.get("http://localhost:11434/api/version", timeout=3)
-        if resp.status_code == 200:
-            return DependencyStatus(
-                "Ollama",
-                True,
-                f"running · {resp.json().get('version', 'unknown')}",
-            )
+        payload = LLMClient().health_sync()
+    except LLMDaemonSpawnFailed:
         return DependencyStatus(
-            "Ollama",
-            True,
-            "installed but not responding on :11434",
+            "chirpd",
+            False,
+            "daemon could not be started — run 'chirp daemon logs' for details",
         )
-    except requests.exceptions.RequestException:
-        return DependencyStatus(
-            "Ollama",
-            True,
-            "installed · not running (brew services start ollama)",
-        )
+    except LLMTransportError as exc:
+        return DependencyStatus("chirpd", False, f"daemon unreachable: {exc}")
+    version = payload.get("version", "unknown")
+    return DependencyStatus("chirpd", True, f"healthy · v{version}")
 
 
-def _ollama_models() -> list[str]:
-    import requests
+def _default_chat_registered() -> DependencyStatus:
+    """Report whether models.toml has a default chat alias registered.
+
+    A missing or unconfigured registry is the normal first-run state, not a
+    failure — the row is non-blocking and points at `chirp models add`.
+    """
+    from llm.exceptions import LLMError
+    from llm.registry import read_registry
 
     try:
-        resp = requests.get("http://localhost:11434/api/tags", timeout=3)
-        if resp.status_code != 200:
-            return []
-        return [m["name"] for m in resp.json().get("models", [])]
-    except requests.exceptions.RequestException:
-        return []
-
-
-def _model_installed(tag: str, available: list[str]) -> bool:
-    if tag in available:
-        return True
-    if f"{tag}:latest" in available:
-        return True
-    base = tag.split(":", 1)[0]
-    return any(name.startswith(f"{base}:") for name in available)
+        registry = read_registry()
+    except (FileNotFoundError, LLMError):
+        return DependencyStatus(
+            "default chat model", False, _MODELS_ADD_HINT, required=False
+        )
+    alias = registry.default_chat
+    if alias and alias in registry.models:
+        return DependencyStatus("default chat model", True, f"default chat: {alias}")
+    return DependencyStatus(
+        "default chat model", False, _MODELS_ADD_HINT, required=False
+    )
 
 
 def _screen_recording_permission() -> DependencyStatus:
@@ -218,70 +219,33 @@ def verify(settings: ChirpSettings, console: Console) -> list[DependencyStatus]:
     statuses = [
         _brew_installed(),
         _ffmpeg_installed(),
-        _ollama_installed(),
+        _daemon_ready(),
+        _default_chat_registered(),
+        _screen_recording_permission(),
     ]
-
-    ollama_up = statuses[-1].installed and "running" in statuses[-1].detail
-    available = _ollama_models() if ollama_up else []
-
-    chat_tag = settings.models.llm
-    emb_tag = settings.notes_chat.emb_model
-
-    if ollama_up:
-        statuses.append(
-            DependencyStatus(
-                f"model: {chat_tag}",
-                _model_installed(chat_tag, available),
-                "installed" if _model_installed(chat_tag, available) else "missing",
-            )
-        )
-        statuses.append(
-            DependencyStatus(
-                f"model: {emb_tag}",
-                _model_installed(emb_tag, available),
-                "installed" if _model_installed(emb_tag, available) else "missing",
-            )
-        )
-    else:
-        statuses.append(
-            DependencyStatus(
-                "models",
-                False,
-                "will check after ollama is installed",
-                required=False,
-            )
-        )
-
-    statuses.append(_screen_recording_permission())
 
     for status in statuses:
         _print_status(console, status)
 
     console.print()
-    missing_deps = [
-        s
-        for s in statuses
-        if s.required and not s.installed and not s.name.startswith("model:")
-    ]
-    missing_models = [
-        s
-        for s in statuses
-        if s.required and not s.installed and s.name.startswith("model:")
-    ]
-    if missing_deps or missing_models:
+    missing_deps = [s for s in statuses if s.required and not s.installed]
+    chat_row = next(s for s in statuses if s.name == "default chat model")
+    if missing_deps or not chat_row.installed:
         console.print(" [dim]──────────────────────────────────────────────[/dim]")
-        if missing_deps:
-            plural = "s" if len(missing_deps) > 1 else ""
-            console.print(
-                f"  need to install: [bold]{len(missing_deps)} piece{plural}[/bold]"
-            )
-        if missing_models:
-            plural = "s" if len(missing_models) > 1 else ""
-            console.print(
-                f"  missing model{plural}: "
-                f"[bold]{len(missing_models)}[/bold] [dim](pulled in phase 4)[/dim]"
-            )
-    else:
+    if missing_deps:
+        plural = "s" if len(missing_deps) > 1 else ""
+        console.print(
+            f"  need to install: [bold]{len(missing_deps)} piece{plural}[/bold]"
+        )
+    if not chat_row.installed:
+        console.print(
+            f"  next step: [bold]chirp models add {RECOMMENDED_CHAT_REPO}[/bold]"
+            " [dim](~2 GB, balanced quality and speed)[/dim]"
+        )
+        console.print(
+            f"  [dim]smaller alternative: chirp models add {SMALLER_CHAT_REPO}[/dim]"
+        )
+    if not missing_deps and chat_row.installed:
         console.print(" [green]everything's already in place.[/green]")
 
     return statuses
@@ -335,14 +299,17 @@ def install_missing(console: Console, statuses: list[DependencyStatus]) -> bool:
     console.print(" [dim]installing dependencies via homebrew...[/dim]")
     console.print()
 
-    denied_user_action_required = False
+    user_action_required = False
     tasks: list[tuple[str, list[str]]] = []
     for status in statuses:
         if status.installed or not status.required:
             continue
-        if status.name == "Ollama":
-            tasks.append(("ollama", [brew, "install", "ollama"]))
-            tasks.append(("ollama service", [brew, "services", "start", "ollama"]))
+        if status.name == "chirpd":
+            # The daemon ships inside the pip package and is lazy-spawned by
+            # llm.client — there is nothing to install when it fails to start.
+            console.print(f" [red]✗[/red] the daemon failed to start — {status.detail}")
+            console.print("   run [bold]chirp daemon logs[/bold] for details.")
+            user_action_required = True
         elif status.name == "ffmpeg":
             tasks.append(("ffmpeg", [brew, "install", "ffmpeg"]))
         elif status.name == "screen recording permission" and status.detail.startswith(
@@ -352,7 +319,7 @@ def install_missing(console: Console, statuses: list[DependencyStatus]) -> bool:
                 "[yellow]![/yellow] screen recording permission must be granted manually — "
                 "open System Settings → Privacy & Security → Screen Recording, then re-run."
             )
-            denied_user_action_required = True
+            user_action_required = True
         elif status.name == "screen recording permission":
             tasks.append(
                 ("capture_audio", [sys.executable, "-m", "audio_capture.build"])
@@ -370,116 +337,69 @@ def install_missing(console: Console, statuses: list[DependencyStatus]) -> bool:
             )
             return False
 
-    if denied_user_action_required:
+    if user_action_required:
         console.print(
-            "[red]init incomplete[/red] — grant screen recording permission and re-run."
+            "[red]init incomplete[/red] — resolve the items above and re-run."
         )
         return False
 
     return True
 
 
-def pick_models(console: Console) -> tuple[str, str]:
-    """Phase 3 — show the two picker boxes, return (chat_tag, embed_tag)."""
-    console.print()
-    console.print(" [dim]ollama is running. let's pick your models.[/dim]")
-    console.print()
-    chat = _pick(console, "Chat / notes generator", CHAT_MODELS)
-    console.print()
-    embed = _pick(
-        console, "Embedding model (for ChromaDB · RAG search)", EMBEDDING_MODELS
-    )
-    return chat, embed
+def _run_switch_model(settings: ChirpSettings, console: Console) -> int:
+    """``--switch-model`` — flip the registry's default chat alias.
 
+    Calls the same `llm.registry` functions `chirp models default` wraps —
+    no subprocess hop.
+    """
+    from llm.exceptions import LLMError
+    from llm.registry import read_registry, set_default_for_role, write_registry
 
-def _pick(console: Console, title: str, options: list[ModelOption]) -> str:
-    console.print(f" [bold]{title}[/bold]")
-    for idx, option in enumerate(options, start=1):
-        marker = "[#d97a3a]●[/#d97a3a]" if idx == 1 else "[dim]○[/dim]"
-        tag = f"[bold]{option.tag}[/bold]" if idx == 1 else f"[dim]{option.tag}[/dim]"
-        console.print(
-            f"   {marker} {idx}. {tag}  [dim]{option.size} · {option.note}[/dim]"
-        )
-    console.print(f"   [dim]{len(options) + 1}. custom… (type an ollama tag)[/dim]")
     try:
-        choice: str = console.input(
-            " [green]›[/green] [dim]pick one (default 1):[/dim] "
+        registry = read_registry()
+        chat_aliases = sorted(
+            alias for alias, entry in registry.models.items() if entry.role == "chat"
+        )
+    except (FileNotFoundError, LLMError):
+        chat_aliases = []
+    if not chat_aliases:
+        console.print(
+            f" [yellow]no chat model registered yet.[/yellow] run: "
+            f"[bold]chirp models add {RECOMMENDED_CHAT_REPO}[/bold]"
+        )
+        console.print(
+            f" [dim]smaller alternative: chirp models add {SMALLER_CHAT_REPO}[/dim]"
+        )
+        return 0
+
+    console.print(" [bold]registered chat models:[/bold]")
+    for idx, alias in enumerate(chat_aliases, start=1):
+        marker = (
+            " [#d97a3a]★ current default[/#d97a3a]"
+            if alias == registry.default_chat
+            else ""
+        )
+        console.print(f"   {idx}. {alias}{marker}")
+    try:
+        choice = console.input(
+            " [green]›[/green] [dim]pick a new default (blank keeps current):[/dim] "
         ).strip()
     except (EOFError, KeyboardInterrupt):
         console.print()
-        return options[0].tag
+        return 1
     if not choice:
-        return options[0].tag
-    if choice.isdigit():
-        idx = int(choice)
-        if 1 <= idx <= len(options):
-            return options[idx - 1].tag
-        if idx == len(options) + 1:
-            custom: str = console.input(
-                " [green]›[/green] [dim]ollama tag:[/dim] "
-            ).strip()
-            return custom or options[0].tag
-    return choice
+        return 0
+    if not (choice.isdigit() and 1 <= int(choice) <= len(chat_aliases)):
+        console.print(" [red]invalid selection.[/red]")
+        return 1
+    chosen = chat_aliases[int(choice) - 1]
+    write_registry(set_default_for_role(registry, chosen))
+    console.print(f" [green]✓[/green] default chat set to [bold]{chosen}[/bold]")
+    return 0
 
 
-def keep_or_pick(console: Console, settings: ChirpSettings) -> tuple[str, str, bool]:
-    """Phase 3 — show "keep these or pick new?" when current models are valid.
-
-    Returns ``(chat_tag, embed_tag, models_changed)``. ``models_changed`` is
-    False when the user kept the existing models and Phase 4 should leave
-    ``models.*`` in ``config.toml`` untouched.
-    """
-    current_chat = settings.models.llm
-    current_embed = settings.notes_chat.emb_model
-    available = _ollama_models()
-    current_present = (
-        bool(current_chat)
-        and bool(current_embed)
-        and _model_installed(current_chat, available)
-        and _model_installed(current_embed, available)
-    )
-
-    if current_present:
-        console.print()
-        console.print(f" [bold]current models:[/bold] {current_chat}, {current_embed}")
-        try:
-            answer = (
-                console.input(
-                    "   [bold]keep these, or pick new?[/bold] [dim][K/p][/dim] "
-                )
-                .strip()
-                .lower()
-            )
-        except (EOFError, KeyboardInterrupt):
-            console.print()
-            return current_chat, current_embed, False
-        if answer in ("", "k", "keep"):
-            return current_chat, current_embed, False
-
-    chat, embed = pick_models(console)
-    return chat, embed, True
-
-
-def pull_and_finalize(
-    console: Console,
-    settings: ChirpSettings,
-    chat_tag: str,
-    embed_tag: str,
-    models_changed: bool = True,
-) -> None:
-    """Phase 4 — pull the picked models, merge config.toml, ensure dirs."""
-    installed = _ollama_models()
-    to_pull = [
-        tag for tag in (chat_tag, embed_tag) if not _model_installed(tag, installed)
-    ]
-    if to_pull:
-        console.print()
-        console.print(" [dim]pulling models...[/dim]")
-        for tag in to_pull:
-            _pull_model(console, tag)
-    else:
-        console.print(" [green]models already present.[/green]")
-
+def _finalize_paths(settings: ChirpSettings, console: Console) -> None:
+    """Phase 3 — ensure config/chroma/notes paths exist, print the summary."""
     config_path = ChirpSettings.get_config_path()
     chroma_dir = settings.notes_chat.index_dir / "chroma"
     notes_root = settings.directories.notes_root
@@ -488,13 +408,8 @@ def pull_and_finalize(
     chroma_existed = chroma_dir.exists()
     notes_existed = notes_root.exists()
 
-    settings.models.llm = chat_tag
-    settings.notes_chat.emb_model = embed_tag
-
-    config_written = False
-    if models_changed or not config_existed:
-        _merge_config(config_path, chat_tag, embed_tag, console=console)
-        config_written = True
+    if not config_existed:
+        _merge_config(config_path, console=console)
 
     chroma_dir.mkdir(parents=True, exist_ok=True)
     notes_root.mkdir(parents=True, exist_ok=True)
@@ -502,7 +417,7 @@ def pull_and_finalize(
     _print_path_summary(
         console,
         config_path=config_path,
-        config_changed=config_written,
+        config_changed=not config_existed,
         chroma_dir=chroma_dir,
         chroma_was_new=not chroma_existed,
         notes_root=notes_root,
@@ -517,17 +432,13 @@ def pull_and_finalize(
     )
 
 
-def _merge_config(
-    config_path: Path,
-    chat_tag: str,
-    embed_tag: str,
-    console: Console | None = None,
-) -> None:
-    """Merge models.* fields into config.toml without dropping user keys.
+def _merge_config(config_path: Path, console: Console | None = None) -> None:
+    """Write config.toml preserving any user keys already present.
 
-    On a corrupt file we copy the original aside as ``config.toml.bak-<ts>``
-    and warn loudly before writing a fresh config — never silently clobber
-    hand-edited keys.
+    Model selection lives in models.toml (the registry); init only touches
+    the user-editable settings file. On a corrupt file we copy the original
+    aside as ``config.toml.bak-<ts>`` and warn loudly before writing a fresh
+    config — never silently clobber hand-edited keys.
     """
     existing: dict[str, Any] = {}
     if config_path.exists():
@@ -544,9 +455,6 @@ def _merge_config(
                     "backup.[/yellow]"
                 )
             existing = {}
-
-    existing.setdefault("models", {})["llm"] = chat_tag
-    existing.setdefault("notes_chat", {})["emb_model"] = embed_tag
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
     with config_path.open("wb") as fh:
@@ -610,80 +518,25 @@ def _path_line(
     return line
 
 
-def _pull_model(console: Console, tag: str) -> None:
-    progress = Progress(
-        SpinnerColumn(),
-        TextColumn("[bold]{task.description}"),
-        BarColumn(),
-        TaskProgressColumn(),
-        TimeRemainingColumn(),
-        console=console,
-    )
-    task = None
-    with progress:
-        task = progress.add_task(f"ollama pull {tag}", total=100)
-        try:
-            proc = subprocess.Popen(
-                ["ollama", "pull", tag],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-            )
-        except FileNotFoundError:
-            progress.update(task, description="[red]✗[/red] ollama not on PATH")
-            return
-        if proc.stdout is None:
-            proc.wait()
-            return
-        for line in proc.stdout:
-            pct = _parse_percent(line)
-            if pct is not None:
-                progress.update(task, completed=pct)
-        proc.wait()
-        if proc.returncode == 0:
-            progress.update(task, completed=100)
-        else:
-            progress.update(
-                task,
-                description=f"[red]✗[/red] ollama pull {tag} failed",
-            )
-
-
-def _parse_percent(line: str) -> float | None:
-    line = line.strip()
-    if "%" not in line:
-        return None
-    for token in line.split():
-        if token.endswith("%"):
-            try:
-                return float(token.rstrip("%"))
-            except ValueError:
-                return None
-    return None
-
-
 def run_init(
     settings: ChirpSettings,
     console: Console,
     recheck: bool = False,
     switch_model: bool = False,
 ) -> int:
-    """Top-level entry — orchestrates the four phases. Returns exit code."""
+    """Top-level entry — orchestrates the phases. Returns exit code."""
+    code = _require_apple_silicon(console)
+    if code is not None:
+        return code
+
     if switch_model:
-        chat, embed = pick_models(console)
-        pull_and_finalize(console, settings, chat, embed, models_changed=True)
-        return 0
+        return _run_switch_model(settings, console)
 
     statuses = verify(settings, console)
     if recheck:
         return 0
 
-    missing = [
-        s
-        for s in statuses
-        if s.required and not s.installed and not s.name.startswith("model:")
-    ]
+    missing = [s for s in statuses if s.required and not s.installed]
     if missing:
         if not _confirm(console, "Install the missing pieces?", default=True):
             console.print(" [yellow]skipped install.[/yellow]")
@@ -695,13 +548,5 @@ def run_init(
             " [dim]phase 2 · everything's already installed — skipping.[/dim]"
         )
 
-    ollama = _ollama_installed()
-    if not ollama.installed or "running" not in ollama.detail:
-        console.print(
-            " [red]ollama isn't running.[/red] start it with `brew services start ollama`, then re-run."
-        )
-        return 1
-
-    chat, embed, models_changed = keep_or_pick(console, settings)
-    pull_and_finalize(console, settings, chat, embed, models_changed=models_changed)
+    _finalize_paths(settings, console)
     return 0

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -73,7 +73,7 @@ def _run(args: list[str], timeout: float = 10.0) -> tuple[int, str]:
         return 124, str(exc)  # shell convention: timed out (cf. timeout(1))
 
 
-def _require_apple_silicon(console: Console) -> int | None:
+def require_apple_silicon(console: Console) -> int | None:
     """Phase 0 gate — returns EXIT_NOT_APPLE_SILICON on non-arm64, else None."""
     machine = platform.machine()
     if machine == "arm64":
@@ -106,11 +106,16 @@ def _ffmpeg_installed() -> DependencyStatus:
     if not path:
         return DependencyStatus("ffmpeg", False, "not found")
     code, out = _run([path, "-version"])
+    if code != 0:
+        return DependencyStatus(
+            "ffmpeg",
+            False,
+            f"found at {path} but `ffmpeg -version` failed — try `brew reinstall ffmpeg`",
+        )
     detail = path
-    if code == 0:
-        first_line = out.splitlines()[0] if out else ""
-        if first_line.startswith("ffmpeg version"):
-            detail = first_line.split()[2]
+    first_line = out.splitlines()[0] if out else ""
+    if first_line.startswith("ffmpeg version"):
+        detail = first_line.split()[2]
     return DependencyStatus("ffmpeg", True, detail)
 
 
@@ -288,8 +293,12 @@ def _confirm(console: Console, prompt: str, default: bool = True) -> bool:
 
 
 def install_missing(console: Console, statuses: list[DependencyStatus]) -> bool:
-    """Phase 2 — brew install what's missing. Returns True if everything
-    that was required is now installed, False if the user aborted."""
+    """Phase 2 — install what's missing via Homebrew.
+
+    Returns True when every actionable task succeeded. Returns False on
+    non-macOS hosts, when Homebrew itself is missing, when a brew/build task
+    fails, or when manual user action remains (denied screen-recording
+    permission, a daemon that won't start)."""
     if platform.system() != "Darwin":
         console.print(
             " [yellow]automatic install is macOS-only.[/yellow] "
@@ -539,7 +548,7 @@ def run_init(
     switch_model: bool = False,
 ) -> int:
     """Top-level entry — orchestrates the phases. Returns exit code."""
-    code = _require_apple_silicon(console)
+    code = require_apple_silicon(console)
     if code is not None:
         return code
 

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -811,3 +811,34 @@ def test_switch_model_surfaces_malformed_registry(tmp_path, monkeypatch):
     output = console.file.getvalue()
     assert "registry unreadable" in output
     assert "chirp models add" not in output
+
+
+def test_ffmpeg_on_path_but_broken_reports_not_installed(monkeypatch):
+    monkeypatch.setattr(init_flow, "_which", lambda _cmd: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(
+        init_flow, "_run", lambda args, timeout=10.0: (1, "dyld: library missing")
+    )
+
+    status = init_flow._ffmpeg_installed()
+
+    assert status.installed is False
+    assert "brew reinstall ffmpeg" in status.detail
+
+
+def test_cli_init_gates_before_loading_settings(monkeypatch):
+    from typer.testing import CliRunner
+
+    from chirp.cli import app
+
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "x86_64")
+
+    settings_loads = []
+    monkeypatch.setattr(
+        "chirp.cli.get_settings",
+        lambda: settings_loads.append(True) or ChirpSettings(),
+    )
+
+    result = CliRunner().invoke(app, ["init"])
+
+    assert result.exit_code == 7
+    assert settings_loads == []  # config.toml must not be created pre-gate

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -1,7 +1,8 @@
 """Unit tests for the chirp init flow.
 
-The external pieces (homebrew, ollama, audio midi setup, subprocess calls)
-are mocked out so the tests stay fast and platform-agnostic.
+The external pieces (homebrew, the chirpd daemon, the model registry, audio
+permission probes, subprocess calls) are mocked out so the tests stay fast,
+platform-agnostic, and never spawn a real daemon or write a real models.toml.
 """
 
 from io import StringIO
@@ -10,6 +11,8 @@ from rich.console import Console
 
 from chirp import init_flow
 from config.settings import ChirpSettings
+from llm.exceptions import LLMDaemonSpawnFailed, LLMDaemonUnreachable
+from llm.registry import Registry, RegistryEntry
 
 
 def _fake_settings(tmp_path):
@@ -23,353 +26,33 @@ def _console() -> Console:
     return Console(file=StringIO(), width=120, force_terminal=False)
 
 
-def test_parse_percent_reads_ollama_progress():
-    assert init_flow._parse_percent("pulling manifest 12%") == 12.0
-    assert init_flow._parse_percent("digest 99.9% done") == 99.9
-    assert init_flow._parse_percent("") is None
-    assert init_flow._parse_percent("done") is None
-
-
-def test_model_installed_matches_latest_and_base():
-    assert init_flow._model_installed("llama3.1:8b", ["llama3.1:8b"])
-    assert init_flow._model_installed("llama3.1:8b", ["llama3.1:8b:latest"])
-    assert init_flow._model_installed("nomic-embed-text", ["nomic-embed-text:v1.5"])
-    assert not init_flow._model_installed("llama3.1:8b", ["qwen2.5:7b"])
-
-
-def test_verify_reports_missing_everything(tmp_path, monkeypatch):
-    monkeypatch.setattr(init_flow, "_which", lambda _cmd: None)
-    monkeypatch.setattr(init_flow, "_ollama_models", lambda: [])
-
-    console = _console()
-    settings = _fake_settings(tmp_path)
-
-    statuses = init_flow.verify(settings, console)
-
-    names = [s.name for s in statuses]
-    assert "homebrew" in names
-    assert "ffmpeg" in names
-    assert "Ollama" in names
-    missing_required = [s for s in statuses if s.required and not s.installed]
-    assert missing_required, "verify should report missing pieces"
-
-
-def test_run_init_recheck_short_circuits(tmp_path, monkeypatch):
-    """--recheck returns 0 without prompting / installing."""
-    monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
-    monkeypatch.setattr(
-        init_flow,
-        "_ollama_installed",
-        lambda: init_flow.DependencyStatus("Ollama", True, "running · 0.1"),
-    )
-    monkeypatch.setattr(
-        init_flow, "_ollama_models", lambda: ["llama3.1:8b", "nomic-embed-text"]
-    )
-    monkeypatch.setattr(
-        init_flow,
-        "_ffmpeg_installed",
-        lambda: init_flow.DependencyStatus("ffmpeg", True, "7.1.1"),
-    )
-
-    console = _console()
-    settings = _fake_settings(tmp_path)
-
-    code = init_flow.run_init(settings, console, recheck=True)
-    assert code == 0
-
-
-def test_pick_models_defaults_on_blank_input(monkeypatch):
-    console = _console()
-    answers = iter(["", ""])
-    monkeypatch.setattr(console, "input", lambda *args, **kwargs: next(answers))
-
-    chat, embed = init_flow.pick_models(console)
-
-    assert chat == "llama3.1:8b"
-    assert embed == "nomic-embed-text"
-
-
-def test_pick_models_honours_numeric_selection(monkeypatch):
-    console = _console()
-    answers = iter(["2", "3"])
-    monkeypatch.setattr(console, "input", lambda *args, **kwargs: next(answers))
-
-    chat, embed = init_flow.pick_models(console)
-
-    assert chat == init_flow.CHAT_MODELS[1].tag
-    assert embed == init_flow.EMBEDDING_MODELS[2].tag
-
-
-def test_run_init_phases_run_in_order(tmp_path, monkeypatch):
-    """Smoke: run_init walks verify → install → keep_or_pick → finalize."""
-    calls: list[str] = []
-
-    monkeypatch.setattr(
-        init_flow,
-        "verify",
-        lambda settings, console: (
-            calls.append("verify")
-            or [
-                init_flow.DependencyStatus("homebrew", False, "missing"),
-            ]
+def _registry_with_default(default_chat="gemma-4-4b-it-4bit", extra_aliases=()):
+    models = {
+        default_chat: RegistryEntry(
+            hf_repo=f"mlx-community/{default_chat}", role="chat"
         ),
-    )
-    monkeypatch.setattr(init_flow, "_confirm", lambda *args, **kwargs: True)
+    }
+    for alias in extra_aliases:
+        models[alias] = RegistryEntry(hf_repo=f"mlx-community/{alias}", role="chat")
+    return Registry(schema_version=1, default_chat=default_chat, models=models)
+
+
+def _empty_registry():
+    return Registry(schema_version=1, models={})
+
+
+def _stub_healthy_daemon(monkeypatch):
     monkeypatch.setattr(
-        init_flow,
-        "install_missing",
-        lambda console, statuses: calls.append("install") or True,
+        "llm.client.LLMClient.health_sync",
+        lambda self, **kwargs: {"event": "ready", "status": "ok", "version": "0.1.0"},
     )
+
+
+def _stub_verify_deps(monkeypatch, registry=None, arm64=True):
+    """Stub every external probe for a healthy Apple Silicon box."""
     monkeypatch.setattr(
-        init_flow,
-        "_ollama_installed",
-        lambda: init_flow.DependencyStatus("Ollama", True, "running · 0.1"),
+        init_flow.platform, "machine", lambda: "arm64" if arm64 else "x86_64"
     )
-    monkeypatch.setattr(
-        init_flow,
-        "keep_or_pick",
-        lambda console, settings: (
-            calls.append("keep_or_pick") or ("llama3.1:8b", "nomic-embed-text", True)
-        ),
-    )
-    monkeypatch.setattr(
-        init_flow,
-        "pull_and_finalize",
-        lambda *args, **kwargs: calls.append("finalize"),
-    )
-
-    code = init_flow.run_init(_fake_settings(tmp_path), _console())
-    assert code == 0
-    assert calls == ["verify", "install", "keep_or_pick", "finalize"]
-
-
-def test_keep_or_pick_keeps_when_user_accepts_default(tmp_path, monkeypatch):
-    settings = _fake_settings(tmp_path)
-    settings.models.llm = "llama3.1:8b"
-    settings.notes_chat.emb_model = "nomic-embed-text"
-    monkeypatch.setattr(
-        init_flow, "_ollama_models", lambda: ["llama3.1:8b", "nomic-embed-text"]
-    )
-
-    console = _console()
-    monkeypatch.setattr(console, "input", lambda *args, **kwargs: "")
-
-    chat, embed, changed = init_flow.keep_or_pick(console, settings)
-    assert (chat, embed, changed) == ("llama3.1:8b", "nomic-embed-text", False)
-
-
-def test_keep_or_pick_runs_pickers_when_user_picks(tmp_path, monkeypatch):
-    settings = _fake_settings(tmp_path)
-    settings.models.llm = "llama3.1:8b"
-    settings.notes_chat.emb_model = "nomic-embed-text"
-    monkeypatch.setattr(
-        init_flow, "_ollama_models", lambda: ["llama3.1:8b", "nomic-embed-text"]
-    )
-    monkeypatch.setattr(
-        init_flow,
-        "pick_models",
-        lambda console: ("qwen2.5:7b", "mxbai-embed-large"),
-    )
-
-    console = _console()
-    monkeypatch.setattr(console, "input", lambda *args, **kwargs: "p")
-
-    chat, embed, changed = init_flow.keep_or_pick(console, settings)
-    assert (chat, embed, changed) == ("qwen2.5:7b", "mxbai-embed-large", True)
-
-
-def test_keep_or_pick_falls_through_when_models_missing(tmp_path, monkeypatch):
-    """If current models aren't installed, skip the prompt and run pickers."""
-    settings = _fake_settings(tmp_path)
-    settings.models.llm = "llama3.1:8b"
-    settings.notes_chat.emb_model = "nomic-embed-text"
-    monkeypatch.setattr(init_flow, "_ollama_models", lambda: [])  # nothing installed
-    monkeypatch.setattr(
-        init_flow,
-        "pick_models",
-        lambda console: ("phi3:mini", "all-minilm"),
-    )
-
-    console = _console()
-    chat, embed, changed = init_flow.keep_or_pick(console, settings)
-    assert (chat, embed, changed) == ("phi3:mini", "all-minilm", True)
-
-
-def test_pull_and_finalize_merges_user_keys(tmp_path, monkeypatch):
-    """A custom key already in config.toml survives a re-run."""
-    config_path = tmp_path / "config.toml"
-    chroma_dir = tmp_path / "chroma"
-    notes_root = tmp_path / "notes"
-
-    import tomli_w
-
-    with config_path.open("wb") as fh:
-        tomli_w.dump(
-            {
-                "models": {"llm": "old-llm"},
-                "notes_chat": {"emb_model": "old-embed"},
-                "user_custom": {"theme": "midnight"},
-            },
-            fh,
-        )
-
-    settings = _fake_settings(tmp_path)
-    settings.directories.notes_root = notes_root
-    settings.notes_chat.index_dir = tmp_path
-
-    monkeypatch.setattr(init_flow.ChirpSettings, "get_config_path", lambda: config_path)
-    monkeypatch.setattr(init_flow, "_ollama_models", lambda: ["new-llm", "new-embed"])
-
-    console = _console()
-    init_flow.pull_and_finalize(
-        console, settings, "new-llm", "new-embed", models_changed=True
-    )
-
-    import tomllib
-
-    with config_path.open("rb") as fh:
-        merged = tomllib.load(fh)
-    assert merged["user_custom"] == {"theme": "midnight"}
-    assert merged["models"]["llm"] == "new-llm"
-    assert merged["notes_chat"]["emb_model"] == "new-embed"
-    assert chroma_dir.exists()
-    assert notes_root.exists()
-
-
-def test_pull_and_finalize_skips_config_write_when_models_unchanged(
-    tmp_path, monkeypatch
-):
-    """When the user keeps current models, config.toml isn't rewritten."""
-    config_path = tmp_path / "config.toml"
-    chroma_dir = tmp_path / "chroma"
-    notes_root = tmp_path / "notes"
-
-    import tomli_w
-
-    with config_path.open("wb") as fh:
-        tomli_w.dump({"models": {"llm": "kept"}}, fh)
-
-    original_mtime = config_path.stat().st_mtime
-    import time as _time
-
-    _time.sleep(0.01)  # ensure mtime can change if we did write
-
-    settings = _fake_settings(tmp_path)
-    settings.directories.notes_root = notes_root
-    settings.notes_chat.index_dir = tmp_path
-
-    monkeypatch.setattr(init_flow.ChirpSettings, "get_config_path", lambda: config_path)
-    monkeypatch.setattr(init_flow, "_ollama_models", lambda: ["kept", "kept-embed"])
-
-    console = _console()
-    init_flow.pull_and_finalize(
-        console, settings, "kept", "kept-embed", models_changed=False
-    )
-
-    assert config_path.stat().st_mtime == original_mtime
-    assert chroma_dir.exists()
-    assert notes_root.exists()
-
-
-def _stub_for_clean_box(monkeypatch):
-    """Stub all external probes for a fully-installed, ollama-running box."""
-    monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
-    monkeypatch.setattr(
-        init_flow,
-        "_ollama_installed",
-        lambda: init_flow.DependencyStatus("Ollama", True, "running · 0.1"),
-    )
-    monkeypatch.setattr(
-        init_flow,
-        "_ffmpeg_installed",
-        lambda: init_flow.DependencyStatus("ffmpeg", True, "7.1.1"),
-    )
-    monkeypatch.setattr(
-        init_flow, "_ollama_models", lambda: ["llama3.1:8b", "nomic-embed-text"]
-    )
-
-
-def test_run_init_rerun_is_idempotent_and_preserves_user_keys(tmp_path, monkeypatch):
-    """AC-11: run twice in a tmp HOME, assert second run preserves a hand-edited key."""
-    config_path = tmp_path / "config.toml"
-    notes_root = tmp_path / "notes"
-
-    settings = _fake_settings(tmp_path)
-    settings.directories.notes_root = notes_root
-    settings.notes_chat.index_dir = tmp_path
-    settings.models.llm = "llama3.1:8b"
-    settings.notes_chat.emb_model = "nomic-embed-text"
-
-    monkeypatch.setattr(init_flow.ChirpSettings, "get_config_path", lambda: config_path)
-    _stub_for_clean_box(monkeypatch)
-
-    pick_calls = {"count": 0}
-
-    def boom_pick(_console):
-        pick_calls["count"] += 1
-        return ("llama3.1:8b", "nomic-embed-text")
-
-    monkeypatch.setattr(init_flow, "pick_models", boom_pick)
-
-    console1 = _console()
-    monkeypatch.setattr(console1, "input", lambda *args, **kwargs: "")  # K/p → keep
-
-    code = init_flow.run_init(settings, console1)
-    assert code == 0
-    assert config_path.exists()
-
-    import tomllib
-
-    import tomli_w
-
-    with config_path.open("rb") as fh:
-        first = tomllib.load(fh)
-    first["user_custom"] = {"theme": "midnight"}
-    with config_path.open("wb") as fh:
-        tomli_w.dump(first, fh)
-
-    first_mtime = config_path.stat().st_mtime
-    import time as _time
-
-    _time.sleep(0.01)
-
-    console2 = _console()
-    monkeypatch.setattr(console2, "input", lambda *args, **kwargs: "")  # K/p → keep
-
-    code = init_flow.run_init(settings, console2)
-    assert code == 0
-    assert pick_calls["count"] == 0  # user kept current models on both runs
-    assert config_path.stat().st_mtime == first_mtime  # no rewrite
-
-    with config_path.open("rb") as fh:
-        second = tomllib.load(fh)
-    assert second["user_custom"] == {"theme": "midnight"}
-
-
-def test_merge_config_backs_up_corrupt_file(tmp_path):
-    """A corrupt config.toml is renamed to .bak-<ts> before fresh write."""
-    config_path = tmp_path / "config.toml"
-    config_path.write_text("this is { not valid toml\n", encoding="utf-8")
-
-    console = _console()
-    init_flow._merge_config(config_path, "new-llm", "new-embed", console=console)
-
-    backups = list(tmp_path.glob("config.toml.bak-*"))
-    assert len(backups) == 1
-    assert backups[0].read_text(encoding="utf-8") == "this is { not valid toml\n"
-
-    output = console.file.getvalue()
-    assert "could not be parsed" in output
-
-    import tomllib
-
-    with config_path.open("rb") as fh:
-        new = tomllib.load(fh)
-    assert new["models"]["llm"] == "new-llm"
-    assert new["notes_chat"]["emb_model"] == "new-embed"
-
-
-def _stub_verify_deps(monkeypatch):
     monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
     monkeypatch.setattr(
         init_flow,
@@ -381,95 +64,258 @@ def _stub_verify_deps(monkeypatch):
         "_ffmpeg_installed",
         lambda: init_flow.DependencyStatus("ffmpeg", True, "7.1.1"),
     )
+    _stub_healthy_daemon(monkeypatch)
     monkeypatch.setattr(
-        init_flow,
-        "_ollama_installed",
-        lambda: init_flow.DependencyStatus("Ollama", True, "running · 0.1"),
-    )
-    monkeypatch.setattr(
-        init_flow, "_ollama_models", lambda: ["llama3.1:8b", "nomic-embed-text"]
+        "llm.registry.read_registry",
+        lambda path=None: (
+            registry if registry is not None else _registry_with_default()
+        ),
     )
 
 
-def test_verify_includes_screen_recording_permission_last(tmp_path, monkeypatch):
-    _stub_verify_deps(monkeypatch)
-    monkeypatch.setattr(
-        init_flow.audio_capture,
-        "check_permissions",
-        lambda: {"screen_recording": "granted", "microphone": "granted"},
-    )
-    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+# --- Apple-Silicon gate (AC-1) ----------------------------------------------
 
+
+def test_run_init_fails_fast_on_intel(tmp_path, monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "x86_64")
+
+    health_calls = []
+    monkeypatch.setattr(
+        "llm.client.LLMClient.health_sync",
+        lambda self, **kwargs: health_calls.append(True) or {},
+    )
+
+    console = _console()
     settings = _fake_settings(tmp_path)
-    statuses = init_flow.verify(settings, _console())
 
-    assert statuses[-1].name == "screen recording permission"
-    assert statuses[-1].installed is True
-    assert statuses[-1].detail == "granted"
+    code = init_flow.run_init(settings, console)
+
+    assert code == 7
+    output = console.file.getvalue()
+    assert "Apple Silicon" in output
+    assert "x86_64" in output
+    assert "homebrew" not in output  # no verify table printed
+    assert health_calls == []  # daemon never lazy-spawned
+    assert not settings.directories.notes_root.exists()  # no filesystem mutation
+    assert not settings.notes_chat.index_dir.exists()
 
 
-def test_verify_handles_denied_screen_recording(tmp_path, monkeypatch):
+def test_run_init_apple_silicon_passes_through(tmp_path, monkeypatch):
     _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
     monkeypatch.setattr(
-        init_flow.audio_capture,
-        "check_permissions",
-        lambda: {"screen_recording": "denied", "microphone": "granted"},
-    )
-    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
-
-    settings = _fake_settings(tmp_path)
-    statuses = init_flow.verify(settings, _console())
-
-    perm = next(s for s in statuses if s.name == "screen recording permission")
-    assert perm.installed is False
-    assert (
-        "denied — open System Settings → Privacy & Security → Screen Recording"
-        in perm.detail
+        init_flow.ChirpSettings,
+        "get_config_path",
+        lambda: tmp_path / "config.toml",
     )
 
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console, recheck=True)
 
-def test_verify_handles_missing_binary(tmp_path, monkeypatch):
+    assert code == 0
+    output = console.file.getvalue()
+    assert "checking what you've already got" in output
+    assert "homebrew" in output
+
+
+# --- verify() rows (AC-2, AC-3, AC-4) ----------------------------------------
+
+
+def test_verify_includes_daemon_and_registry_rows_no_ollama(tmp_path, monkeypatch):
     _stub_verify_deps(monkeypatch)
-
-    def _raise():
-        raise FileNotFoundError(
-            "capture_audio binary not found. Build it with: python -m audio_capture.build"
-        )
-
-    monkeypatch.setattr(init_flow.audio_capture, "check_permissions", _raise)
-    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
-
-    settings = _fake_settings(tmp_path)
-    statuses = init_flow.verify(settings, _console())
-
-    perm = next(s for s in statuses if s.name == "screen recording permission")
-    assert perm.installed is False
-    assert (
-        "capture_audio binary not built — run python -m audio_capture.build"
-        in perm.detail
-    )
-
-
-def test_verify_screen_recording_skipped_on_non_darwin(tmp_path, monkeypatch):
-    _stub_verify_deps(monkeypatch)
-
-    called = []
-
-    def _track():
-        called.append(True)
-        return {}
-
-    monkeypatch.setattr(init_flow.audio_capture, "check_permissions", _track)
     monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
 
-    settings = _fake_settings(tmp_path)
-    statuses = init_flow.verify(settings, _console())
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
 
-    perm = next(s for s in statuses if s.name == "screen recording permission")
-    assert perm.installed is True
-    assert perm.required is False
-    assert "not applicable on Linux" in perm.detail
-    assert called == [], "check_permissions must not be called on non-Darwin"
+    names = [s.name for s in statuses]
+    assert names == [
+        "homebrew",
+        "ffmpeg",
+        "chirpd",
+        "default chat model",
+        "screen recording permission",
+    ]
+    assert not any(n == "Ollama" or n.startswith("model:") for n in names)
+
+    chirpd = statuses[2]
+    assert chirpd.installed is True
+    assert chirpd.detail == "healthy · v0.1.0"
+
+    chat = statuses[3]
+    assert chat.installed is True
+    assert chat.detail == "default chat: gemma-4-4b-it-4bit"
+
+
+def test_verify_handles_daemon_spawn_failure(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+
+    def _spawn_failed(self, **kwargs):
+        raise LLMDaemonSpawnFailed("spawn timed out")
+
+    monkeypatch.setattr("llm.client.LLMClient.health_sync", _spawn_failed)
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    chirpd = next(s for s in statuses if s.name == "chirpd")
+    assert chirpd.installed is False
+    assert chirpd.required is True
+    assert "chirp daemon logs" in chirpd.detail
+
+
+def test_verify_handles_daemon_unreachable(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+
+    def _unreachable(self, **kwargs):
+        raise LLMDaemonUnreachable("socket refused connection")
+
+    monkeypatch.setattr("llm.client.LLMClient.health_sync", _unreachable)
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    chirpd = next(s for s in statuses if s.name == "chirpd")
+    assert chirpd.installed is False
+    assert "daemon unreachable" in chirpd.detail
+    assert "socket refused connection" in chirpd.detail
+
+
+def test_verify_handles_empty_registry(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch, registry=_empty_registry())
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    chat = next(s for s in statuses if s.name == "default chat model")
+    assert chat.installed is False
+    assert chat.required is False
+    assert "chirp models add mlx-community/gemma-4-4b-it-4bit" in chat.detail
+
+
+def test_verify_handles_missing_registry_file(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+
+    def _missing(path=None):
+        raise FileNotFoundError("models.toml absent")
+
+    monkeypatch.setattr("llm.registry.read_registry", _missing)
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    chat = next(s for s in statuses if s.name == "default chat model")
+    assert chat.installed is False
+    assert chat.required is False
+    assert "chirp models add" in chat.detail
+
+
+def test_run_init_prints_models_add_hint_when_registry_empty(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch, registry=_empty_registry())
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        init_flow.ChirpSettings,
+        "get_config_path",
+        lambda: tmp_path / "config.toml",
+    )
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console)
+
+    assert code == 0
+    output = console.file.getvalue()
+    assert "chirp models add mlx-community/gemma-4-4b-it-4bit" in output
+    assert "ollama" not in output.lower()
+
+
+# --- --switch-model (AC-7) ----------------------------------------------------
+
+
+def test_switch_model_with_empty_registry_prints_models_add_hint(tmp_path, monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        "llm.registry.read_registry", lambda path=None: _empty_registry()
+    )
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console, switch_model=True)
+
+    assert code == 0
+    output = console.file.getvalue()
+    assert "chirp models add mlx-community/gemma-4-4b-it-4bit" in output
+    assert "pick" not in output.lower()  # no tag picker shown
+
+
+def test_switch_model_with_registered_aliases_calls_set_default(tmp_path, monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+    registry = _registry_with_default(
+        "gemma-4-4b-it-4bit", extra_aliases=["qwen2.5-7b-instruct-4bit"]
+    )
+    monkeypatch.setattr("llm.registry.read_registry", lambda path=None: registry)
+
+    written = []
+    monkeypatch.setattr(
+        "llm.registry.write_registry", lambda reg, path=None: written.append(reg)
+    )
+
+    console = _console()
+    # Aliases listed sorted: 1=gemma..., 2=qwen... — pick the second.
+    monkeypatch.setattr(console, "input", lambda *args, **kwargs: "2")
+
+    code = init_flow.run_init(_fake_settings(tmp_path), console, switch_model=True)
+
+    assert code == 0
+    # The real set_default_for_role ran; the written registry proves the flip.
+    assert len(written) == 1
+    assert written[0].default_chat == "qwen2.5-7b-instruct-4bit"
+
+
+def test_switch_model_user_abort_returns_one(tmp_path, monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        "llm.registry.read_registry", lambda path=None: _registry_with_default()
+    )
+
+    console = _console()
+
+    def _interrupt(*args, **kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(console, "input", _interrupt)
+
+    code = init_flow.run_init(_fake_settings(tmp_path), console, switch_model=True)
+    assert code == 1
+
+
+# --- install_missing (AC-5) ---------------------------------------------------
+
+
+def test_install_missing_surfaces_daemon_failure_without_installing(monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
+
+    run_calls: list[list[str]] = []
+
+    def _fake_run(args, timeout=10.0):
+        run_calls.append(list(args))
+        return 0, ""
+
+    monkeypatch.setattr(init_flow, "_run", _fake_run)
+
+    statuses = [
+        init_flow.DependencyStatus(
+            "chirpd",
+            False,
+            "daemon could not be started — run 'chirp daemon logs' for details",
+        )
+    ]
+
+    console = _console()
+    result = init_flow.install_missing(console, statuses)
+
+    assert result is False
+    assert run_calls == []  # nothing brew-installable for the daemon
+    output = console.file.getvalue()
+    assert "chirp daemon logs" in output
 
 
 def test_install_missing_dispatches_build_for_missing_binary(tmp_path, monkeypatch):
@@ -503,60 +349,6 @@ def test_install_missing_dispatches_build_for_missing_binary(tmp_path, monkeypat
     )
 
 
-def test_verify_handles_undetermined_screen_recording(tmp_path, monkeypatch):
-    _stub_verify_deps(monkeypatch)
-    monkeypatch.setattr(
-        init_flow.audio_capture,
-        "check_permissions",
-        lambda: {"screen_recording": "undetermined", "microphone": "granted"},
-    )
-    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
-
-    settings = _fake_settings(tmp_path)
-    statuses = init_flow.verify(settings, _console())
-
-    perm = next(s for s in statuses if s.name == "screen recording permission")
-    assert perm.installed is True
-    assert perm.required is False
-    assert perm.detail == "will prompt on first record"
-
-
-def test_verify_handles_runtime_error_from_check_permissions(tmp_path, monkeypatch):
-    _stub_verify_deps(monkeypatch)
-
-    def _raise():
-        raise RuntimeError("malformed permission line in helper output: 'garbage'")
-
-    monkeypatch.setattr(init_flow.audio_capture, "check_permissions", _raise)
-    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
-
-    settings = _fake_settings(tmp_path)
-    statuses = init_flow.verify(settings, _console())
-
-    perm = next(s for s in statuses if s.name == "screen recording permission")
-    assert perm.installed is False
-    assert "permission probe failed" in perm.detail
-    assert "malformed permission line in helper output: 'garbage'" in perm.detail
-
-
-def test_verify_guards_against_unexpected_permission_state(tmp_path, monkeypatch):
-    _stub_verify_deps(monkeypatch)
-    monkeypatch.setattr(
-        init_flow.audio_capture,
-        "check_permissions",
-        lambda: {"screen_recording": "BUSTED", "microphone": "granted"},
-    )
-    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
-
-    settings = _fake_settings(tmp_path)
-    statuses = init_flow.verify(settings, _console())
-
-    perm = next(s for s in statuses if s.name == "screen recording permission")
-    assert perm.installed is False
-    assert "unexpected permission state" in perm.detail
-    assert "BUSTED" in perm.detail
-
-
 def test_install_missing_surfaces_denied_permission_without_dispatching(monkeypatch):
     monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
@@ -585,3 +377,398 @@ def test_install_missing_surfaces_denied_permission_without_dispatching(monkeypa
     output = console.file.getvalue()
     assert "screen recording permission must be granted manually" in output
     assert "init incomplete" in output
+
+
+# --- run_init orchestration (AC-6) ---------------------------------------------
+
+
+def test_run_init_recheck_short_circuits(tmp_path, monkeypatch):
+    """--recheck returns 0 after the verify table without install/finalize."""
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+
+    finalize_calls = []
+    monkeypatch.setattr(
+        init_flow, "_finalize_paths", lambda *a, **k: finalize_calls.append(True)
+    )
+
+    code = init_flow.run_init(_fake_settings(tmp_path), _console(), recheck=True)
+
+    assert code == 0
+    assert finalize_calls == []
+
+
+def test_run_init_phases_run_in_order(tmp_path, monkeypatch):
+    """Smoke: run_init walks gate → verify → install → finalize."""
+    calls: list[str] = []
+
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        init_flow,
+        "verify",
+        lambda settings, console: (
+            calls.append("verify")
+            or [init_flow.DependencyStatus("homebrew", False, "missing")]
+        ),
+    )
+    monkeypatch.setattr(init_flow, "_confirm", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        init_flow,
+        "install_missing",
+        lambda console, statuses: calls.append("install") or True,
+    )
+    monkeypatch.setattr(
+        init_flow,
+        "_finalize_paths",
+        lambda *args, **kwargs: calls.append("finalize"),
+    )
+
+    code = init_flow.run_init(_fake_settings(tmp_path), _console())
+    assert code == 0
+    assert calls == ["verify", "install", "finalize"]
+
+
+def test_run_init_rerun_is_idempotent_and_preserves_user_keys(tmp_path, monkeypatch):
+    """AC-11: run twice in a tmp HOME, assert second run preserves a hand-edited key."""
+    config_path = tmp_path / "config.toml"
+
+    settings = _fake_settings(tmp_path)
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(init_flow.ChirpSettings, "get_config_path", lambda: config_path)
+
+    code = init_flow.run_init(settings, _console())
+    assert code == 0
+    assert config_path.exists()
+
+    import tomllib
+
+    import tomli_w
+
+    with config_path.open("rb") as fh:
+        first = tomllib.load(fh)
+    first["user_custom"] = {"theme": "midnight"}
+    with config_path.open("wb") as fh:
+        tomli_w.dump(first, fh)
+
+    first_mtime = config_path.stat().st_mtime
+    import time as _time
+
+    _time.sleep(0.01)
+
+    code = init_flow.run_init(settings, _console())
+    assert code == 0
+    assert config_path.stat().st_mtime == first_mtime  # existing config untouched
+
+    with config_path.open("rb") as fh:
+        second = tomllib.load(fh)
+    assert second["user_custom"] == {"theme": "midnight"}
+
+
+def test_merge_config_backs_up_corrupt_file(tmp_path):
+    """A corrupt config.toml is renamed to .bak-<ts> before fresh write."""
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("this is { not valid toml\n", encoding="utf-8")
+
+    console = _console()
+    init_flow._merge_config(config_path, console=console)
+
+    backups = list(tmp_path.glob("config.toml.bak-*"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == "this is { not valid toml\n"
+
+    output = console.file.getvalue()
+    assert "could not be parsed" in output
+    assert config_path.exists()
+
+
+# --- screen-recording permission rows (unchanged behavior from story 2.3) -----
+
+
+def test_verify_includes_screen_recording_permission_last(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(
+        init_flow.audio_capture,
+        "check_permissions",
+        lambda: {"screen_recording": "granted", "microphone": "granted"},
+    )
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    assert statuses[-1].name == "screen recording permission"
+    assert statuses[-1].installed is True
+    assert statuses[-1].detail == "granted"
+
+
+def test_verify_handles_denied_screen_recording(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(
+        init_flow.audio_capture,
+        "check_permissions",
+        lambda: {"screen_recording": "denied", "microphone": "granted"},
+    )
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    perm = next(s for s in statuses if s.name == "screen recording permission")
+    assert perm.installed is False
+    assert (
+        "denied — open System Settings → Privacy & Security → Screen Recording"
+        in perm.detail
+    )
+
+
+def test_verify_handles_missing_binary(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+
+    def _raise():
+        raise FileNotFoundError(
+            "capture_audio binary not found. Build it with: python -m audio_capture.build"
+        )
+
+    monkeypatch.setattr(init_flow.audio_capture, "check_permissions", _raise)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    perm = next(s for s in statuses if s.name == "screen recording permission")
+    assert perm.installed is False
+    assert (
+        "capture_audio binary not built — run python -m audio_capture.build"
+        in perm.detail
+    )
+
+
+def test_verify_screen_recording_skipped_on_non_darwin(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+
+    called = []
+
+    def _track():
+        called.append(True)
+        return {}
+
+    monkeypatch.setattr(init_flow.audio_capture, "check_permissions", _track)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    perm = next(s for s in statuses if s.name == "screen recording permission")
+    assert perm.installed is True
+    assert perm.required is False
+    assert "not applicable on Linux" in perm.detail
+    assert called == [], "check_permissions must not be called on non-Darwin"
+
+
+def test_verify_handles_undetermined_screen_recording(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(
+        init_flow.audio_capture,
+        "check_permissions",
+        lambda: {"screen_recording": "undetermined", "microphone": "granted"},
+    )
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    perm = next(s for s in statuses if s.name == "screen recording permission")
+    assert perm.installed is True
+    assert perm.required is False
+    assert perm.detail == "will prompt on first record"
+
+
+def test_verify_handles_runtime_error_from_check_permissions(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+
+    def _raise():
+        raise RuntimeError("malformed permission line in helper output: 'garbage'")
+
+    monkeypatch.setattr(init_flow.audio_capture, "check_permissions", _raise)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    perm = next(s for s in statuses if s.name == "screen recording permission")
+    assert perm.installed is False
+    assert "permission probe failed" in perm.detail
+    assert "malformed permission line in helper output: 'garbage'" in perm.detail
+
+
+def test_verify_guards_against_unexpected_permission_state(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(
+        init_flow.audio_capture,
+        "check_permissions",
+        lambda: {"screen_recording": "BUSTED", "microphone": "granted"},
+    )
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    perm = next(s for s in statuses if s.name == "screen recording permission")
+    assert perm.installed is False
+    assert "unexpected permission state" in perm.detail
+    assert "BUSTED" in perm.detail
+
+
+# --- helper-level coverage ------------------------------------------------------
+
+
+def test_run_returns_127_on_missing_binary():
+    code, out = init_flow._run(["/nonexistent/definitely-not-a-binary"])
+    assert code == 127
+    assert out
+
+
+def test_brew_missing_is_required_on_darwin(monkeypatch):
+    monkeypatch.setattr(init_flow, "_which", lambda _cmd: None)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+
+    status = init_flow._brew_installed()
+
+    assert status.installed is False
+    assert status.required is True
+    assert "brew.sh" in status.detail
+
+
+def test_ffmpeg_version_parsed_from_output(monkeypatch):
+    monkeypatch.setattr(init_flow, "_which", lambda _cmd: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(
+        init_flow, "_run", lambda args, timeout=10.0: (0, "ffmpeg version 7.1.1 etc\n")
+    )
+
+    status = init_flow._ffmpeg_installed()
+
+    assert status.installed is True
+    assert status.detail == "7.1.1"
+
+
+def test_ffmpeg_missing(monkeypatch):
+    monkeypatch.setattr(init_flow, "_which", lambda _cmd: None)
+    assert init_flow._ffmpeg_installed().installed is False
+
+
+def test_confirm_answers(monkeypatch):
+    console = _console()
+
+    monkeypatch.setattr(console, "input", lambda *a, **k: "")
+    assert init_flow._confirm(console, "go?") is True
+
+    monkeypatch.setattr(console, "input", lambda *a, **k: "n")
+    assert init_flow._confirm(console, "go?") is False
+
+    monkeypatch.setattr(console, "input", lambda *a, **k: "yes")
+    assert init_flow._confirm(console, "go?", default=False) is True
+
+    def _interrupt(*a, **k):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(console, "input", _interrupt)
+    assert init_flow._confirm(console, "go?") is False
+
+
+def test_install_missing_is_macos_only(monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    assert init_flow.install_missing(_console(), []) is False
+
+
+def test_install_missing_requires_brew(monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(init_flow, "_which", lambda _cmd: None)
+    assert init_flow.install_missing(_console(), []) is False
+
+
+def test_install_missing_brew_installs_ffmpeg(monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
+
+    run_calls: list[list[str]] = []
+    monkeypatch.setattr(
+        init_flow,
+        "_run",
+        lambda args, timeout=10.0: run_calls.append(list(args)) or (0, ""),
+    )
+
+    statuses = [init_flow.DependencyStatus("ffmpeg", False, "not found")]
+    assert init_flow.install_missing(_console(), statuses) is True
+    assert run_calls == [["/usr/bin/brew", "install", "ffmpeg"]]
+
+
+def test_install_missing_surfaces_brew_failure(monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
+    monkeypatch.setattr(
+        init_flow, "_run", lambda args, timeout=10.0: (1, "Error: install exploded")
+    )
+
+    statuses = [init_flow.DependencyStatus("ffmpeg", False, "not found")]
+    console = _console()
+    assert init_flow.install_missing(console, statuses) is False
+    assert "install exploded" in console.file.getvalue()
+
+
+def test_switch_model_blank_input_keeps_current(tmp_path, monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        "llm.registry.read_registry", lambda path=None: _registry_with_default()
+    )
+    written = []
+    monkeypatch.setattr(
+        "llm.registry.write_registry", lambda reg, path=None: written.append(reg)
+    )
+
+    console = _console()
+    monkeypatch.setattr(console, "input", lambda *a, **k: "")
+
+    code = init_flow.run_init(_fake_settings(tmp_path), console, switch_model=True)
+    assert code == 0
+    assert written == []
+
+
+def test_switch_model_invalid_selection_returns_one(tmp_path, monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        "llm.registry.read_registry", lambda path=None: _registry_with_default()
+    )
+
+    console = _console()
+    monkeypatch.setattr(console, "input", lambda *a, **k: "99")
+
+    code = init_flow.run_init(_fake_settings(tmp_path), console, switch_model=True)
+    assert code == 1
+    assert "invalid selection" in console.file.getvalue()
+
+
+def test_run_init_user_declines_install(tmp_path, monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(
+        init_flow,
+        "verify",
+        lambda settings, console: [
+            init_flow.DependencyStatus("ffmpeg", False, "not found")
+        ],
+    )
+    monkeypatch.setattr(init_flow, "_confirm", lambda *a, **k: False)
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console)
+
+    assert code == 1
+    assert "skipped install" in console.file.getvalue()
+
+
+def test_finalize_paths_preserves_existing_config(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text('[user_custom]\ntheme = "midnight"\n', encoding="utf-8")
+    original_mtime = config_path.stat().st_mtime
+
+    settings = _fake_settings(tmp_path)
+    monkeypatch.setattr(init_flow.ChirpSettings, "get_config_path", lambda: config_path)
+
+    init_flow._finalize_paths(settings, _console())
+
+    assert config_path.stat().st_mtime == original_mtime
+    assert (settings.notes_chat.index_dir / "chroma").exists()
+    assert settings.directories.notes_root.exists()

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -772,3 +772,42 @@ def test_finalize_paths_preserves_existing_config(tmp_path, monkeypatch):
     assert config_path.stat().st_mtime == original_mtime
     assert (settings.notes_chat.index_dir / "chroma").exists()
     assert settings.directories.notes_root.exists()
+
+
+def test_verify_surfaces_malformed_registry(tmp_path, monkeypatch):
+    from llm.exceptions import LLMMalformedResponse
+
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+
+    def _corrupt(path=None):
+        raise LLMMalformedResponse("models.toml is not valid TOML")
+
+    monkeypatch.setattr("llm.registry.read_registry", _corrupt)
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    chat = next(s for s in statuses if s.name == "default chat model")
+    assert chat.installed is False
+    assert "registry unreadable" in chat.detail
+    assert "not valid TOML" in chat.detail
+    assert "chirp models add" not in chat.detail  # not the fresh-install hint
+
+
+def test_switch_model_surfaces_malformed_registry(tmp_path, monkeypatch):
+    from llm.exceptions import LLMMalformedResponse
+
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+
+    def _corrupt(path=None):
+        raise LLMMalformedResponse("models.toml is not valid TOML")
+
+    monkeypatch.setattr("llm.registry.read_registry", _corrupt)
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console, switch_model=True)
+
+    assert code == 1
+    output = console.file.getvalue()
+    assert "registry unreadable" in output
+    assert "chirp models add" not in output


### PR DESCRIPTION
## Summary

Story 7.1 (EPIC-INIT-AND-MIGRATION): `chirp init` is now chirpd-shaped.

- **Phase-0 Apple-Silicon gate** — non-arm64 fails fast with a single-line message and exit code `7`, before any verify/daemon/filesystem work.
- **Daemon-readiness row** (`chirpd`) — driven by `LLMClient().health_sync()`; the client owns lazy-spawn and the version handshake. Spawn failure → `chirp daemon logs` pointer; other transport errors → `daemon unreachable: <reason>`.
- **Default-chat-model row** — registry-backed via `llm.registry.read_registry()`; unconfigured is a non-blocking first-run state pointing at `chirp models add mlx-community/gemma-4-4b-it-4bit` (with the smaller `gemma-4-e2b-it-8bit` alternative). Constants `RECOMMENDED_CHAT_REPO`/`SMALLER_CHAT_REPO` are the single source of truth for stories 7.2/7.5.
- **`--switch-model`** flips `models.toml`'s `default_chat` via `set_default_for_role` + `write_registry` directly (no subprocess), listing registered chat aliases with the current default starred.
- **Deleted**: the entire Ollama verify/install/pick/pull surface (`CHAT_MODELS`, `EMBEDDING_MODELS`, `ModelOption`, `_ollama_installed`, `_ollama_models`, `_model_installed`, `pick_models`, `_pick`, `keep_or_pick`, `_pull_model`, `_parse_percent`, `requests` probes). `pull_and_finalize` → `_finalize_paths`; `_merge_config` no longer writes model tags.

As-built deviations (verified against live surfaces): health payload's version key is `version` (not `daemon_version`); `read_registry()` returns an empty `Registry` on a missing file rather than raising.

## Test plan

- [x] 38 tests in `tests/test_init_flow.py` — the eight AC-8 scenarios plus helper-branch coverage; no real daemon spawned, no real models.toml written
- [x] Coverage on `chirp/init_flow.py`: 97% (gate ≥90%)
- [x] `make check` clean; full suite 1422 passed
- [x] `rg -n "ollama|requests\." chirp/init_flow.py` → zero; `chirp --help` / `chirp init --help` ollama-free
- [x] Live smoke: `chirp init --recheck` → all rows green (`chirpd · healthy · v0.0.1a0`); `chirp init --switch-model` lists aliases, blank keeps current