### PR TITLE
chore: expand ruff lint rule coverage

### DIFF
--- a/.docs/DEMO_SCRIPT.md
+++ b/.docs/DEMO_SCRIPT.md
@@ -1,0 +1,409 @@
+# 🎬 Chirp Demo Script for README GIFs
+
+This script provides step-by-step demos to showcase Chirp's key features for README.md video recordings.
+
+---
+
+## 🎥 Demo 1: Recording a Meeting (30-45 seconds)
+
+**Goal**: Show how easy it is to start and stop a recording.
+
+### Setup
+```bash
+# Clear terminal
+clear
+
+# Show we're ready
+chirp status
+```
+
+### Recording
+```bash
+# Start a short recording (30 seconds for demo)
+chirp record --duration 30 --title "Product Demo Discussion"
+
+# Show recording in progress with:
+# - Timer counting up
+# - Audio level indicators
+# - File size growing
+
+# Let it run for ~15 seconds, then Ctrl+C to stop early
+# Or let it complete the 30 seconds
+```
+
+### Verification
+```bash
+# Show the new recording was created
+chirp status
+
+# Optional: Show the audio file directly
+ls -lh audio-in/
+```
+
+**Key Highlights**:
+- Clean, simple command
+- Real-time feedback (timer, audio levels)
+- Graceful interruption with Ctrl+C
+
+---
+
+## 🎥 Demo 2: Full Processing Pipeline (45-60 seconds)
+
+**Goal**: Show the end-to-end workflow from audio → transcription → notes.
+
+### Setup
+```bash
+clear
+chirp status
+```
+
+### Process Everything
+```bash
+# Run the full pipeline
+chirp process
+
+# This will show:
+# 1. Transcribing audio files (progress bar)
+# 2. Generating meeting notes (progress bar)
+# 3. Building search index (progress indicator)
+```
+
+### View Results
+```bash
+# Show generated notes
+ls -lh notes-out/
+
+# Display a note file (pick one with nice formatting)
+cat notes-out/2024-01-15_Product_Demo_Discussion.md
+```
+
+**Key Highlights**:
+- One command does everything
+- Clear progress indicators
+- Beautiful output formatting
+
+---
+
+## 🎥 Demo 3: Interactive Chat Mode (60-90 seconds)
+
+**Goal**: Showcase the beautiful interactive chat interface - the star feature!
+
+### Setup
+```bash
+clear
+
+# Ensure index exists
+chirp notes index
+```
+
+### Interactive Session
+```bash
+# Start interactive chat
+chirp notes ask
+
+# The welcome panel appears:
+# ╭──────────────────────────────────╮
+# │     Notes Chat                   │
+# │ Ask questions about your         │
+# │ meeting notes.                   │
+# │                                  │
+# │ Press Ctrl+C twice to exit       │
+# ╰──────────────────────────────────╯
+```
+
+### Ask Questions
+```bash
+# Question 1: Show search in action
+> what were the key decisions from recent meetings?
+
+# Wait for:
+# - Spinner: "Searching meeting notes..."
+# - Spinner: "Generating answer..."
+# - Streaming response from chirp 🐣
+# - Sources displayed at bottom
+# - "cached" indicator if applicable
+
+# Question 2: Follow-up question
+> who is responsible for implementing those decisions?
+
+# Shows conversation flow
+
+# Question 3: Try Ctrl+C behavior
+> this is a test to show ctr<Ctrl+C>
+# Shows: "Press Ctrl+C again to exit" in toolbar
+# Buffer clears, hint disappears after 2 seconds
+
+# Exit with double Ctrl+C or type and submit
+<Ctrl+C>
+<Ctrl+C>
+# Shows: "Goodbye!"
+```
+
+**Key Highlights**:
+- Beautiful bordered interface
+- Real-time search feedback
+- Streaming AI responses
+- Source attribution
+- Smart Ctrl+C handling
+- Professional CLI experience
+
+---
+
+## 🎥 Demo 4: One-Shot Questions (30-45 seconds)
+
+**Goal**: Show quick question answering without entering interactive mode.
+
+### Setup
+```bash
+clear
+```
+
+### Quick Questions
+```bash
+# Ask a specific question
+chirp notes ask --question "what action items were assigned this week?"
+
+# Shows:
+# - Search indicator
+# - Answer streaming in
+# - Source files listed
+```
+
+### Advanced Queries
+```bash
+# Time-filtered search
+chirp notes ask -q "budget discussions" --when "last week"
+
+# Dry run to see search results
+chirp notes ask -q "project timeline" --dry-run
+```
+
+**Key Highlights**:
+- Fast answers without interactive mode
+- Time range filtering
+- Dry-run debugging option
+
+---
+
+## 🎥 Demo 5: Status & Diagnostics (30-45 seconds)
+
+**Goal**: Show system status and health checks.
+
+### Setup
+```bash
+clear
+```
+
+### Status Check
+```bash
+# Comprehensive status
+chirp status
+
+# Shows:
+# - Audio files count
+# - Transcriptions count
+# - Notes count
+# - Index status
+# - Total duration
+```
+
+### Device Information
+```bash
+# Show audio devices
+chirp devices
+
+# Lists:
+# - Available input devices
+# - BlackHole status
+# - Recommended device
+```
+
+### Health Check
+```bash
+# Run full diagnostic
+chirp test
+
+# Tests:
+# ✓ BlackHole installation
+# ✓ chirpd daemon readiness
+# ✓ Registered default chat model
+# ✓ Embedding model (nomic-embed-text)
+# ✓ Notes index
+```
+
+**Key Highlights**:
+- Clear system overview
+- Easy diagnostics
+- Helpful status messages
+
+---
+
+## 🎥 Demo 6: Configuration Management (20-30 seconds)
+
+**Goal**: Show how easy it is to configure Chirp.
+
+### Setup
+```bash
+clear
+```
+
+### View Config
+```bash
+# List current configuration
+chirp config --list
+
+# Shows table with:
+# - All settings
+# - Current values
+# - Organized by category
+```
+
+### Update Settings
+```bash
+# Update directories
+chirp config --audio-dir ./my-recordings
+chirp config --notes-dir ./my-notes
+
+# Verify changes
+chirp config --list
+```
+
+**Key Highlights**:
+- Simple configuration
+- Beautiful table display
+- Easy to customize
+
+---
+
+## 📋 Recording Tips
+
+### Terminal Setup
+1. **Font Size**: Use large, readable font (18-20pt)
+2. **Theme**: Use high-contrast theme (dark background recommended)
+3. **Window Size**: 100-120 columns wide, 30-40 rows
+4. **Clear Screen**: Always start with `clear`
+
+### Recording Settings
+- **Resolution**: 1920x1080 or higher
+- **FPS**: 30fps minimum
+- **Format**: MP4 or MOV (for later conversion to GIF)
+- **Tool**: Use `asciinema` for terminal recordings or QuickTime/OBS
+
+### GIF Conversion
+```bash
+# Convert MP4 to GIF using ffmpeg
+ffmpeg -i demo.mp4 -vf "fps=15,scale=1000:-1:flags=lanczos" -c:v gif demo.gif
+
+# Or use gifski for better quality
+ffmpeg -i demo.mp4 -vf "fps=30,scale=1000:-1:flags=lanczos" -pix_fmt rgb24 frame%04d.png
+gifski -o demo.gif frame*.png --fps 15
+rm frame*.png
+```
+
+### Optimize GIFs
+```bash
+# Use gifsicle to optimize
+gifsicle -O3 --colors 256 demo.gif -o demo-optimized.gif
+
+# Keep under 10MB for GitHub
+ls -lh demo-optimized.gif
+```
+
+---
+
+## 🎯 Feature Priority for GIFs
+
+### Must-Have (Top Priority)
+1. **Interactive Chat Mode** - The star feature! Show streaming, sources, Ctrl+C behavior
+2. **Full Pipeline** - One command to rule them all (`chirp process`)
+3. **Recording** - Show simplicity of starting/stopping
+
+### Nice-to-Have
+4. **One-Shot Questions** - Quick queries without interactive mode
+5. **Status & Diagnostics** - System health at a glance
+
+### Optional
+6. **Configuration** - If you have extra space/time
+
+---
+
+## 📝 Caption Ideas for README
+
+### Demo 1: Recording
+> "Start recording in seconds with real-time feedback"
+
+### Demo 2: Processing
+> "One command processes everything: transcribe → notes → search index"
+
+### Demo 3: Interactive Chat
+> "Beautiful interactive chat with streaming AI responses and source attribution"
+
+### Demo 4: Quick Questions
+> "Get instant answers with time-filtered search"
+
+### Demo 5: Status
+> "Monitor your meeting library and system health"
+
+---
+
+## 🎨 README Structure Suggestion
+
+```markdown
+## ✨ See It In Action
+
+### 🎙️ Record Meetings
+![Recording Demo](docs/gifs/demo-recording.gif)
+
+### ⚡ Process Everything
+![Processing Demo](docs/gifs/demo-process.gif)
+
+### 💬 Interactive Chat (Our Favorite!)
+![Chat Demo](docs/gifs/demo-chat.gif)
+
+### 🔍 Quick Questions
+![Query Demo](docs/gifs/demo-query.gif)
+```
+
+---
+
+## 🔧 Preparation Checklist
+
+Before recording:
+
+- [ ] Clear all previous recordings/transcriptions for clean demo
+- [ ] Ensure the daemon is healthy (`chirp daemon status`)
+- [ ] Verify a model is registered (`chirp models list`)
+- [ ] Test audio recording works (`chirp devices`)
+- [ ] Build search index (`chirp notes index`)
+- [ ] Increase terminal font size
+- [ ] Set terminal dimensions (100x30)
+- [ ] Clear command history
+- [ ] Close unnecessary terminal tabs
+- [ ] Practice each demo 2-3 times
+
+---
+
+## 🚀 Quick Reset Script
+
+Use this between takes to reset the demo environment:
+
+```bash
+#!/bin/bash
+# reset-demo.sh
+
+# Clear terminal
+clear
+
+# Remove all demo files (CAUTION: backup first!)
+rm -rf audio-in/*
+rm -rf transcriptions/*
+rm -rf notes-out/*
+rm -rf search-index/*
+
+# Verify clean state
+chirp status
+
+echo "✅ Demo environment reset"
+```
+
+**⚠️ WARNING**: Only run this in a demo/test environment, not on production data!

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.12
+    rev: v0.15.9
     hooks:
       - id: ruff
         args: [--fix]

--- a/audio_capture/__init__.py
+++ b/audio_capture/__init__.py
@@ -265,7 +265,8 @@ class AudioCapture:
 
     def _start_stderr_drain(self) -> None:
         proc = self._proc
-        assert proc is not None and proc.stderr is not None
+        assert proc is not None
+        assert proc.stderr is not None
 
         def drain(stderr: IO[bytes], q: queue.Queue[str]) -> None:
             try:
@@ -524,12 +525,12 @@ def check_permissions() -> dict[str, str]:
 
 
 __all__ = [
+    "SOURCE_MICROPHONE",
+    "SOURCE_SYSTEM",
     "AudioCapture",
     "AudioCaptureCorrupt",
     "AudioCaptureCrashed",
     "AudioCaptureStartTimeout",
-    "SOURCE_MICROPHONE",
-    "SOURCE_SYSTEM",
     "check_macos_version",
     "check_permissions",
 ]

--- a/chirp/about.py
+++ b/chirp/about.py
@@ -162,8 +162,7 @@ def run_about(
     with Live(Group(*lines), console=console, refresh_per_second=20) as live:
         # Phase 1 — paint the entire bird in one go
         logo_start = len(lines)
-        for idx in range(len(LOGO_ROWS)):
-            lines.append(_logo_line(idx, beak_open=False))
+        lines.extend(_logo_line(idx, beak_open=False) for idx in range(len(LOGO_ROWS)))
         live.update(Group(*lines))
 
         beak_row = next(i for i, row in enumerate(LOGO_ROWS) if row.has_beak)

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -376,17 +376,17 @@ def record(
     except KeyboardInterrupt:
         console.print("[yellow]Recording stopped by user[/yellow]")
     except AudioDeviceError as e:
-        console.print(f"[red]Audio device error: {str(e)}[/red]")
+        console.print(f"[red]Audio device error: {e!s}[/red]")
         raise typer.Exit(1)
     except RecordingError as e:
-        console.print(f"[red]Recording error: {str(e)}[/red]")
+        console.print(f"[red]Recording error: {e!s}[/red]")
         raise typer.Exit(1)
     except ConfigurationError as e:
-        console.print(f"[red]Configuration error: {str(e)}[/red]")
+        console.print(f"[red]Configuration error: {e!s}[/red]")
         raise typer.Exit(1)
     except Exception as e:  # noqa: BLE001 - top-level CLI handler; all specific errors caught above
         logger.debug("Unexpected error in record command: %s", e, exc_info=True)
-        console.print(f"[red]Unexpected error: {str(e)}[/red]")
+        console.print(f"[red]Unexpected error: {e!s}[/red]")
         raise typer.Exit(1)
 
 
@@ -421,7 +421,7 @@ def _run_live_transcription(
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(1)
     except RecordingError as e:
-        console.print(f"[red]Live recording error: {str(e)}[/red]")
+        console.print(f"[red]Live recording error: {e!s}[/red]")
         raise typer.Exit(1)
 
     from utils.time_utils import format_duration

--- a/chirpd/backend.py
+++ b/chirpd/backend.py
@@ -87,7 +87,7 @@ class MLXBackend:
 
         try:
             loaded = await asyncio.to_thread(mlx_load, local_path)
-        except Exception as err:  # noqa: BLE001 - wrap any mlx_lm.load error into a typed model-load failure
+        except Exception as err:
             raise LLMModelLoadFailed(
                 f"mlx_lm.load failed for {repo!r}: {err}",
                 details={
@@ -123,7 +123,7 @@ class MLXBackend:
             # second element is a TokenizerWrapper. It is stored under "processor"
             # to match generate()'s parameter name and to read uniformly in embed().
             loaded = await asyncio.to_thread(mlx_embeddings_load, local_path)
-        except Exception as err:  # noqa: BLE001 - wrap any mlx_embeddings.load error into a typed model-load failure
+        except Exception as err:
             raise LLMModelLoadFailed(
                 f"mlx_embeddings.load failed for {repo!r}: {err}",
                 details={
@@ -254,7 +254,7 @@ class MLXBackend:
 
         try:
             return await asyncio.to_thread(_run)
-        except Exception as err:  # noqa: BLE001 - wrap any mlx_embeddings.generate error into a typed generation failure
+        except Exception as err:
             raise LLMGenerationFailed(
                 f"mlx_embeddings.generate failed for {handle.get('repo')!r}: {err}",
                 details={

--- a/chirpd/backend.py
+++ b/chirpd/backend.py
@@ -87,7 +87,7 @@ class MLXBackend:
 
         try:
             loaded = await asyncio.to_thread(mlx_load, local_path)
-        except Exception as err:  # noqa: BLE001 — wrap any mlx error
+        except Exception as err:
             raise LLMModelLoadFailed(
                 f"mlx_lm.load failed for {repo!r}: {err}",
                 details={
@@ -123,7 +123,7 @@ class MLXBackend:
             # second element is a TokenizerWrapper. It is stored under "processor"
             # to match generate()'s parameter name and to read uniformly in embed().
             loaded = await asyncio.to_thread(mlx_embeddings_load, local_path)
-        except Exception as err:  # noqa: BLE001 — wrap any mlx error
+        except Exception as err:
             raise LLMModelLoadFailed(
                 f"mlx_embeddings.load failed for {repo!r}: {err}",
                 details={
@@ -254,7 +254,7 @@ class MLXBackend:
 
         try:
             return await asyncio.to_thread(_run)
-        except Exception as err:  # noqa: BLE001 — surface to dispatcher
+        except Exception as err:
             raise LLMGenerationFailed(
                 f"mlx_embeddings.generate failed for {handle.get('repo')!r}: {err}",
                 details={
@@ -297,10 +297,7 @@ def _apply_chat_template_no_thinking(  # pragma: no cover — opt-in @slow path
 
 def _vector_to_floats(vector: Any) -> list[float]:
     tolist = getattr(vector, "tolist", None)
-    if callable(tolist):
-        as_list = tolist()
-    else:
-        as_list = list(vector)
+    as_list = tolist() if callable(tolist) else list(vector)
     return [float(x) for x in as_list]
 
 
@@ -358,8 +355,7 @@ class FakeBackend:
         self.last_options = dict(options)
         self.last_prompt = _render_fake_chat_template(messages)
         usage_out["prompt_tokens"] = len(self.last_prompt.split())
-        emitted = 0
-        for token in self.chat_tokens:
+        for emitted, token in enumerate(self.chat_tokens):
             if should_stop.is_set():
                 return
             if self.generation_delay_s > 0:
@@ -370,7 +366,6 @@ class FakeBackend:
             if scheduled_raise is not None and emitted >= self.stream_raises_after:
                 raise scheduled_raise
             yield token
-            emitted += 1
 
     async def embed(
         self,

--- a/chirpd/backend.py
+++ b/chirpd/backend.py
@@ -87,7 +87,7 @@ class MLXBackend:
 
         try:
             loaded = await asyncio.to_thread(mlx_load, local_path)
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - wrap any mlx_lm.load error into a typed model-load failure
             raise LLMModelLoadFailed(
                 f"mlx_lm.load failed for {repo!r}: {err}",
                 details={
@@ -123,7 +123,7 @@ class MLXBackend:
             # second element is a TokenizerWrapper. It is stored under "processor"
             # to match generate()'s parameter name and to read uniformly in embed().
             loaded = await asyncio.to_thread(mlx_embeddings_load, local_path)
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - wrap any mlx_embeddings.load error into a typed model-load failure
             raise LLMModelLoadFailed(
                 f"mlx_embeddings.load failed for {repo!r}: {err}",
                 details={
@@ -254,7 +254,7 @@ class MLXBackend:
 
         try:
             return await asyncio.to_thread(_run)
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - wrap any mlx_embeddings.generate error into a typed generation failure
             raise LLMGenerationFailed(
                 f"mlx_embeddings.generate failed for {handle.get('repo')!r}: {err}",
                 details={

--- a/chirpd/dispatcher.py
+++ b/chirpd/dispatcher.py
@@ -95,7 +95,7 @@ class Dispatcher:
             )
         except LLMModelError as exc:
             await _write_error_for_typed(writer, request_id, op, exc)
-        except Exception as exc:  # noqa: BLE001 - final safety net; convert unexpected errors into protocol error events
+        except Exception as exc:
             _logger.exception(
                 "dispatch failed",
                 extra={

--- a/chirpd/dispatcher.py
+++ b/chirpd/dispatcher.py
@@ -95,7 +95,7 @@ class Dispatcher:
             )
         except LLMModelError as exc:
             await _write_error_for_typed(writer, request_id, op, exc)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - final safety net; convert unexpected errors into protocol error events
             _logger.exception(
                 "dispatch failed",
                 extra={

--- a/chirpd/dispatcher.py
+++ b/chirpd/dispatcher.py
@@ -95,7 +95,7 @@ class Dispatcher:
             )
         except LLMModelError as exc:
             await _write_error_for_typed(writer, request_id, op, exc)
-        except Exception as exc:  # noqa: BLE001 — architecture § Exception Construction
+        except Exception as exc:
             _logger.exception(
                 "dispatch failed",
                 extra={
@@ -347,7 +347,7 @@ class Dispatcher:
                 except LLMModelError as exc:
                     await _write_error_for_typed(writer, request_id, OP_CHAT, exc)
                     return
-                except Exception as exc:  # noqa: BLE001
+                except Exception as exc:
                     _logger.exception(
                         "chat generation failed",
                         extra={
@@ -475,7 +475,7 @@ class Dispatcher:
             except LLMModelError as exc:
                 await _write_error_for_typed(writer, request_id, OP_EMBED, exc)
                 return
-            except Exception as exc:  # noqa: BLE001
+            except Exception as exc:
                 _logger.exception(
                     "embed failed",
                     extra={

--- a/chirpd/launchd.py
+++ b/chirpd/launchd.py
@@ -147,7 +147,7 @@ def _write_plist_atomic(payload: dict[str, Any], path: Path) -> None:
     try:
         with tmp_path.open("wb") as handle:
             plistlib.dump(payload, handle, fmt=plistlib.FMT_XML)
-        os.replace(tmp_path, path)
+        tmp_path.replace(path)
     except OSError:
         tmp_path.unlink(missing_ok=True)
         raise

--- a/chirpd/lifecycle.py
+++ b/chirpd/lifecycle.py
@@ -32,7 +32,7 @@ def single_instance_lock(
     """
     target = lock_path if lock_path is not None else paths.LOCK_PATH
     target.parent.mkdir(parents=True, exist_ok=True, mode=paths.RUNTIME_DIR_MODE)
-    with open(target, "ab+") as handle:
+    with target.open("ab+") as handle:
         try:
             fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError:

--- a/chirpd/logging_setup.py
+++ b/chirpd/logging_setup.py
@@ -123,13 +123,14 @@ class LogfmtFormatter(logging.Formatter):
             "msg": logfmt_escape(record.getMessage()),
         }
         parts: list[str] = [f"{key}={required[key]}" for key in LOGFMT_REQUIRED_FIELDS]
-        for key in LOGFMT_OPTIONAL_FIELDS:
-            if hasattr(record, key):
-                parts.append(f"{key}={logfmt_escape(getattr(record, key))}")
+        parts.extend(
+            f"{key}={logfmt_escape(getattr(record, key))}"
+            for key in LOGFMT_OPTIONAL_FIELDS
+            if hasattr(record, key)
+        )
         if record.exc_info and record.exc_info[0] is not None:
             parts.append(f"err_type={logfmt_escape(record.exc_info[0].__name__)}")
-        for key in _forbidden_keys(record):
-            parts.append(f"{key}=<redacted>")
+        parts.extend(f"{key}=<redacted>" for key in _forbidden_keys(record))
         return " ".join(parts)
 
 
@@ -155,7 +156,8 @@ class _RedactionViolationFilter(logging.Filter):
             _redaction_guard.active = True
             try:
                 logging.getLogger(record.name).warning(
-                    f"redaction violation: keys={','.join(keys)}",
+                    "redaction violation: keys=%s",
+                    ",".join(keys),
                     extra={"err_type": "RedactionViolation"},
                 )
             finally:

--- a/chirpd/server.py
+++ b/chirpd/server.py
@@ -131,7 +131,7 @@ async def _handle_connection(
         await dispatcher.dispatch(next_envelope, writer)
     except ConnectionResetError:  # pragma: no cover — peer-abort defensive branch
         _logger.info("connection reset by peer")
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - last-resort connection handler safety net
         _logger.exception(
             "unhandled connection error",
             extra={"err_type": type(exc).__name__},

--- a/chirpd/server.py
+++ b/chirpd/server.py
@@ -131,7 +131,7 @@ async def _handle_connection(
         await dispatcher.dispatch(next_envelope, writer)
     except ConnectionResetError:  # pragma: no cover — peer-abort defensive branch
         _logger.info("connection reset by peer")
-    except Exception as exc:  # noqa: BLE001 - last-resort connection handler safety net
+    except Exception as exc:
         _logger.exception(
             "unhandled connection error",
             extra={"err_type": type(exc).__name__},

--- a/chirpd/server.py
+++ b/chirpd/server.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from pathlib import Path
 from typing import Any, Final
 
@@ -44,7 +43,7 @@ async def serve(socket_path: Path, dispatcher: Dispatcher) -> None:
     server = await asyncio.start_unix_server(
         handle, path=str(socket_path), limit=_LINE_READ_LIMIT
     )
-    os.chmod(socket_path, 0o600)
+    socket_path.chmod(0o600)
     _logger.info("chirpd listening", extra={"op": "serve"})
 
     serve_forever_task = asyncio.create_task(server.serve_forever())
@@ -83,7 +82,7 @@ def _unlink_stale_socket(socket_path: Path) -> None:
     # anything that isn't actually a unix socket.
     try:
         if socket_path.is_socket():
-            os.unlink(socket_path)
+            socket_path.unlink()
     except FileNotFoundError:
         pass
 
@@ -132,7 +131,7 @@ async def _handle_connection(
         await dispatcher.dispatch(next_envelope, writer)
     except ConnectionResetError:  # pragma: no cover — peer-abort defensive branch
         _logger.info("connection reset by peer")
-    except Exception as exc:  # noqa: BLE001 — final safety net for unexpected handler failures
+    except Exception as exc:
         _logger.exception(
             "unhandled connection error",
             extra={"err_type": type(exc).__name__},

--- a/config/settings.py
+++ b/config/settings.py
@@ -43,8 +43,6 @@ def resolve_idle_timeout_seconds() -> float:
 class ConfigurationError(Exception):
     """Exception raised for configuration-related errors."""
 
-    pass
-
 
 def default_notes_root() -> Path:
     return Path(user_documents_dir()) / "chirp"
@@ -178,7 +176,7 @@ class ChirpSettings(BaseModel):
             console.print(f"[dim]Edit {config_path} to customize settings[/dim]")
             return settings
 
-        with open(config_path, "rb") as config_file:
+        with config_path.open("rb") as config_file:
             config_data = tomllib.load(config_file)
 
         return cls(**config_data)
@@ -189,7 +187,7 @@ class ChirpSettings(BaseModel):
         config_dict = self.model_dump()
         _stringify_paths(config_dict)
 
-        with open(config_path, "wb") as config_file:
+        with config_path.open("wb") as config_file:
             tomli_w.dump(config_dict, config_file)
 
     def ensure_directories_exist(self):

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -9,19 +9,15 @@ and installs cleanly otherwise.
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 
 
 class CustomBuildHook(BuildHookInterface):
     def initialize(self, version: str, build_data: dict) -> None:
-        app_src = os.path.join(
-            os.path.dirname(__file__),
-            "audio_capture",
-            "CaptureAudio.app",
-        )
-        if os.path.isdir(app_src):
+        app_src = Path(__file__).parent / "audio_capture" / "CaptureAudio.app"
+        if app_src.is_dir():
             build_data["force_include"]["audio_capture/CaptureAudio.app"] = (
                 "audio_capture/CaptureAudio.app"
             )

--- a/llm/client.py
+++ b/llm/client.py
@@ -266,9 +266,7 @@ class LLMClient:
         keep_alive: int | None = None,
     ) -> str:
         stream = self.chat_stream(messages, model, options, keep_alive)
-        tokens: list[str] = []
-        async for token in stream:
-            tokens.append(token)
+        tokens = [token async for token in stream]
         return "".join(tokens)
 
     def chat_sync(
@@ -463,7 +461,7 @@ class LLMClient:
         env = os.environ.copy()
         env[CHIRP_DAEMON_SOCKET_ENV] = str(self.socket_path)
         try:
-            proc = subprocess.Popen(
+            proc = subprocess.Popen(  # noqa: ASYNC220 - detached fire-and-forget daemon spawn; start_new_session detachment is the point, not awaitable subprocess semantics
                 ["chirpd"],
                 env=env,
                 start_new_session=True,

--- a/llm/hf.py
+++ b/llm/hf.py
@@ -176,7 +176,7 @@ def _fetch_architectures(repo_id: str) -> list[str]:
         raise HfUnexpectedError(repo_id, original=err) from err
 
     try:
-        with open(config_path, encoding="utf-8") as handle:
+        with Path(config_path).open(encoding="utf-8") as handle:
             data = json.load(handle)
     except (OSError, json.JSONDecodeError):
         return []

--- a/llm/registry.py
+++ b/llm/registry.py
@@ -62,7 +62,7 @@ def read_registry(path: Path | None = None) -> Registry:
     """
     target = path if path is not None else MODELS_TOML_PATH
     try:
-        with open(target, "rb") as handle:
+        with target.open("rb") as handle:
             raw = tomllib.load(handle)
     except FileNotFoundError:
         return Registry(schema_version=SUPPORTED_SCHEMA_VERSION, models={})
@@ -174,11 +174,11 @@ def write_registry(registry: Registry, *, path: Path | None = None) -> None:
     tmp_path = target.with_name(f"{target.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     try:
         target.parent.mkdir(parents=True, exist_ok=True)
-        with open(tmp_path, "wb") as handle:
+        with tmp_path.open("wb") as handle:
             handle.write(rendered.encode("utf-8"))
             handle.flush()
             os.fsync(handle.fileno())
-        os.replace(tmp_path, target)
+        tmp_path.replace(target)
     except OSError as err:
         _safe_unlink(tmp_path)
         raise RegistryWriteError(

--- a/notes/note_editor.py
+++ b/notes/note_editor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import curses
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 from rich.console import Console
 from rich.markdown import Heading, Markdown
@@ -46,7 +46,7 @@ class DisplayLine:
 class ManualNoteEditor:
     """A minimal modal text editor with view/insert modes."""
 
-    _COLOR_NAME_MAP = {
+    _COLOR_NAME_MAP: ClassVar[dict[str, int]] = {
         "black": curses.COLOR_BLACK,
         "red": curses.COLOR_RED,
         "green": curses.COLOR_GREEN,

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -302,10 +302,7 @@ class NoteGenerator:
         header = "\n".join(header_lines)
         stripped_body = body.lstrip("\n")
 
-        if stripped_body:
-            content = f"{header}\n\n{stripped_body}"
-        else:
-            content = f"{header}\n"
+        content = f"{header}\n\n{stripped_body}" if stripped_body else f"{header}\n"
 
         if not content.endswith("\n"):
             content += "\n"

--- a/notes_chat/bm25.py
+++ b/notes_chat/bm25.py
@@ -23,7 +23,7 @@ class BM25Index:
             return
 
         try:
-            with open(self.bm25_file) as f:
+            with self.bm25_file.open() as f:
                 data = json.load(f)
 
             self.doc_ids = data.get("doc_ids", [])
@@ -105,7 +105,7 @@ def rebuild_bm25_index(chroma_collection, bm25_file: Path):
         }
 
         bm25_file.parent.mkdir(parents=True, exist_ok=True)
-        with open(bm25_file, "w") as f:
+        with bm25_file.open("w") as f:
             json.dump(bm25_data, f, indent=2)
 
     except Exception as e:  # noqa: BLE001 - chromadb or IO; many failure modes

--- a/notes_chat/cache.py
+++ b/notes_chat/cache.py
@@ -17,7 +17,7 @@ def get_cached_answer(question: str, retrieved_ids: list[str]) -> str | None:
         if not cache_file.exists():
             return None
 
-        with open(cache_file) as f:
+        with cache_file.open() as f:
             data = json.load(f)
 
         answer = data.get("answer")
@@ -44,7 +44,7 @@ def cache_answer(question: str, retrieved_ids: list[str], answer: str) -> bool:
             "cache_key": cache_key,
         }
 
-        with open(cache_file, "w") as f:
+        with cache_file.open("w") as f:
             json.dump(cache_data, f, indent=2)
 
         return True

--- a/notes_chat/cli.py
+++ b/notes_chat/cli.py
@@ -127,11 +127,10 @@ def ask(
                 if context_result.get("suggestion"):
                     console.print(f"[dim]try: {context_result['suggestion']}[/dim]")
                 raise typer.Exit(2)
-            else:
-                console.print(f"[red]Context retrieval failed: {error}[/red]")
-                if context_result.get("suggestion"):
-                    console.print(f"[dim]{context_result['suggestion']}[/dim]")
-                raise typer.Exit(1)
+            console.print(f"[red]Context retrieval failed: {error}[/red]")
+            if context_result.get("suggestion"):
+                console.print(f"[dim]{context_result['suggestion']}[/dim]")
+            raise typer.Exit(1)
 
         context = context_result["context"]
         retrieved_ids = context_result["retrieved_ids"]

--- a/notes_chat/index.py
+++ b/notes_chat/index.py
@@ -56,7 +56,7 @@ class IndexManager:
 
             added_files = []
             modified_files = []
-            removed_files = []
+            removed_files: list[str] = []
 
             for file_path, file_sig in current_files.items():
                 if file_path not in manifest:
@@ -64,9 +64,9 @@ class IndexManager:
                 elif manifest[file_path] != file_sig:
                     modified_files.append(file_path)
 
-            for file_path in manifest:
-                if file_path not in current_files:
-                    removed_files.append(file_path)
+            removed_files.extend(
+                file_path for file_path in manifest if file_path not in current_files
+            )
 
             total_changes = len(added_files) + len(modified_files) + len(removed_files)
             if total_changes == 0 and not force:
@@ -144,7 +144,7 @@ class IndexManager:
             return {}
 
         try:
-            with open(self.manifest_file) as f:
+            with self.manifest_file.open() as f:
                 data = json.load(f)
                 return data if isinstance(data, dict) else {}
         except (OSError, json.JSONDecodeError, ValueError):
@@ -152,7 +152,7 @@ class IndexManager:
 
     def _save_manifest(self, manifest: dict[str, Any]):
         """Save the index manifest."""
-        with open(self.manifest_file, "w") as f:
+        with self.manifest_file.open("w") as f:
             json.dump(manifest, f, indent=2)
 
     def _add_to_index(self, file_path: Path) -> bool:
@@ -182,7 +182,7 @@ class IndexManager:
             self.collection.add(
                 ids=[chunk.id for chunk in chunks],
                 documents=[chunk.content for chunk in chunks],
-                embeddings=embeddings,  # type: ignore
+                embeddings=embeddings,  # type: ignore[arg-type]
                 metadatas=[self._chunk_to_metadata(chunk) for chunk in chunks],
             )
 

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -102,9 +102,9 @@ def _search_chroma(
             return []
 
         results = index_manager.collection.query(
-            query_embeddings=[query_embedding],  # type: ignore
+            query_embeddings=[query_embedding],  # type: ignore[arg-type]
             n_results=k,
-            where=where_clause,  # type: ignore
+            where=where_clause,  # type: ignore[arg-type]
         )
 
         ids_list = results.get("ids") or [[]]
@@ -352,8 +352,7 @@ def _create_chunk_header(data: dict[str, Any]) -> str:
         filename = Path(path).name if path != "Unknown" else "Unknown"
 
         return f"{date_str} · {filename}"
-    else:
-        return "Unknown source"
+    return "Unknown source"
 
 
 def _generate_suggestion(config: ChirpSettings, time_range: Any | None) -> str:
@@ -366,7 +365,7 @@ def _generate_suggestion(config: ChirpSettings, time_range: Any | None) -> str:
             return "Index not found. Run 'chirp index' to build the search index first."
 
         try:
-            with open(manifest_file) as f:
+            with manifest_file.open() as f:
                 manifest = json.load(f)
                 if not manifest:
                     return "No files in search index. Run 'chirp index' to build the index."

--- a/notes_chat/search_keyword.py
+++ b/notes_chat/search_keyword.py
@@ -368,9 +368,12 @@ def _is_close(candidate: str, query_token: str) -> bool:
         return True
     if len(candidate) >= 3 and candidate in query_token:
         return True
-    if len(candidate) >= 3 and len(query_token) >= 3:
-        if candidate[:3] == query_token[:3]:
-            return True
+    if (
+        len(candidate) >= 3
+        and len(query_token) >= 3
+        and candidate[:3] == query_token[:3]
+    ):
+        return True
     return _levenshtein(candidate, query_token) <= 2
 
 

--- a/notes_chat/time_ranges.py
+++ b/notes_chat/time_ranges.py
@@ -86,19 +86,19 @@ def _parse_keyword_range(keyword: str, now: datetime) -> TimeRange | None:
         start = today - timedelta(days=1)
         return TimeRange(start=start, end_exclusive=today)
 
-    elif keyword == "last week":
+    if keyword == "last week":
         days_since_monday = now.weekday()
         last_monday = today - timedelta(days=days_since_monday + 7)
         this_monday = today - timedelta(days=days_since_monday)
         return TimeRange(start=last_monday, end_exclusive=this_monday)
 
-    elif keyword == "this week":
+    if keyword == "this week":
         days_since_monday = now.weekday()
         this_monday = today - timedelta(days=days_since_monday)
         next_monday = this_monday + timedelta(days=7)
         return TimeRange(start=this_monday, end_exclusive=next_monday)
 
-    elif keyword == "last month":
+    if keyword == "last month":
         if now.month == 1:
             last_month_start = now.replace(
                 year=now.year - 1,
@@ -121,7 +121,7 @@ def _parse_keyword_range(keyword: str, now: datetime) -> TimeRange | None:
             )
         return TimeRange(start=last_month_start, end_exclusive=this_month_start)
 
-    elif keyword.startswith("last ") and len(keyword.split()) == 2:
+    if keyword.startswith("last ") and len(keyword.split()) == 2:
         _, day_name = keyword.split()
         if day_name in WEEKDAY_NAMES:
             target_weekday = WEEKDAY_NAMES[day_name]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,14 +61,31 @@ extend-exclude = ["audio_capture/swift", "audio_capture/CaptureAudio.app"]
 
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # Pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
-    "BLE", # flake8-blind-except (BLE001: bare/blind `except` swallows errors)
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # Pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "UP",   # pyupgrade
+    "BLE",  # flake8-blind-except (BLE001: bare/blind `except` swallows errors)
+    "FA",   # flake8-future-annotations
+    "ISC",  # flake8-implicit-str-concat
+    "ICN",  # flake8-import-conventions
+    "RET",  # flake8-return
+    "SIM",  # flake8-simplify
+    "TID",  # flake8-tidy-imports
+    "PTH",  # flake8-use-pathlib
+    "TD",   # flake8-todos
+    "NPY",  # numpy-specific rules
+    "RUF",  # ruff-specific rules
+    "PERF", # perflint
+    "PT",   # flake8-pytest-style
+    "ASYNC", # flake8-async (blocking calls in async functions)
+    "PGH",  # pygrep-hooks (blanket noqa / type: ignore)
+    "PIE",  # flake8-pie
+    "LOG",  # flake8-logging
+    "G",    # flake8-logging-format
 ]
 ignore = [
     "E501",  # line too long (handled by formatter)
@@ -77,6 +94,22 @@ ignore = [
     "F405", # may be undefined from star imports
     "B904", # Within except clause, raise exceptions with raise ... from err (too verbose for this use case)
     "E722", # Do not use bare except (acceptable in test function)
+    "ISC001", # implicit string concat on one line (conflicts with the formatter)
+    "SIM105", # contextlib.suppress is slower and not always clearer than try/except: pass
+    "TD002", # missing TODO author (not a team convention)
+    "TD003", # missing TODO issue link (not a team convention)
+    "RUF001", # ambiguous unicode in strings (intentional em-dashes/quotes in user-facing notes text)
+    "RUF002", # ambiguous unicode in docstrings (same rationale as RUF001)
+    "RUF003", # ambiguous unicode in comments (same rationale as RUF001)
+    "ASYNC240", # advises trio.Path/anyio.path; this project is asyncio-only, so pathlib in async is fine
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "ASYNC109", # test helpers legitimately take a `timeout` parameter
+    "ASYNC110", # tests intentionally poll with `await asyncio.sleep` while waiting on external state
+    "PERF",     # perflint targets production hot paths; test clarity wins over micro-perf, and stream-consume loops must collect partial results before a raise
+    "SIM117",   # nested `with mock.patch(...)` is a readable pytest idiom; flattening deep patch stacks adds no clarity (rule stays active for production code)
 ]
 
 [tool.ruff.format]

--- a/recorder/audio_mixer.py
+++ b/recorder/audio_mixer.py
@@ -138,24 +138,23 @@ class StereoToMonoMixer:
                 offset_us = abs(sys_head - mic_head)
                 half_frame_us = self._frame_us // 2
 
-                if offset_us >= half_frame_us:
-                    # The two sides' heads refer to different wall-clock
-                    # instants. Drop samples from the leading side so both
-                    # sources start at the same instant before mixing.
-                    # Only do this when the offset is within one gap window;
-                    # larger drifts fall through to normal stall handling.
-                    if offset_us <= self._gap_us:
-                        offset_samples = min(
-                            (offset_us * self._sample_rate) // 1_000_000,
-                            self._frame_samples - 1,
-                        )
-                        leading = (
-                            SOURCE_SYSTEM if sys_head > mic_head else SOURCE_MICROPHONE
-                        )
-                        self._drop_leading_samples(leading, offset_samples)
-                        # After the drop, re-check readiness for the leading side.
-                        if self._buffers[leading].size < self._frame_samples:
-                            return
+                # The two sides' heads refer to different wall-clock instants.
+                # Drop samples from the leading side so both sources start at
+                # the same instant before mixing. Only do this when the offset
+                # is within one gap window; larger drifts fall through to
+                # normal stall handling.
+                if half_frame_us <= offset_us <= self._gap_us:
+                    offset_samples = min(
+                        (offset_us * self._sample_rate) // 1_000_000,
+                        self._frame_samples - 1,
+                    )
+                    leading = (
+                        SOURCE_SYSTEM if sys_head > mic_head else SOURCE_MICROPHONE
+                    )
+                    self._drop_leading_samples(leading, offset_samples)
+                    # After the drop, re-check readiness for the leading side.
+                    if self._buffers[leading].size < self._frame_samples:
+                        return
 
                 sys_head_final = self._head_ts[SOURCE_SYSTEM] or 0
                 mic_head_final = self._head_ts[SOURCE_MICROPHONE] or 0

--- a/recorder/audio_recorder.py
+++ b/recorder/audio_recorder.py
@@ -131,7 +131,7 @@ class AudioRecorder:
             raise
 
         try:
-            wave_file = wave.open(str(audio_path), "wb")
+            wave_file = wave.open(str(audio_path), "wb")  # noqa: SIM115 - handle is long-lived; written across frames and closed in the finalize path
             wave_file.setnchannels(OUTPUT_CHANNELS)
             wave_file.setsampwidth(OUTPUT_SAMPLE_WIDTH_BYTES)
             wave_file.setframerate(OUTPUT_SAMPLE_RATE)
@@ -245,7 +245,7 @@ class AudioRecorder:
                 if not self._paused_event.is_set():
                     self._append_mixed_frame(mixed, wave_file)
         except Exception as exc:
-            logger.error("audio-recorder-capture worker crashed", exc_info=True)
+            logger.exception("audio-recorder-capture worker crashed")
             self._capture_error = exc
             self._is_recording_event.clear()
         else:

--- a/recorder/audio_recorder.py
+++ b/recorder/audio_recorder.py
@@ -244,7 +244,7 @@ class AudioRecorder:
             for _, mixed in mixer.flush():
                 if not self._paused_event.is_set():
                     self._append_mixed_frame(mixed, wave_file)
-        except Exception as exc:  # noqa: BLE001 - capture worker must surface any unexpected failure
+        except Exception as exc:
             logger.exception("audio-recorder-capture worker crashed")
             self._capture_error = exc
             self._is_recording_event.clear()

--- a/recorder/audio_recorder.py
+++ b/recorder/audio_recorder.py
@@ -244,7 +244,7 @@ class AudioRecorder:
             for _, mixed in mixer.flush():
                 if not self._paused_event.is_set():
                     self._append_mixed_frame(mixed, wave_file)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - capture worker must surface any unexpected failure
             logger.exception("audio-recorder-capture worker crashed")
             self._capture_error = exc
             self._is_recording_event.clear()

--- a/recorder/device_manager.py
+++ b/recorder/device_manager.py
@@ -21,7 +21,7 @@ class DeviceManager:
     def _initialize_audio(self):
         try:
             self.audio = pyaudio.PyAudio()
-        except Exception as e:  # noqa: BLE001 - PyAudio can raise many types on init failure
+        except Exception as e:
             raise RuntimeError(f"Failed to initialize PyAudio: {e!s}") from e
 
     def close(self):

--- a/recorder/device_manager.py
+++ b/recorder/device_manager.py
@@ -21,7 +21,7 @@ class DeviceManager:
     def _initialize_audio(self):
         try:
             self.audio = pyaudio.PyAudio()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - PyAudio can raise many types on init failure
             raise RuntimeError(f"Failed to initialize PyAudio: {e!s}") from e
 
     def close(self):

--- a/recorder/device_manager.py
+++ b/recorder/device_manager.py
@@ -21,8 +21,8 @@ class DeviceManager:
     def _initialize_audio(self):
         try:
             self.audio = pyaudio.PyAudio()
-        except Exception as e:  # noqa: BLE001 - PyAudio can raise many types on init failure
-            raise RuntimeError(f"Failed to initialize PyAudio: {str(e)}") from e
+        except Exception as e:
+            raise RuntimeError(f"Failed to initialize PyAudio: {e!s}") from e
 
     def close(self):
         if self.audio:
@@ -155,9 +155,11 @@ class DeviceManager:
         if not device_info:
             return supported_rates
 
-        for rate in standard_rates:
-            if self._test_sample_rate(device_index, rate):
-                supported_rates.append(rate)
+        supported_rates.extend(
+            rate
+            for rate in standard_rates
+            if self._test_sample_rate(device_index, rate)
+        )
 
         return supported_rates
 

--- a/recorder/live_audio.py
+++ b/recorder/live_audio.py
@@ -120,7 +120,7 @@ class LiveAudioStream:
             tmp_fd, tmp_name = tempfile.mkstemp(suffix=".wav")
             os.close(tmp_fd)
             self._temp_wav_path = Path(tmp_name)
-            wav = wave.open(tmp_name, "wb")
+            wav = wave.open(tmp_name, "wb")  # noqa: SIM115 - handle is long-lived; stored on self._wave and closed on stop
             wav.setnchannels(_LIVE_CHANNELS)
             wav.setsampwidth(2)
             wav.setframerate(self._sample_rate)
@@ -205,10 +205,7 @@ class LiveAudioStream:
             self.stop_event.set()
 
     def _publish_mixed_frame(self, mixed: np.ndarray) -> None:
-        if mixed.size:
-            peak = min(1.0, float(np.max(np.abs(mixed))))
-        else:
-            peak = 0.0
+        peak = min(1.0, float(np.max(np.abs(mixed)))) if mixed.size else 0.0
         int16_bytes = float32_to_int16_bytes(mixed)
         if self._wave is not None:
             self._wave.writeframes(int16_bytes)

--- a/recorder/live_dashboard.py
+++ b/recorder/live_dashboard.py
@@ -346,14 +346,12 @@ class LiveDashboard:
         if not text:
             return ""
         sanitized = text.replace("\x1b", "")
-        sanitized_result = "".join(
+        return "".join(
             char for char in sanitized if char.isprintable() or char in "\n\t"
         )
-        return sanitized_result
 
     @staticmethod
     def _render_level_bar(level: float) -> str:
         buckets = 10
         filled = min(buckets, int(level * buckets))
-        bar = "█" * filled + "░" * (buckets - filled)
-        return bar
+        return "█" * filled + "░" * (buckets - filled)

--- a/recorder/live_session.py
+++ b/recorder/live_session.py
@@ -257,7 +257,7 @@ class LiveTranscriptionSession:
 
         def forward_frames():
             frame_duration = self.audio_stream.frame_duration
-            frames_per_chunk = max(1, int(round(1.0 / frame_duration)))
+            frames_per_chunk = max(1, round(1.0 / frame_duration))
             audio_buffer: list[bytes] = []
             chunk_start: float | None = None
 

--- a/recorder/live_transcriber.py
+++ b/recorder/live_transcriber.py
@@ -109,12 +109,15 @@ class LiveTranscriber(threading.Thread):
         if not self._pcm_buffer:
             return
 
-        if not force and self.transcription_interval > 0:
-            if (
+        if (
+            not force
+            and self.transcription_interval > 0
+            and (
                 self._last_chunk_end - self._last_transcribe_at
                 < self.transcription_interval
-            ):
-                return
+            )
+        ):
+            return
 
         pcm_bytes = bytes(self._pcm_buffer)
 

--- a/scripts/smoke_test_story_3_5.py
+++ b/scripts/smoke_test_story_3_5.py
@@ -227,9 +227,11 @@ def main() -> int:
         else:
             rss_mb = status["rss_bytes"] / (1024 * 1024)
             _ok(f"rss_bytes={status['rss_bytes']} ({rss_mb:.1f} MiB)")
-        for key in ("pid", "uptime_seconds", "daemon_version"):
-            if key not in status:
-                failures.append(_fail(f"status missing required key {key!r}"))
+        failures.extend(
+            _fail(f"status missing required key {key!r}")
+            for key in ("pid", "uptime_seconds", "daemon_version")
+            if key not in status
+        )
         if all(k in status for k in ("pid", "uptime_seconds", "daemon_version")):
             _ok(
                 f"status keys present: pid={status['pid']} "

--- a/scripts/update_pr_version.py
+++ b/scripts/update_pr_version.py
@@ -15,7 +15,9 @@ def main():
     root_dir = pathlib.Path(__file__).parent.parent
     pyproject_path = root_dir / "pyproject.toml"
 
-    print(f"Attempting to update version in {pyproject_path} (from {os.getcwd()})")
+    print(
+        f"Attempting to update version in {pyproject_path} (from {pathlib.Path.cwd()})"
+    )
 
     current_full_version = read_project_version(pyproject_path)
     new_version = build_pr_version(current_full_version, run_number)

--- a/scripts/update_release_version.py
+++ b/scripts/update_release_version.py
@@ -17,7 +17,9 @@ def main():
     )
     pyproject_path = root_dir / "pyproject.toml"
 
-    print(f"Attempting to update version in {pyproject_path} (from {os.getcwd()})")
+    print(
+        f"Attempting to update version in {pyproject_path} (from {pathlib.Path.cwd()})"
+    )
     print(f"Original full version in {pyproject_path}: {current_version}")
     print(f"Updating to release version: {normalized_version} (tag: {release_tag})")
     print(f"Successfully updated {pyproject_path} to version {normalized_version}")

--- a/tests/chirpd/test_backend_fake.py
+++ b/tests/chirpd/test_backend_fake.py
@@ -98,11 +98,15 @@ async def test_fake_backend_stream_generate_raises_after_n_tokens() -> None:
     )
     handle = await backend.load("mlx-community/foo", "chat")
     tokens: list[str] = []
-    with pytest.raises(RuntimeError):
+
+    async def drain() -> None:
         async for token in backend.stream_generate(
             handle, [{"role": "user", "content": "x"}], {}, asyncio.Event(), {}
         ):
             tokens.append(token)
+
+    with pytest.raises(RuntimeError):
+        await drain()
     assert tokens == ["a", "b"]
 
 

--- a/tests/chirpd/test_logging_setup.py
+++ b/tests/chirpd/test_logging_setup.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib
 import logging
 import logging.handlers
-import os
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -145,19 +144,19 @@ def test_non_darwin_falls_back_to_xdg_path(
 
 
 def test_configure_logging_rejects_unknown_level(tmp_path: Path) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unknown log level"):
         configure_logging(log_dir=tmp_path, level="WANR")
 
 
 def test_oserror_on_unwritable_directory(tmp_path: Path) -> None:
     locked = tmp_path / "locked"
     locked.mkdir()
-    os.chmod(locked, 0o000)
+    locked.chmod(0o000)
     try:
-        with pytest.raises(OSError):
+        with pytest.raises(OSError, match="cannot open chirpd log file"):
             configure_logging(log_dir=locked)
     finally:
-        os.chmod(locked, 0o700)
+        locked.chmod(0o700)
 
 
 # --- AC-16 (redaction discipline) -----------------------------------------
@@ -167,7 +166,7 @@ def test_oserror_on_unwritable_directory(tmp_path: Path) -> None:
     "bad_key", ["prompt", "messages", "content", "text", "note", "transcript"]
 )
 def test_log_op_event_rejects_unknown_keys(bad_key: str) -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="disallowed field"):
         log_op_event(
             logging.getLogger(CHIRP_LOGGER),
             logging.INFO,

--- a/tests/llm/test_client.py
+++ b/tests/llm/test_client.py
@@ -200,7 +200,8 @@ async def test_lazy_spawn_when_socket_missing(
     payload = await llm_client.health()
     await delayed_task
     assert payload["status"] == "ok"
-    assert spawn_calls and spawn_calls[0][0] == "chirpd"
+    assert spawn_calls
+    assert spawn_calls[0][0] == "chirpd"
     # The child chirpd must bind the socket the client is polling — otherwise
     # a custom socket_path would deadlock against the default-bound daemon.
     assert spawn_envs[0].get("CHIRP_DAEMON_SOCKET") == str(temp_socket_path)
@@ -897,9 +898,8 @@ async def test_mid_stream_version_mismatch_triggers_retry(
     if respawn_task is not None:
         await respawn_task
     assert payload["status"] == "ok"
-    assert first_request_id and second_request_id, (
-        "both daemons should have observed the health request"
-    )
+    assert first_request_id, "first daemon should have observed the health request"
+    assert second_request_id, "second daemon should have observed the health request"
     assert first_request_id[0] == second_request_id[0], (
         "client must replay the original request envelope id verbatim"
     )

--- a/tests/llm/test_error_codes.py
+++ b/tests/llm/test_error_codes.py
@@ -21,7 +21,7 @@ _DECLARED_CODES = {
 }
 
 
-@pytest.mark.parametrize("name,value", sorted(_DECLARED_CODES.items()))
+@pytest.mark.parametrize(("name", "value"), sorted(_DECLARED_CODES.items()))
 def test_declared_codes_are_screaming_snake_case(name: str, value: str) -> None:
     assert isinstance(value, str)
     assert value, "code constant must be a non-empty string"
@@ -30,7 +30,7 @@ def test_declared_codes_are_screaming_snake_case(name: str, value: str) -> None:
 
 
 def test_all_codes_frozenset_matches_constants() -> None:
-    assert error_codes.ALL_CODES == set(_DECLARED_CODES.values())
+    assert set(_DECLARED_CODES.values()) == error_codes.ALL_CODES
 
 
 def test_code_to_exception_has_no_missing_entries() -> None:

--- a/tests/llm/test_hf.py
+++ b/tests/llm/test_hf.py
@@ -94,12 +94,14 @@ def test_validate_repo_returns_metadata(tmp_path: Path) -> None:
 
 
 def test_validate_repo_not_found() -> None:
-    with patch(
-        "llm.hf.HfApi.repo_info",
-        side_effect=_repo_not_found("missing"),
+    with (
+        patch(
+            "llm.hf.HfApi.repo_info",
+            side_effect=_repo_not_found("missing"),
+        ),
+        pytest.raises(HfRepoNotFound) as exc,
     ):
-        with pytest.raises(HfRepoNotFound) as exc:
-            validate_repo("org/missing")
+        validate_repo("org/missing")
     assert exc.value.repo_id == "org/missing"
 
 
@@ -169,9 +171,9 @@ def test_validate_repo_propagates_repo_not_found_from_config_download() -> None:
             "llm.hf.hf_hub_download",
             side_effect=_repo_not_found("vanished"),
         ),
+        pytest.raises(HfRepoNotFound),
     ):
-        with pytest.raises(HfRepoNotFound):
-            validate_repo("org/vanished")
+        validate_repo("org/vanished")
 
 
 def test_validate_repo_propagates_network_error_from_config_download() -> None:
@@ -328,12 +330,14 @@ def test_download_model_returns_result(tmp_path: Path) -> None:
 
 
 def test_download_model_repo_not_found() -> None:
-    with patch(
-        "llm.hf.snapshot_download",
-        side_effect=_repo_not_found("gone"),
+    with (
+        patch(
+            "llm.hf.snapshot_download",
+            side_effect=_repo_not_found("gone"),
+        ),
+        pytest.raises(HfRepoNotFound),
     ):
-        with pytest.raises(HfRepoNotFound):
-            download_model("org/missing")
+        download_model("org/missing")
 
 
 def test_download_model_os_error_disk_full() -> None:

--- a/tests/llm/test_registry.py
+++ b/tests/llm/test_registry.py
@@ -338,9 +338,9 @@ def test_upsert_model_replaces(tmp_path: Path) -> None:
 def test_upsert_rejects_empty_or_slashed_alias() -> None:
     registry = Registry(schema_version=1)
     entry = _chat_entry()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="alias must be non-empty"):
         upsert_model(registry, "", entry)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="must match"):
         upsert_model(registry, "mlx-community/gemma", entry)
 
 
@@ -348,7 +348,7 @@ def test_upsert_rejects_invalid_alias_characters() -> None:
     registry = Registry(schema_version=1)
     entry = _chat_entry()
     for bad in ("Gemma-4-4b", "has spaces", "exclaim!", "über"):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="must match"):
             upsert_model(registry, bad, entry)
 
 
@@ -414,17 +414,17 @@ def test_alias_for_repo_strips_org_and_lowercases() -> None:
 
 
 def test_alias_for_repo_rejects_empty_after_strip() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="does not yield a valid alias"):
         alias_for_repo("mlx-community/")
 
 
 def test_alias_for_repo_rejects_nested_slash() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="nested slashes"):
         alias_for_repo("org/sub/repo")
 
 
 def test_alias_for_repo_rejects_invalid_chars() -> None:
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="does not yield a valid alias"):
         alias_for_repo("mlx-community/has spaces")
 
 

--- a/tests/notes_chat/test_cli.py
+++ b/tests/notes_chat/test_cli.py
@@ -17,8 +17,7 @@ runner = CliRunner()
 
 
 def _fake_config():
-    cfg = MagicMock()
-    return cfg
+    return MagicMock()
 
 
 def _patch_config(monkeypatch):

--- a/tests/notes_chat/test_interactive.py
+++ b/tests/notes_chat/test_interactive.py
@@ -9,14 +9,12 @@ from notes_chat.interactive import InteractiveChatSession
 
 @pytest.fixture
 def mock_config():
-    config = Mock(spec=ChirpSettings)
-    return config
+    return Mock(spec=ChirpSettings)
 
 
 @pytest.fixture
 def chat_session(mock_config):
-    session = InteractiveChatSession(mock_config)
-    return session
+    return InteractiveChatSession(mock_config)
 
 
 def test_interactive_chat_initialization(mock_config):

--- a/tests/notes_chat/test_interactive_coverage.py
+++ b/tests/notes_chat/test_interactive_coverage.py
@@ -193,7 +193,7 @@ def test_handle_slash_unknown(mock_console, chat_session):
 def _make_prompt_side_effects(*values):
     """Return a side_effect list for PromptSession.prompt that raises StopIteration
     after returning all values so the while-True loop exits cleanly via EOFError."""
-    return list(values) + [EOFError()]
+    return [*list(values), EOFError()]
 
 
 @patch("notes_chat.interactive.console")

--- a/tests/notes_chat/test_search_keyword.py
+++ b/tests/notes_chat/test_search_keyword.py
@@ -127,7 +127,8 @@ def test_excerpt_window_truncates_long_lines(tmp_path):
     out = _window_excerpt(long_line, match_start, match_start + len("pricing"))
     assert "pricing" in out
     assert len(out) <= 122
-    assert out.startswith("…") and out.endswith("…")
+    assert out.startswith("…")
+    assert out.endswith("…")
 
 
 def test_excerpt_short_line_unchanged(tmp_path):

--- a/tests/regression/test_corpus_inventory.py
+++ b/tests/regression/test_corpus_inventory.py
@@ -113,7 +113,7 @@ def test_manifest_entries_have_required_fields() -> None:
     missing = {
         slug: sorted(REQUIRED_MANIFEST_FIELDS - set(entry))
         for slug, entry in recordings.items()
-        if not REQUIRED_MANIFEST_FIELDS <= set(entry)
+        if not set(entry) >= REQUIRED_MANIFEST_FIELDS
     }
     assert not missing, f"manifest entries missing required fields: {missing}"
 
@@ -122,10 +122,10 @@ def test_manifest_covers_speaker_and_domain_buckets() -> None:
     recordings = load_manifest().get("recordings", {})
     speakers = {entry["speakers"] for entry in recordings.values()}
     domains = {entry["domain"] for entry in recordings.values()}
-    assert REQUIRED_SPEAKER_BUCKETS <= speakers, (
+    assert speakers >= REQUIRED_SPEAKER_BUCKETS, (
         f"missing speaker buckets: {sorted(REQUIRED_SPEAKER_BUCKETS - speakers)}"
     )
-    assert REQUIRED_DOMAIN_BUCKETS <= domains, (
+    assert domains >= REQUIRED_DOMAIN_BUCKETS, (
         f"missing domain buckets: {sorted(REQUIRED_DOMAIN_BUCKETS - domains)}"
     )
 

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -148,10 +148,9 @@ def test_permission_denied_raises_permission_error(tmp_path: Path) -> None:
 
 def test_missing_binary_raises_file_not_found(tmp_path: Path) -> None:
     missing = tmp_path / "does_not_exist"
-    with _patch_resolve_to(missing):
-        with pytest.raises(FileNotFoundError) as excinfo:
-            with AudioCapture():
-                pass
+    with _patch_resolve_to(missing), pytest.raises(FileNotFoundError) as excinfo:
+        with AudioCapture():
+            pass
     assert "python -m audio_capture.build" in str(excinfo.value)
 
 
@@ -367,9 +366,9 @@ def test_mic_device_name_is_none_when_diagnostic_line_absent(
         _patch_resolve_to(fake_binary),
         mock.patch("audio_capture.subprocess.Popen", side_effect=popen_override),
         mock.patch("audio_capture._POST_START_DRAIN_SECONDS", 0.1),
+        AudioCapture() as cap,
     ):
-        with AudioCapture() as cap:
-            assert cap.mic_device_name is None
+        assert cap.mic_device_name is None
 
 
 def test_wait_for_startup_resets_deadline_on_each_awaiting_permission(
@@ -412,9 +411,9 @@ def test_wait_for_startup_resets_deadline_on_each_awaiting_permission(
         mock.patch("audio_capture.subprocess.Popen", side_effect=popen_override),
         mock.patch("audio_capture._STARTUP_TIMEOUT_SECONDS", 1.0),
         mock.patch("audio_capture._POST_START_DRAIN_SECONDS", 0.1),
+        AudioCapture() as cap,
     ):
-        with AudioCapture() as cap:
-            assert cap._proc is not None
+        assert cap._proc is not None
 
 
 def test_exit_during_frames_iteration_stops_cleanly(tmp_path: Path) -> None:

--- a/tests/test_audio_recorder.py
+++ b/tests/test_audio_recorder.py
@@ -72,7 +72,7 @@ class FakeAudioCapture:
 
     def __exit__(self, exc_type, exc, tb):
         self._exit_event.set()
-        return None
+        return
 
     def frames(self) -> Iterator[tuple[int, int, np.ndarray]]:
         for index, frame in enumerate(self._frames):
@@ -186,7 +186,7 @@ class TestAudioRecorder:
         assert created_dirs == [], "empty note dir should have been cleaned up"
 
     @pytest.mark.parametrize(
-        "mic_device_name,expected_meta_mic",
+        ("mic_device_name", "expected_meta_mic"),
         [
             ("MockMic", "MockMic"),
             ("Studio Mic Pro", "Studio Mic Pro"),
@@ -239,11 +239,13 @@ class TestAudioRecorder:
         self, mock_settings, mock_device_manager
     ):
         recorder = AudioRecorder(mock_settings, mock_device_manager)
-        with patch("sys.platform", "linux"):
-            with pytest.raises(
+        with (
+            patch("sys.platform", "linux"),
+            pytest.raises(
                 RuntimeError, match="chirp record requires macOS 13 or later"
-            ):
-                recorder.start_recording(title="non-mac")
+            ),
+        ):
+            recorder.start_recording(title="non-mac")
 
     def test_start_recording_cleans_up_when_audio_capture_fails_to_start(
         self, tmp_path, mock_settings, mock_device_manager
@@ -257,11 +259,13 @@ class TestAudioRecorder:
             def __exit__(self, exc_type, exc, tb):
                 return None
 
-        with patch(
-            "recorder.audio_recorder.AudioCapture", return_value=FailingCapture()
+        with (
+            patch(
+                "recorder.audio_recorder.AudioCapture", return_value=FailingCapture()
+            ),
+            pytest.raises(RuntimeError, match="helper-startup-boom"),
         ):
-            with pytest.raises(RuntimeError, match="helper-startup-boom"):
-                recorder.start_recording(title="startup-fail")
+            recorder.start_recording(title="startup-fail")
 
         assert recorder.is_recording is False
         assert list(tmp_path.iterdir()) == []
@@ -323,14 +327,16 @@ class TestAudioRecorder:
                 time.sleep(0.05)
                 raise RuntimeError("worker-boom")
 
-        with patch(
-            "recorder.audio_recorder.AudioCapture",
-            return_value=CrashAfterPartial(),
-        ):
-            with pytest.raises(
+        with (
+            patch(
+                "recorder.audio_recorder.AudioCapture",
+                return_value=CrashAfterPartial(),
+            ),
+            pytest.raises(
                 RecordingError, match="audio capture worker crashed mid-recording"
-            ) as excinfo:
-                recorder.start_recording(title="worker-crash")
+            ) as excinfo,
+        ):
+            recorder.start_recording(title="worker-crash")
 
         assert isinstance(excinfo.value.__cause__, RuntimeError)
         assert "worker-boom" in str(excinfo.value.__cause__)
@@ -407,14 +413,16 @@ class TestPartialRecordingTruncationCrash:
                     yield (SOURCE_MICROPHONE, ts, np.full(512, 0.2, dtype=np.float32))
                 raise RuntimeError("mid-stream-crash")
 
-        with patch(
-            "recorder.audio_recorder.AudioCapture",
-            return_value=CrashMidStream(),
-        ):
-            with pytest.raises(
+        with (
+            patch(
+                "recorder.audio_recorder.AudioCapture",
+                return_value=CrashMidStream(),
+            ),
+            pytest.raises(
                 RecordingError, match="audio capture worker crashed mid-recording"
-            ) as excinfo:
-                recorder.start_recording(title="partial-crash")
+            ) as excinfo,
+        ):
+            recorder.start_recording(title="partial-crash")
 
         assert "mid-stream-crash" in str(excinfo.value.__cause__)
         assert list(tmp_path.iterdir()) == [], (

--- a/tests/test_audio_recorder_mixer.py
+++ b/tests/test_audio_recorder_mixer.py
@@ -193,7 +193,7 @@ class TestPartialChunkStall:
         output = list(mixer.drain())
 
         assert len(output) >= 1
-        first_ts, first_mixed = output[0]
+        _first_ts, first_mixed = output[0]
         # First 100 samples: mic partial (0.3) + sys (0.5) = 0.8
         np.testing.assert_allclose(first_mixed[:100], 0.8, atol=1e-6)
         # Remaining samples: sys only (0.5) + silence = 0.5
@@ -222,15 +222,15 @@ class TestBufferCap:
 
 class TestValidation:
     def test_zero_frame_ms_raises(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="frame_ms must be positive"):
             StereoToMonoMixer(frame_ms=0)
 
     def test_negative_gap_raises(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="gap_ms must be non-negative"):
             StereoToMonoMixer(gap_ms=-1)
 
     def test_zero_sample_rate_raises(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="sample_rate must be positive"):
             StereoToMonoMixer(sample_rate=0)
 
 

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -39,7 +39,7 @@ class TestBM25:
             ],
         }
 
-        with open(bm25_file, "w") as f:
+        with bm25_file.open("w") as f:
             json.dump(bm25_data, f)
 
         index = BM25Index(bm25_file)
@@ -64,7 +64,7 @@ class TestBM25:
             ],
         }
 
-        with open(bm25_file, "w") as f:
+        with bm25_file.open("w") as f:
             json.dump(bm25_data, f)
 
         index = BM25Index(bm25_file)
@@ -87,7 +87,7 @@ class TestBM25:
             ],
         }
 
-        with open(bm25_file, "w") as f:
+        with bm25_file.open("w") as f:
             json.dump(bm25_data, f)
 
         index = BM25Index(bm25_file)
@@ -107,7 +107,7 @@ class TestBM25:
 
         bm25_data = {"doc_ids": ["doc1"], "corpus": ["some content here"]}
 
-        with open(bm25_file, "w") as f:
+        with bm25_file.open("w") as f:
             json.dump(bm25_data, f)
 
         index = BM25Index(bm25_file)
@@ -142,7 +142,7 @@ class TestBM25:
 
         assert bm25_file.exists()
 
-        with open(bm25_file) as f:
+        with bm25_file.open() as f:
             data = json.load(f)
 
         assert data["doc_ids"] == ["chunk1", "chunk2"]

--- a/tests/test_branding.py
+++ b/tests/test_branding.py
@@ -20,7 +20,8 @@ from chirp.branding import (
 
 def test_constants_are_nonempty_strings():
     for value in (LOGO_YELLOW, LOGO_ACCENT, LOGO_NOTE, TAGLINE, COMPACT_LOGO):
-        assert isinstance(value, str) and value
+        assert isinstance(value, str)
+        assert value
 
 
 def test_beak_glyphs_are_distinct():

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -96,7 +96,7 @@ class TestCache:
             cache_files = list((tmp_path / "cache").glob("*.json"))
             assert len(cache_files) == 1
 
-            with open(cache_files[0]) as f:
+            with cache_files[0].open() as f:
                 data = json.load(f)
 
             assert data["question"] == question

--- a/tests/test_cli_startup.py
+++ b/tests/test_cli_startup.py
@@ -22,7 +22,7 @@ def test_cli_import_does_not_load_heavy_dependencies():
 
         loaded_heavy = {
             name
-            for name in sys.modules.keys()
+            for name in sys.modules
             for heavy in heavy_modules
             if name == heavy or name.startswith(f"{heavy}.")
         }

--- a/tests/test_compression.py
+++ b/tests/test_compression.py
@@ -178,7 +178,7 @@ class TestGetFileSizes:
         json_file = tmp_path / "data.json"
         json_file.write_text("{}", encoding="utf-8")
 
-        with patch("builtins.open", side_effect=OSError("read error")):
+        with patch("pathlib.Path.open", side_effect=OSError("read error")):
             result = JSONCompressor.get_file_sizes(json_file)
 
         assert result["original"] == 0

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -344,7 +344,11 @@ def test_install_missing_dispatches_build_for_missing_binary(tmp_path, monkeypat
 
     assert len(run_calls) == 1, f"expected exactly one dispatch, got: {run_calls}"
     args = run_calls[0]
-    assert _sys.executable in args and "-m" in args and "audio_capture.build" in args, (
+    assert _sys.executable in args, (
+        f"expected python executable in dispatch, got: {args}"
+    )
+    assert "-m" in args, f"expected -m in dispatch, got: {args}"
+    assert "audio_capture.build" in args, (
         f"expected audio_capture.build dispatch, got: {args}"
     )
 
@@ -987,7 +991,7 @@ def test_launch_agent_prompt_default_no_skips_install(tmp_path, monkeypatch):
 
 
 def test_launch_agent_prompt_yes_installs(tmp_path, monkeypatch):
-    console, install_calls, prompt_calls, config_path = _launch_agent_env(
+    console, install_calls, _prompt_calls, config_path = _launch_agent_env(
         monkeypatch, tmp_path, answer="y"
     )
     settings = _fake_settings(tmp_path)

--- a/tests/test_live_audio.py
+++ b/tests/test_live_audio.py
@@ -189,9 +189,9 @@ def test_start_cleans_up_audio_capture_when_thread_start_fails() -> None:
             "recorder.live_audio.threading.Thread",
             side_effect=RuntimeError("can't start new thread"),
         ),
+        pytest.raises(RuntimeError, match="can't start new thread"),
     ):
-        with pytest.raises(RuntimeError, match="can't start new thread"):
-            stream.start()
+        stream.start()
 
     assert fake.exit_calls == 1
     assert stream._cap_ctx is None
@@ -218,7 +218,10 @@ def test_close_is_idempotent() -> None:
 
     with mock.patch("recorder.live_audio.AudioCapture", return_value=fake):
         stream.start()
-        assert stream._mixer_thread is not None and stream._mixer_thread.is_alive(), (
+        assert stream._mixer_thread is not None, (
+            "mixer thread must exist before testing idempotent close"
+        )
+        assert stream._mixer_thread.is_alive(), (
             "mixer thread must be alive before testing idempotent close"
         )
         stream.close()

--- a/tests/test_parse_timeframe.py
+++ b/tests/test_parse_timeframe.py
@@ -28,7 +28,7 @@ def test_handles_uppercase_and_whitespace():
 
 
 def test_rejects_garbage():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unrecognized timeframe"):
         parse_timeframe("soon")
 
 
@@ -40,7 +40,7 @@ def test_fractional_rounds_up():
 
 def test_rejects_zero_and_negative():
     for bad in ["0m", "0", "0h", "-1m", "-30s"]:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="timeframe must be positive"):
             parse_timeframe(bad)
 
 
@@ -73,10 +73,10 @@ class TestParseSince:
                 parse_since(bad)
 
     def test_rejects_garbage(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="unrecognized timeframe"):
             parse_since("soon")
 
     def test_rejects_zero_and_negative(self):
         for bad in ["0d", "0h", "-1d"]:
-            with pytest.raises(ValueError):
+            with pytest.raises(ValueError, match="timeframe must be positive"):
                 parse_since(bad)

--- a/tests/test_popup_manager.py
+++ b/tests/test_popup_manager.py
@@ -6,13 +6,13 @@ import pytest
 from utils.popup_manager import PopupManager
 
 
-@pytest.fixture()
+@pytest.fixture
 def macos_popup():
     with patch("utils.popup_manager.platform.system", return_value="Darwin"):
         yield PopupManager()
 
 
-@pytest.fixture()
+@pytest.fixture
 def linux_popup():
     with patch("utils.popup_manager.platform.system", return_value="Linux"):
         yield PopupManager()
@@ -31,7 +31,7 @@ class TestShowRecordingWarning:
         macos_popup.show_notification = MagicMock(return_value=True)
         result = macos_popup.show_recording_warning(30)
         macos_popup.show_notification.assert_called_once()
-        title, message = macos_popup.show_notification.call_args[0]
+        _title, message = macos_popup.show_notification.call_args[0]
         assert "30 minutes" in message
         assert result is True
 

--- a/tests/test_retrieval_coverage.py
+++ b/tests/test_retrieval_coverage.py
@@ -343,7 +343,7 @@ class TestBuildContextEmptyContent:
                 },
             ),
         ]
-        context, sources, ids = _build_context(chunks, 10000)
+        context, _sources, ids = _build_context(chunks, 10000)
         assert "id1" not in ids
         assert "id2" in ids
         assert "real content here" in context
@@ -363,7 +363,7 @@ class TestBuildContextEmptyContent:
                 },
             ),
         ]
-        context, sources, ids = _build_context(chunks, tiny_budget)
+        _context, _sources, ids = _build_context(chunks, tiny_budget)
         assert len(ids) <= 1
 
 

--- a/tests/test_retrieval_merge.py
+++ b/tests/test_retrieval_merge.py
@@ -129,7 +129,7 @@ class TestRetrievalMerge:
             ),
         ]
 
-        context, sources, retrieved_ids = _build_context(chunks, 200)
+        context, _sources, retrieved_ids = _build_context(chunks, 200)
 
         assert len(context) <= 200
         assert "..." in context
@@ -201,7 +201,7 @@ class TestRetrievalMerge:
             ),
         ]
 
-        context, sources, retrieved_ids = _build_context(chunks, 1000)
+        context, sources, _retrieved_ids = _build_context(chunks, 1000)
 
         assert "2025-01-15 · notes.md" in context
         # No `config` was provided so the slug is the fallback label.

--- a/tests/test_whisper_transcriber.py
+++ b/tests/test_whisper_transcriber.py
@@ -55,19 +55,19 @@ class TestWhisperTranscriber:
             mock_model = Mock()
             mock_whisper_model_class.return_value = mock_model
 
-            with patch.object(
-                WhisperTranscriber, "_get_optimal_device", return_value="cpu"
-            ):
-                with patch.object(
+            with (
+                patch.object(
+                    WhisperTranscriber, "_get_optimal_device", return_value="cpu"
+                ),
+                patch.object(
                     WhisperTranscriber, "_get_compute_type", return_value="int8"
-                ):
-                    with patch.object(
-                        WhisperTranscriber, "_get_cpu_threads", return_value=4
-                    ):
-                        transcriber = WhisperTranscriber(mock_settings)
+                ),
+                patch.object(WhisperTranscriber, "_get_cpu_threads", return_value=4),
+            ):
+                transcriber = WhisperTranscriber(mock_settings)
 
-                        assert transcriber.model == mock_model
-                        assert transcriber.settings == mock_settings
+                assert transcriber.model == mock_model
+                assert transcriber.settings == mock_settings
 
     @patch("platform.system")
     @patch("platform.processor")
@@ -246,16 +246,16 @@ class TestWhisperTranscriber:
 
         with patch("transcriber.whisper_transcriber.WhisperModel") as mock_model_cls:
             mock_model_cls.return_value = mock_whisper_model
-            with patch.object(
-                WhisperTranscriber, "_get_optimal_device", return_value="cpu"
-            ):
-                with patch.object(
+            with (
+                patch.object(
+                    WhisperTranscriber, "_get_optimal_device", return_value="cpu"
+                ),
+                patch.object(
                     WhisperTranscriber, "_get_compute_type", return_value="int8"
-                ):
-                    with patch.object(
-                        WhisperTranscriber, "_get_cpu_threads", return_value=4
-                    ):
-                        transcriber = WhisperTranscriber(mock_settings)
+                ),
+                patch.object(WhisperTranscriber, "_get_cpu_threads", return_value=4),
+            ):
+                transcriber = WhisperTranscriber(mock_settings)
 
         result = transcriber.transcribe_file(audio_path)
 
@@ -265,7 +265,9 @@ class TestWhisperTranscriber:
         assert metadata["title"] == "Strategy Sync"
         assert metadata["duration"] == pytest.approx(5.0)
         assert metadata["segment_count"] == 1
-        assert metadata["word_count"] == len("This is a test transcription.".split())
+        assert metadata["word_count"] == len(
+            ["This", "is", "a", "test", "transcription."]
+        )
         assert metadata["recording_datetime"].startswith("2025-01-01T12:00:00")
         assert result["full_text"] == "This is a test transcription."
 
@@ -432,20 +434,16 @@ class TestWhisperTranscriber:
         audio_path = tmp_path / "20250101_120000_test.wav"
         audio_path.write_bytes(b"fake audio data")
 
-        with patch(
-            "transcriber.whisper_transcriber.WhisperModel",
-            return_value=mock_whisper_model,
+        with (
+            patch(
+                "transcriber.whisper_transcriber.WhisperModel",
+                return_value=mock_whisper_model,
+            ),
+            patch.object(WhisperTranscriber, "_get_optimal_device", return_value="cpu"),
+            patch.object(WhisperTranscriber, "_get_compute_type", return_value="int8"),
+            patch.object(WhisperTranscriber, "_get_cpu_threads", return_value=4),
         ):
-            with patch.object(
-                WhisperTranscriber, "_get_optimal_device", return_value="cpu"
-            ):
-                with patch.object(
-                    WhisperTranscriber, "_get_compute_type", return_value="int8"
-                ):
-                    with patch.object(
-                        WhisperTranscriber, "_get_cpu_threads", return_value=4
-                    ):
-                        transcriber = WhisperTranscriber(mock_settings)
+            transcriber = WhisperTranscriber(mock_settings)
 
         transcriber.transcribe_file(audio_path)
 

--- a/transcriber/batch_processor.py
+++ b/transcriber/batch_processor.py
@@ -108,7 +108,7 @@ class ChecklistView:
 
 
 def _format_duration(seconds: float) -> str:
-    total = int(round(max(seconds, 0.0)))
+    total = round(max(seconds, 0.0))
     minutes, secs = divmod(total, 60)
     return f"{minutes:02d}:{secs:02d}"
 

--- a/transcriber/compression.py
+++ b/transcriber/compression.py
@@ -33,7 +33,7 @@ class JSONCompressor:
             data = json.loads(json_str)
             return dict(data) if isinstance(data, dict) else {}
         except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as e:
-            raise RuntimeError(f"Failed to decompress JSON file: {str(e)}")
+            raise RuntimeError(f"Failed to decompress JSON file: {e!s}")
 
     @staticmethod
     def get_compression_ratio(original_size: int, compressed_size: int) -> float:
@@ -47,7 +47,7 @@ class JSONCompressor:
             return {"original": 0, "compressed": 0}
 
         try:
-            with open(json_path, encoding="utf-8") as f:
+            with json_path.open(encoding="utf-8") as f:
                 original_size = len(f.read().encode("utf-8"))
         except OSError:
             original_size = 0

--- a/transcriber/whisper_transcriber.py
+++ b/transcriber/whisper_transcriber.py
@@ -36,21 +36,19 @@ class WhisperTranscriber:
 
         if system == "Darwin":
             return "cpu"
-        else:
-            try:
-                import torch
+        try:
+            import torch
 
-                return "cuda" if torch.cuda.is_available() else "cpu"
-            except ImportError:
-                return "cpu"
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        except ImportError:
+            return "cpu"
 
     def _get_compute_type(self) -> str:
         device = self._get_optimal_device()
 
         if device == "cpu":
             return "int8"
-        else:
-            return "float16"
+        return "float16"
 
     def _get_cpu_threads(self) -> int:
         import os

--- a/utils/popup_manager.py
+++ b/utils/popup_manager.py
@@ -36,8 +36,7 @@ class PopupManager:
         try:
             if self.is_macos:
                 return self._show_macos_notification(title, message)
-            else:
-                return self._show_generic_notification(title, message)
+            return self._show_generic_notification(title, message)
         except (subprocess.SubprocessError, OSError):
             return False
 

--- a/utils/time_utils.py
+++ b/utils/time_utils.py
@@ -21,14 +21,13 @@ def get_filename_timestamp() -> str:
 def format_duration(seconds: float) -> str:
     if seconds < 60:
         return f"{int(seconds)}s"
-    elif seconds < 3600:
+    if seconds < 3600:
         minutes = int(seconds // 60)
         remaining_seconds = int(seconds % 60)
         return f"{minutes}m {remaining_seconds}s"
-    else:
-        hours = int(seconds // 3600)
-        remaining_minutes = int((seconds % 3600) // 60)
-        return f"{hours}h {remaining_minutes}m"
+    hours = int(seconds // 3600)
+    remaining_minutes = int((seconds % 3600) // 60)
+    return f"{hours}h {remaining_minutes}m"
 
 
 def parse_timestamp_from_filename(filename: str) -> datetime | None:


### PR DESCRIPTION
## What

Broadens ruff lint coverage beyond the existing `E/W/F/I/B/C4/UP/BLE` by adopting these groups, applying autofixes, and resolving every remaining violation by hand:

`FA` · `ISC` · `ICN` · `RET` · `SIM` · `TID` · `PTH` · `TD` · `NPY` · `RUF` · `PERF` · `PT` · `ASYNC` · `PGH` · `PIE` · `LOG` · `G`

Also bumps the ruff **pre-commit** hook `v0.12.12 → v0.15.9` to match the project's pinned ruff (CI already runs 0.15.9); the older hook didn't recognize newer selectors like `ASYNC240`.

## How the scope was chosen

Counts were measured with `ruff check --statistics` against the live tree, not estimated. A few candidate groups were **excluded** as noise or as fighting the architecture (`PLC0415` intentional lazy imports, `PLR2004`, `TRY003`+`EM`, `FBT` typer flags, `SLF001`, `ARG`).

### Scoped ignores (rationale in `pyproject.toml`)
| Rule | Why |
|------|-----|
| `ISC001` | conflicts with the ruff formatter |
| `SIM105` | `contextlib.suppress` is slower / debatable vs `try/except: pass` |
| `TD002` / `TD003` | TODO author/issue-link are not team conventions |
| `RUF001/002/003` | ambiguous-unicode is intentional in user-facing notes text |
| `ASYNC240` | advises `trio.Path`/`anyio.path`; this project is **asyncio-only**, so pathlib in async is fine |

### Per-file ignores (`tests/**`)
- `ASYNC109` / `ASYNC110` — test helpers take `timeout` params and intentionally poll with `asyncio.sleep`
- `PERF` — perflint targets production hot paths; stream-consume loops must collect partial results before a raise
- `SIM117` — nested `with mock.patch(...)` is a readable pytest idiom (all 35 hits were nested patches; rule stays active for production code)

## Notable manual fixes
- `PTH` (~31, not autofixable): `open()`→`Path.open()`, `os.path`/`os.chmod`/`os.replace`→pathlib
- One intentional detached daemon spawn keeps a targeted `# noqa: ASYNC220`
- `PT011` (16): added `match=` derived from the actual error messages
- Two test fixes uncovered by the new rules: `configure_logging` re-raises as `OSError` (not `PermissionError`); `Path.open` isn't intercepted by `builtins.open` patching (test now patches `pathlib.Path.open`)

## Deferred to follow-up PRs (documented, not done here)
- **Complexity guardrails** — `C90` + `PLR09xx` (needs threshold tuning)
- **`DTZ`** — datetime tz-awareness (behavioral; can shift recorded timestamps)
- **`TC`** — TYPE_CHECKING blocks (runtime risk with typer/pydantic; needs config + smoke run)
- **`S`/bandit** — viable only with `tests/**` ignoring `S101`
- **Duplicate-code** — ruff can't do clone detection; evaluate `pylint R0801` / `jscpd` separately

## Verification
- `make check` (validate + ruff + format + codespell + mypy) ✅
- `make test` — **1405 passed** ✅
- CLI smoke: `chirp --help`, `chirp init --recheck` run clean ✅