### PR TITLE
fix(chirpd): release MLX Metal buffer cache on model unload

### DIFF
--- a/chirpd/backend.py
+++ b/chirpd/backend.py
@@ -147,7 +147,17 @@ class MLXBackend:
             handle.pop("model", None)
             handle.pop("tokenizer", None)
             handle.pop("processor", None)
-        await asyncio.to_thread(gc.collect)
+
+        def _collect_and_release() -> None:
+            gc.collect()
+            # gc only drops the Python references; MLX parks freed Metal
+            # buffers in its allocator cache, so without clearing it the
+            # daemon's resident memory never shrinks after an idle unload.
+            import mlx.core as mx
+
+            mx.clear_cache()
+
+        await asyncio.to_thread(_collect_and_release)
 
     async def stream_generate(  # pragma: no cover — exercised via opt-in @slow tests
         self,

--- a/chirpd/backend.py
+++ b/chirpd/backend.py
@@ -153,8 +153,12 @@ class MLXBackend:
             # gc only drops the Python references; MLX parks freed Metal
             # buffers in its allocator cache, so without clearing it the
             # daemon's resident memory never shrinks after an idle unload.
-            import mlx.core as mx
-
+            # Best-effort: MLX is gated to darwin+arm64, so off that platform
+            # there is no cache to clear and the import simply won't resolve.
+            try:
+                import mlx.core as mx
+            except ImportError:
+                return
             mx.clear_cache()
 
         await asyncio.to_thread(_collect_and_release)

--- a/tests/chirpd/test_backend_fake.py
+++ b/tests/chirpd/test_backend_fake.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import sys
+import types
 
 import pytest
 
@@ -162,3 +164,44 @@ def test_apply_chat_template_no_thinking_falls_back_on_typeerror() -> None:
     # First call attempts with enable_thinking; fallback call omits it.
     assert "enable_thinking" in seen_kwargs[0]
     assert "enable_thinking" not in seen_kwargs[1]
+
+
+async def test_mlx_backend_unload_clears_handle_and_survives_missing_mlx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """unload() drops the heavy handle refs and treats MLX as best-effort.
+
+    MLX is gated to darwin+arm64, so on other CI platforms `import mlx.core`
+    raises ImportError — unload must swallow it (there is no cache to clear)
+    rather than failing the model.unload op.
+    """
+    from chirpd.backend import MLXBackend
+
+    # A None entry in sys.modules makes `import mlx.core` raise ImportError,
+    # simulating a non-darwin/arm64 host where the dep isn't installed.
+    monkeypatch.setitem(sys.modules, "mlx", None)
+    monkeypatch.setitem(sys.modules, "mlx.core", None)
+
+    handle = {"repo": "r", "role": "chat", "model": object(), "tokenizer": object()}
+    await MLXBackend().unload(handle)  # must not raise
+
+    assert "model" not in handle
+    assert "tokenizer" not in handle
+
+
+async def test_mlx_backend_unload_clears_cache_when_mlx_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When MLX is importable, unload() clears its Metal allocator cache."""
+    from chirpd.backend import MLXBackend
+
+    cleared: list[bool] = []
+    fake_mlx_core = types.SimpleNamespace(clear_cache=lambda: cleared.append(True))
+    fake_mlx = types.ModuleType("mlx")
+    fake_mlx.core = fake_mlx_core  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "mlx", fake_mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", fake_mlx_core)
+
+    await MLXBackend().unload({"model": object()})
+
+    assert cleared == [True]


### PR DESCRIPTION
## Summary

Colby noticed the daemon holding ~4 GB long after going idle. Investigation: the idle-unload lifecycle works (the `model.unload` op fires on schedule, Ollama-`keep_alive`-style), but `MLXBackend.unload` only dropped Python references + `gc.collect()` — MLX keeps freed Metal buffers in its allocator cache, so the process RSS never shrank.

Fix: `mx.clear_cache()` after the collect, in the same `asyncio.to_thread` worker.

## Evidence (M4, llama-3.2-1b-instruct-4bit, `CHIRP_MODEL_IDLE_TIMEOUT=15`, isolated socket)

| | RSS loaded | RSS 25 s after last use |
|---|---|---|
| before | 1255 MB | **1255 MB** (unload logged, memory kept) |
| after | 1248 MB | **585 MB** (framework baseline) |

A 7B-class default chat model returns ~4.3 GB on unload.

## Test plan

- [x] `tests/chirpd` + `tests/llm`: 570 passed (FakeBackend paths unaffected; MLXBackend.unload exercised via the live measurement above)
- [x] ruff/mypy clean