### PR TITLE
feat(init): detect leftover Ollama installs on --recheck and print migration plan (story 7.2)

### DIFF
--- a/_bmad-output/planning-artifacts/epic-init-and-migration/stories/7.2-recheck-ollama-detect-and-migration-plan.md
+++ b/_bmad-output/planning-artifacts/epic-init-and-migration/stories/7.2-recheck-ollama-detect-and-migration-plan.md
@@ -1,6 +1,6 @@
 # Story 7.2 — `chirp init --recheck`: Ollama-detection and loud migration plan
 
-- **Status:** Draft
+- **Status:** Review — implemented on branch `feat/story-7.2-recheck-migration-plan` (stacked on 7.1). All ACs verified; live Devon-scenario smoke ran on a machine with real Ollama remnants (all three heuristics fired). See **Dev Agent Record**.
 - **Epic:** [EPIC-INIT-AND-MIGRATION](../epic.md)
 - **Depends on:** 7.1 (the new `verify()` shape and Apple-Silicon gate must already be in place; the migration plan prints **after** the verify table)
 - **Blocks:** —
@@ -143,3 +143,26 @@ Files to touch:
 - **Manual Devon scenario:** on a Mac with `brew install ollama` already done, run `chirp init --recheck`. Confirm the plan prints, the "Detected on this machine" section shows `[ollama on PATH]  yes`, and no `subprocess` to brew was issued. Then `brew uninstall ollama`, leave `~/.ollama` in place, re-run `chirp init --recheck` — plan still prints (`[~/.ollama directory]  yes`). Then `rm -rf ~/.ollama`, re-run — plan no longer prints.
 - **Manual no-Ollama path:** on a Mac that never had Ollama (Maya's machine simulation: ensure `which ollama` is empty, `~/.ollama` absent, `ollama` not importable), run `chirp init --recheck` — only the verify table prints, no migration plan.
 - **Manual no-mutation check:** put a tripwire file at `~/.ollama/CANARY`, run `chirp init --recheck`, confirm the file is still there afterwards. (Belt-and-suspenders for AC-4.)
+
+## Dev Agent Record
+
+### Completion Notes
+
+- **AC-1/AC-5** Detection + plan hook sits inside `run_init`'s `if recheck:` branch, after `verify()` returns; full `chirp init` never calls `_detect_ollama_install` (asserted by `test_full_init_no_recheck_does_not_print_plan`); empty detection ends `--recheck` silently after the table.
+- **AC-2** `_detect_ollama_install()` returns the exact three-key dict; `_try_import_ollama_module()` wraps the import probe.
+- **AC-3** Plan rendered per the binding structure. One rendering nuance: the bracketed detection labels (`[ollama on PATH]` etc.) must print with `markup=False` — Rich otherwise parses them as markup tags and swallows them.
+- **AC-4** No subprocess/filesystem/env mutation in any added code path; `test_recheck_plan_does_not_mutate_ollama_install` patches `subprocess.run` with an AssertionError mock.
+- **AC-6** The plan call site is a single straight-line block after `verify()` — no retry path re-enters it.
+- **AC-7** Both `chirp models add` examples interpolate `RECOMMENDED_CHAT_REPO` / `SMALLER_CHAT_REPO` from story 7.1's constants.
+- **AC-8** All seven named tests implemented (45 total in the file).
+- **AC-9** `make check` clean; coverage on `chirp/init_flow.py` 97%.
+- **AC-10 (live)** This machine has real remnants (`/opt/homebrew/bin/ollama`, `~/.ollama`, importable module): `chirp init --recheck` printed the table then the plan with all three heuristics `yes`. The uninstall-then-recheck regression half of AC-10 is the operator's cleanup decision.
+
+### File List
+
+- `chirp/init_flow.py` (modified — `_detect_ollama_install`, `_try_import_ollama_module`, `_print_migration_plan`, recheck hook)
+- `tests/test_init_flow.py` (modified — seven AC-8 tests added)
+
+## Change Log
+
+- 2026-06-11: Story 7.2 implemented — `--recheck` detects leftover Ollama installs (PATH/data-dir/module heuristics) and prints the loud, informational-only migration plan. Status → Review.

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -518,6 +518,85 @@ def _path_line(
     return line
 
 
+def _try_import_ollama_module() -> bool:
+    try:
+        import ollama  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _detect_ollama_install() -> dict[str, bool]:
+    """Heuristics for a leftover Ollama install (OR'd; any one is enough)."""
+    return {
+        "cli_on_path": shutil.which("ollama") is not None,
+        "data_dir_present": (Path.home() / ".ollama").is_dir(),
+        "python_module_importable": _try_import_ollama_module(),
+    }
+
+
+_DETECTION_LABELS = {
+    "cli_on_path": "[ollama on PATH]",
+    "data_dir_present": "[~/.ollama directory]",
+    "python_module_importable": "[ollama python module]",
+}
+
+
+def _print_migration_plan(console: Console, detection: dict[str, bool]) -> None:
+    """Print the loud, informational-only Ollama migration plan.
+
+    PRD §Project Scoping → Out of Scope forbids auto-uninstalling Ollama —
+    cleanup commands are shown for the user to run, never executed. OQ6 is
+    resolved to a loud multi-line plan (Devon's journey): offline-friendly
+    and explicit beats a one-line pointer at an external URL.
+    """
+    rule = " [dim]──────────────────────────────────────────────────────────[/dim]"
+    console.print()
+    console.print(rule)
+    console.print(" [bold]Ollama migration[/bold]")
+    console.print(rule)
+    console.print(
+        " chirp 2.x no longer uses Ollama. The bundled chirpd daemon\n"
+        " (visible in the verify table above) replaces it for chat\n"
+        " and embeddings."
+    )
+    console.print()
+    console.print(" Your existing chirp data is unchanged:")
+    console.print(
+        "   · ~/Documents/chirp/<slug>/        [dim](notes, transcripts, audio)[/dim]"
+    )
+    console.print("   · ~/.chirp/config.toml             [dim](settings)[/dim]")
+    console.print("   · ~/.chirp/chroma/                 [dim](search index)[/dim]")
+    console.print()
+    console.print(" To finish the migration:")
+    console.print("   1. Pick an MLX model [dim](GGUF models do not work)[/dim]:")
+    console.print(f"        [bold]chirp models add {RECOMMENDED_CHAT_REPO}[/bold]")
+    console.print("      [dim](~2 GB, balanced quality and speed)[/dim]")
+    console.print()
+    console.print("      Tight on RAM? Use the smaller-footprint variant:")
+    console.print(f"        [bold]chirp models add {SMALLER_CHAT_REPO}[/bold]")
+    console.print("   2. (Optional) Once you're satisfied with the new setup,")
+    console.print(
+        "      clean up Ollama manually. chirp will [bold]NOT[/bold] do this for you:"
+    )
+    console.print(
+        "        [dim]brew uninstall ollama        # if installed via Homebrew[/dim]"
+    )
+    console.print(
+        "        [dim]rm -rf ~/.ollama             # reclaims ~5 GB of GGUF files[/dim]"
+    )
+    console.print(
+        "        [dim]unset OLLAMA_HOST            # if set in your shell rc[/dim]"
+    )
+    console.print()
+    console.print(" Detected on this machine:")
+    for key, label in _DETECTION_LABELS.items():
+        answer = "yes" if detection.get(key) else "no"
+        # markup=False: the bracketed labels would otherwise parse as Rich tags.
+        console.print(f"   {label.ljust(28)}{answer}", markup=False)
+    console.print(rule)
+
+
 def run_init(
     settings: ChirpSettings,
     console: Console,
@@ -534,6 +613,11 @@ def run_init(
 
     statuses = verify(settings, console)
     if recheck:
+        # --recheck is the migration touchpoint (Devon's journey); full init
+        # is the fresh-setup flow and stays free of migration noise.
+        detection = _detect_ollama_install()
+        if any(detection.values()):
+            _print_migration_plan(console, detection)
         return 0
 
     missing = [s for s in statuses if s.required and not s.installed]

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -772,3 +772,137 @@ def test_finalize_paths_preserves_existing_config(tmp_path, monkeypatch):
     assert config_path.stat().st_mtime == original_mtime
     assert (settings.notes_chat.index_dir / "chroma").exists()
     assert settings.directories.notes_root.exists()
+
+
+# --- --recheck Ollama migration plan (story 7.2) ---------------------------------
+
+
+def _stub_detection(monkeypatch, tmp_path, cli=False, data_dir=False, module=False):
+    """Control the three _detect_ollama_install heuristics."""
+    monkeypatch.setattr(
+        init_flow.shutil,
+        "which",
+        lambda cmd: "/opt/homebrew/bin/ollama" if (cmd == "ollama" and cli) else None,
+    )
+    fake_home = tmp_path / "home"
+    fake_home.mkdir(exist_ok=True)
+    if data_dir:
+        (fake_home / ".ollama").mkdir()
+    monkeypatch.setattr(init_flow.Path, "home", lambda: fake_home)
+    monkeypatch.setattr(init_flow, "_try_import_ollama_module", lambda: module)
+
+
+def test_recheck_with_no_ollama_detected_prints_no_plan(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    _stub_detection(monkeypatch, tmp_path)
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console, recheck=True)
+
+    assert code == 0
+    output = console.file.getvalue()
+    assert "checking what you've already got" in output  # verify table printed
+    assert "Ollama migration" not in output
+
+
+def test_recheck_with_ollama_cli_on_path_prints_plan(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    _stub_detection(monkeypatch, tmp_path, cli=True)
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console, recheck=True)
+
+    assert code == 0
+    output = console.file.getvalue()
+    assert "Ollama migration" in output
+    assert f"chirp models add {init_flow.RECOMMENDED_CHAT_REPO}" in output
+    assert "[ollama on PATH]            yes" in output
+    # The plan prints after the verify table.
+    assert output.index("checking what you've already got") < output.index(
+        "Ollama migration"
+    )
+
+
+def test_recheck_with_data_dir_only_prints_plan(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    _stub_detection(monkeypatch, tmp_path, data_dir=True)
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console, recheck=True)
+
+    assert code == 0
+    output = console.file.getvalue()
+    assert "Ollama migration" in output
+    assert "[~/.ollama directory]       yes" in output
+    assert "[ollama on PATH]            no" in output
+    assert "[ollama python module]      no" in output
+
+
+def test_recheck_with_python_module_importable_prints_plan(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    _stub_detection(monkeypatch, tmp_path, module=True)
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console, recheck=True)
+
+    assert code == 0
+    output = console.file.getvalue()
+    assert "Ollama migration" in output
+    assert "[ollama python module]      yes" in output
+
+
+def test_recheck_plan_does_not_mutate_ollama_install(tmp_path, monkeypatch):
+    from unittest.mock import Mock
+
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    _stub_detection(monkeypatch, tmp_path, cli=True, data_dir=True, module=True)
+    monkeypatch.setattr(
+        init_flow.subprocess,
+        "run",
+        Mock(side_effect=AssertionError("must not call subprocess during recheck")),
+    )
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console, recheck=True)
+
+    assert code == 0
+    output = console.file.getvalue()
+    assert "Ollama migration" in output
+    assert "chirp will NOT do this for you" in output
+    # All three heuristics fired and were reported.
+    assert output.count("yes") >= 3
+
+
+def test_full_init_no_recheck_does_not_print_plan(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    _stub_detection(monkeypatch, tmp_path, cli=True, data_dir=True, module=True)
+    monkeypatch.setattr(
+        init_flow.ChirpSettings,
+        "get_config_path",
+        lambda: tmp_path / "config.toml",
+    )
+
+    console = _console()
+    code = init_flow.run_init(_fake_settings(tmp_path), console)
+
+    assert code == 0
+    assert "Ollama migration" not in console.file.getvalue()
+
+
+def test_plan_recommends_default_chat_repo(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    _stub_detection(monkeypatch, tmp_path, cli=True)
+
+    console = _console()
+    init_flow.run_init(_fake_settings(tmp_path), console, recheck=True)
+
+    output = console.file.getvalue()
+    assert "mlx-community/gemma-4-4b-it-4bit" in output
+    assert init_flow.SMALLER_CHAT_REPO in output


### PR DESCRIPTION
## Summary

Story 7.2 (EPIC-INIT-AND-MIGRATION) — **stacked on #89 (story 7.1)**; merge that first, this PR retargets to main automatically.

- `chirp init --recheck` runs three OR'd detection heuristics after the verify table: `ollama` on PATH, `~/.ollama` directory present, `ollama` Python module importable.
- Any hit prints the loud multi-line **Ollama migration** plan (Devon's journey, OQ6 resolved to loud): your-data-is-unchanged reassurance, `chirp models add` commands interpolated from 7.1's `RECOMMENDED_CHAT_REPO`/`SMALLER_CHAT_REPO`, and manual cleanup commands chirp explicitly will **NOT** run (PRD out-of-scope: auto-uninstall).
- Informational only — no subprocess, filesystem, or env mutation anywhere in the added paths; a strict `subprocess.run` mock test enforces it.
- Full `chirp init` (no `--recheck`) never detects or prints; empty detection ends `--recheck` silently.

## Test plan

- [x] Seven AC-8 tests (45 total in `test_init_flow.py`); coverage on `chirp/init_flow.py` 97%
- [x] `make check` clean; lint/format/mypy green
- [x] Live Devon smoke on a machine with real remnants: verify table → plan, all three heuristics `yes`, `~/.ollama` untouched