### PR TITLE
Story 8.4 — Audio capture & transcription reliability

### DIFF
--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.4-audio-capture-and-transcription-reliability.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.4-audio-capture-and-transcription-reliability.md
@@ -1,6 +1,6 @@
 # Story 8.4 — Audio capture & transcription reliability
 
-- **Status:** ready-for-dev
+- **Status:** ready-for-review
 - **Epic:** [EPIC-PRODUCTION-HARDENING](../epic.md)
 - **Depends on:** [EPIC-AUDIO-CAPTURE](../../epic-audio-capture/epic.md) (done; this story hardens it — the native ScreenCaptureKit/AVAudioEngine Swift-helper capture path it shipped is the strong part, this fixes the glue around it). Loosely benefits from 8.6's tolerant-config / coverage-floor guardrails landing alongside, but does not block on them.
 - **Blocks:** —
@@ -172,33 +172,66 @@ On a slow CPU-int8 Whisper, `chunk_queue` (maxsize 50) fills and **speech chunks
 
 ### Agent Model Used
 
-_TBD_
+claude-opus-4-8[1m] (Claude Code dev agent)
 
 ### Debug Log References
 
-_TBD_
+- `grep -rn "self.device_manager\." recorder/` → zero hits (dead-code claim re-confirmed post-change).
+- `grep -rn "device_manager" recorder/` → zero hits after AC-1b (capture classes fully cleaned).
+- `chirp/cli.py` `device_manager`/`DeviceManager` references now only in `_resolve_mic_name`, the `with`-scoped `record` mic-name lookup, and the `with`-scoped `devices` enumeration.
+- `make check` → ruff check, ruff format --check, codespell, mypy all green (70 source files, no mypy issues).
+- `make test` → 1518 passed (run twice, stable).
 
 ### Completion Notes List
 
-_TBD_
+- **AC-1 — DONE (AC-1b per locked decision + AC-1a).** Removed `device_manager` param/attr from `AudioRecorder.__init__`, `LiveAudioStream.__init__`, and `LiveTranscriptionSession.__init__` (plus their TYPE_CHECKING imports and the forward into `LiveAudioStream`). Updated `record` (`AudioRecorder(settings)`, `_run_live_transcription(...)` no longer takes `device_manager`) and `_run_live_transcription`'s signature/`LiveTranscriptionSession(...)` call. AC-1a: `record` resolves the cosmetic mic-name inside `with DeviceManager() as device_manager:` and `devices` enumerates inside `with DeviceManager() as device_manager:` — both close the PortAudio handle deterministically; no PortAudio teardown relies on `__del__`. `DeviceManager` the class is untouched (still used by `devices`/`_resolve_mic_name`).
+- **AC-2 — DONE.** Added `WhisperModelLoadError(TranscriptionError)` to `chirp/exceptions.py`. Wrapped `WhisperModel(...)` in `_load_model` with a typed, actionable message (names the Whisper model, suggests network/disk/retry/config remedy, chains the underlying error). Live ordering fixed: `LiveTranscriptionSession.run()` now constructs the `LiveTranscriber` (which loads Whisper) **before** `audio_stream.start()`; on a start failure the transcriber is closed and `RecordingError` raised. Offline path: `chirp transcribe` catches `WhisperModelLoadError` from `BatchProcessor(...)` construction and prints the actionable message instead of a traceback; `_run_live_transcription` catches it too.
+- **AC-3 — DONE (belt-and-suspenders).** `_stop_pipeline` now joins the transcriber unbounded (`self.transcriber.join()` with no timeout) so the final `_maybe_transcribe(force=True)` pass completes before segments are read. `export_transcript` now reads through the lock-guarded `segments` property instead of touching `self._segments` directly — no `RuntimeError: list changed size during iteration` and no torn write.
+- **AC-4 — DONE.** Thread-safe drop counters added: `LiveAudioStream._dropped_frames` (incremented in the `frame_queue` `queue.Full` branch; level-queue drops left cosmetic) exposed via `dropped_frames`; `VADChunker._dropped_chunks` (incremented in the `chunk_queue` `queue.Full` branch, emits a `"dropped"` `DashboardEvent`) exposed via `dropped_chunks`. Dashboard renders a yellow "Dropped: N (transcript only)" status row when > 0. `LiveSessionResult` carries `dropped_chunks`/`dropped_frames`; `_run_live_transcription` prints a yellow warning when either is > 0, explicitly stating the saved `audio.wav` is complete and unaffected. No blocking backpressure added; WAV write path untouched.
+- **AC-5 — DONE.** `WhisperTranscriber.close()` is idempotent and nulls `self.model`; `__del__` is now a best-effort backstop calling `close()`. `LiveTranscriber.close()` tears down its `WhisperTranscriber` idempotently. `LiveTranscriptionSession` calls `self.transcriber.close()` on the clean path, the capture-error path, the start-failure path, and in `stop()`.
+- **AC-6 — DONE (tidy only).** `_get_optimal_device`/`_get_compute_type` reconciled with reality: Darwin returns `cpu`/`int8`; the non-Darwin CUDA branch is kept only as a portability hint with an accurate comment that it is not exercised on the supported platform (no fake GPU support added). `batch_processor.py` TODO comment corrected: Whisper runs CPU int8 here while chirpd/MLX targets Metal.
+- **AC-7 — DONE.** `check_permissions` wraps `subprocess.run(..., timeout=3)` in `try/except subprocess.TimeoutExpired`, raising `AudioCaptureStartTimeout` with an actionable "did not respond within 3s … check Privacy & Security … try again" message. Because `AudioCaptureStartTimeout` subclasses `RuntimeError`, both callers (`chirp/init_flow.py`, `chirp/cli.py devices`) already handle it gracefully via their existing `except RuntimeError`.
+- **AC-8 — DONE.** `make check` green; `make test` → 1518 passed (twice). New behavior covered by mocked tests; no test instantiates a real `DeviceManager`, opens a real PyAudio/PortAudio stream, spawns the real Swift helper, or downloads/loads a real Whisper model.
+- **Test-suite note (not a regression):** the pre-existing `tests/test_audio_capture.py::test_frames_raises_on_nonzero_exit` (an EPIC-AUDIO-CAPTURE `frames()` test that spawns a fake `sh` helper and drains stderr on a background thread) is load-sensitive: when the heavy audio test files are force-run as a small back-to-back subset it can intermittently miss the final stderr line. It passes in isolation, passes its own file (24/24), and passes under the canonical `make test` (1518/1518). My changes do not touch `frames()`, the stderr drain, or `AudioCaptureCrashed`.
+
+### Code Review Fixes (2026-06-15)
+
+- **MEDIUM-1 (missed call site / leak) — FIXED.** `scripts/test_live_vad.py` still passed the removed `device_manager=` kwarg to `LiveAudioStream` (would `TypeError` at runtime) and constructed a bare unclosed `DeviceManager()` (the exact AC-1 leak). Dropped the dead kwarg and `with`-scoped the `DeviceManager()` device probe so the handle closes deterministically. Re-grepped the whole repo (`grep -rn "device_manager" --include="*.py" .`): the only remaining production references are the legitimate `chirp/cli.py` `_resolve_mic_name` + the two `with`-scoped uses; all other hits are the `DeviceManager` class/tests.
+- **MEDIUM-2 (weak AC-3 join test) — FIXED.** `tests/test_live_session.py::test_slow_final_pass_is_included_in_export` previously used a `SlowTranscriber.join()` that ignored its `timeout` arg, so it could not catch the unbounded-join regression. Rewrote it to use a real `threading.Thread` subclass whose `run()` (the simulated final `_maybe_transcribe(force=True)` pass) sleeps 1.5s before appending the final segment + setting `total_words`. Verified fail-before/pass-after: under a temporarily-reverted `join(timeout=1)` the test FAILS (`total_words == 0`, final segment missing, no transcript written); under the shipped unbounded `join()` it PASSES.
+- **NIT-1 (unused fixture params) — FIXED.** Dropped the now-unused `mock_device_manager` param from the 10 `tests/test_audio_recorder.py` test signatures, and removed the now-dead `mock_device_manager` fixture and `_build_device_manager` helper.
+- **LOW-1 (dashboard `dropped` event can itself be queue-dropped) — ANNOTATED.** Left a one-line comment at the `vad_chunker.py` emit site noting the dashboard event is best-effort and the authoritative total flows via `LiveSessionResult.dropped_chunks` / the final summary. (NIT-2 duplicate local import skipped per review.)
 
 ### File List
 
-_Expected to touch (final list filled at implementation):_
-- `chirp/cli.py` (AC-1: `with`-scope DeviceManager; drop `device_manager` from capture call sites; AC-4: surface drop warning)
-- `recorder/device_manager.py` (AC-1: verify close/`__enter__`/`__exit__` usage; likely unchanged beyond confirmation)
-- `recorder/audio_recorder.py` (AC-1b: drop unused `device_manager` attr)
-- `recorder/live_audio.py` (AC-1b: drop `device_manager` param; AC-4: count frame drops)
-- `recorder/live_session.py` (AC-1b; AC-2 ordering; AC-3 join; AC-4 summary; AC-5 transcriber close)
-- `recorder/live_transcriber.py` (AC-3 lock-guard export; AC-5 `close()`)
-- `recorder/vad_chunker.py` (AC-4: count chunk drops)
-- `transcriber/whisper_transcriber.py` (AC-2 typed load error; AC-5 `close()`; AC-6 device/compute tidy)
-- `transcriber/batch_processor.py` (AC-6: fix Metal comment)
-- `audio_capture/__init__.py` (AC-7: `check_permissions` TimeoutExpired)
-- `chirp/exceptions.py` (AC-2: `WhisperModelLoadError`)
-- `tests/test_device_manager.py`, `tests/test_whisper_transcriber.py`, `tests/test_live_transcriber.py`, `tests/test_live_session.py`, `tests/test_audio_capture.py` (mocked tests)
+Source:
+- `chirp/exceptions.py` — AC-2 `WhisperModelLoadError(TranscriptionError)`.
+- `transcriber/whisper_transcriber.py` — AC-2 typed load error; AC-5 idempotent `close()` + `__del__` backstop; AC-6 device/compute tidy.
+- `transcriber/batch_processor.py` — AC-6 corrected Metal TODO comment.
+- `recorder/audio_recorder.py` — AC-1b dropped `device_manager` param/attr + TYPE_CHECKING import.
+- `recorder/live_audio.py` — AC-1b dropped `device_manager` param + import; AC-4 `_dropped_frames` counter + `dropped_frames` property.
+- `recorder/vad_chunker.py` — AC-4 `_dropped_chunks` counter + `dropped_chunks` property + `"dropped"` event.
+- `recorder/live_transcriber.py` — AC-3 lock-guarded `export_transcript`; AC-5 `close()`.
+- `recorder/live_session.py` — AC-1b dropped `device_manager`; AC-2 load-before-capture ordering; AC-3 unbounded transcriber join; AC-4 `LiveSessionResult` drop fields + collection; AC-5 transcriber `close()` in cleanup/`stop()`.
+- `recorder/live_dashboard.py` — AC-4 `"dropped"` event handling + status-row indicator.
+- `chirp/cli.py` — AC-1a `with`-scoped `DeviceManager` in `record`/`devices`; AC-1b updated `record`/`_run_live_transcription` call sites; AC-2 `WhisperModelLoadError` handling in `transcribe`/`_run_live_transcription`; AC-4 drop warning in `_run_live_transcription`.
+- `audio_capture/__init__.py` — AC-7 `check_permissions` `TimeoutExpired` → `AudioCaptureStartTimeout`.
+- `scripts/test_live_vad.py` — review MEDIUM-1: dropped dead `device_manager=` kwarg to `LiveAudioStream`; `with`-scoped the `DeviceManager()` device probe.
+
+Tests (all mocked; no real hardware/model):
+- `tests/test_device_manager.py` — AC-1 `with`-exit terminates once; `close()` idempotent.
+- `tests/test_whisper_transcriber.py` — AC-2 typed load error; AC-5 `close()` idempotent + nulls model; AC-6 `get_model_info()` cpu/int8 on Darwin.
+- `tests/test_live_transcriber.py` — AC-3 concurrent export never raises; AC-5 `close()` tears down wrapped transcriber.
+- `tests/test_live_session.py` — AC-2 capture not started on model-load failure; AC-3 slow final pass included in export; AC-4 drop counters surface in result; AC-5 transcriber closed during cleanup. (Plus fixed three existing tests that passed `device_manager=`.)
+- `tests/test_live_audio.py` — AC-4 full frame_queue increments drop counter. (Plus fixed `_make_stream`/`test_frame_samples_derived_from_frame_ms` for the dropped `device_manager` param.)
+- `tests/test_vad_chunker.py` — AC-4 full chunk_queue increments counter + emits `"dropped"` event.
+- `tests/test_audio_capture.py` — AC-7 `TimeoutExpired` → `AudioCaptureStartTimeout`.
+- `tests/test_cli_commands.py` — AC-1 `devices` closes the PortAudio handle; AC-2 `transcribe` surfaces `WhisperModelLoadError` cleanly.
+- `tests/test_audio_recorder.py` — fixed for the dropped `device_manager` constructor arg.
+- `tests/test_record_view.py` — `FakeRecorder.__init__` single-arg; `FakeDeviceManager` context-manager support.
 
 ## Change Log
 
 - 2026-06-14: Story 8.4 drafted from the 2026-06-14 production-readiness audit (audio/transcription reliability findings). Line numbers verified against source; dead-code claim for `DeviceManager` in the capture path confirmed (`grep -rn "self.device_manager\." recorder/` → zero hits). Status → ready-for-dev.
 - 2026-06-15: Maintainer locked AC-1 approach → AC-1b (remove `DeviceManager` from the capture path), with AC-1a deterministic close retained for the surviving `devices` / mic-name uses.
+- 2026-06-15: Implemented all 8 ACs (dev agent). `make check` green; `make test` 1518 passed. Status → ready-for-review.
+- 2026-06-15: Addressed code-review nits (dev agent): MEDIUM-1 fixed the missed `scripts/test_live_vad.py` call site + unclosed `DeviceManager` leak; MEDIUM-2 strengthened the AC-3 join test to a real-thread regression guard (verified fail-before `join(timeout=1)` / pass-after unbounded `join()`); NIT-1 removed unused `mock_device_manager` fixture params + dead helper; LOW-1 annotated the best-effort `dropped` dashboard event. `make check` green; `make test` 1518 passed.

--- a/audio_capture/__init__.py
+++ b/audio_capture/__init__.py
@@ -494,13 +494,20 @@ def check_permissions() -> dict[str, str]:
                 "capture_audio binary not found. Build it with: "
                 "python -m audio_capture.build"
             )
-        result = subprocess.run(
-            [str(binary_path), "--check-permissions"],
-            capture_output=True,
-            text=True,
-            timeout=3,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                [str(binary_path), "--check-permissions"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise AudioCaptureStartTimeout(
+                "The capture helper did not respond to --check-permissions "
+                "within 3s; it may be wedged. Check System Settings → Privacy "
+                "& Security (Microphone and Screen Recording) and try again."
+            ) from exc
     if result.returncode != 0:
         raise RuntimeError(
             f"capture_audio --check-permissions exited {result.returncode}: "

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -264,7 +264,6 @@ def record(
     from utils.time_utils import parse_timeframe
 
     settings = get_settings()
-    device_manager = DeviceManager()
 
     is_tty = sys.stdin.isatty() and sys.stdout.isatty()
     if title is None and is_tty:
@@ -289,7 +288,6 @@ def record(
     if live_transcribe:
         _run_live_transcription(
             settings,
-            device_manager,
             title,
             duration,
             debug_live=debug_live,
@@ -297,8 +295,9 @@ def record(
         )
         return
 
-    recorder = AudioRecorder(settings, device_manager)
-    mic_name = _resolve_mic_name(device_manager)
+    recorder = AudioRecorder(settings)
+    with DeviceManager() as device_manager:
+        mic_name = _resolve_mic_name(device_manager)
     state = _RecordViewState(
         title=title,
         cap_minutes=duration,
@@ -392,12 +391,12 @@ def record(
 
 def _run_live_transcription(
     settings,
-    device_manager,
     title: str | None,
     duration: int | None,
     debug_live: bool = False,
     tags: list[str] | None = None,
 ):
+    from chirp.exceptions import WhisperModelLoadError
     from recorder.live_session import LiveSessionResult, LiveTranscriptionSession
 
     if title:
@@ -407,7 +406,6 @@ def _run_live_transcription(
 
     session = LiveTranscriptionSession(
         settings=settings,
-        device_manager=device_manager,
         console=console,
         title=title,
         duration_minutes=duration,
@@ -419,6 +417,9 @@ def _run_live_transcription(
         result: LiveSessionResult = session.run()
     except ImportError as e:
         console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+    except WhisperModelLoadError as e:
+        console.print(f"[red]{e!s}[/red]")
         raise typer.Exit(1)
     except RecordingError as e:
         console.print(f"[red]Live recording error: {e!s}[/red]")
@@ -432,6 +433,15 @@ def _run_live_transcription(
     console.print(
         f"[dim]Duration:[/dim] {format_duration(result.duration_seconds)}  •  [dim]Live words transcribed:[/dim] {result.total_words}"
     )
+    if result.dropped_chunks > 0 or result.dropped_frames > 0:
+        console.print(
+            f"[yellow]⚠ This machine couldn't keep up: "
+            f"{result.dropped_chunks} speech chunk(s) and "
+            f"{result.dropped_frames} audio frame(s) were dropped, so the live "
+            f"transcript may be incomplete. The saved audio.wav is complete and "
+            f"unaffected — run 'chirp transcribe' for the full transcript."
+            f"[/yellow]"
+        )
     console.print(
         "[dim]Run 'chirp transcribe' to generate the high-quality transcript.[/dim]"
     )
@@ -486,7 +496,13 @@ def transcribe(
     if model:
         console.print(f"[cyan]Using Whisper model: {model}[/cyan]")
 
-    processor = BatchProcessor(settings, model_override=model)
+    from chirp.exceptions import WhisperModelLoadError
+
+    try:
+        processor = BatchProcessor(settings, model_override=model)
+    except WhisperModelLoadError as e:
+        console.print(f"[red]{e!s}[/red]")
+        raise typer.Exit(1)
     processor.run_queue(n=n, force=force, console=console)
 
 
@@ -1105,11 +1121,10 @@ def devices():
     """List available audio devices"""
     from recorder.device_manager import DeviceManager
 
-    device_manager = DeviceManager()
-    devices_info = device_manager.list_devices()
-
-    default_input_index = device_manager.get_default_input_device()
-    default_output_index = device_manager.get_default_output_device()
+    with DeviceManager() as device_manager:
+        devices_info = device_manager.list_devices()
+        default_input_index = device_manager.get_default_input_device()
+        default_output_index = device_manager.get_default_output_device()
 
     input_devices = [d for d in devices_info if d["max_input_channels"] > 0]
     output_devices = [d for d in devices_info if d["max_output_channels"] > 0]

--- a/chirp/exceptions.py
+++ b/chirp/exceptions.py
@@ -14,6 +14,17 @@ class TranscriptionError(ChirpException):
     pass
 
 
+class WhisperModelLoadError(TranscriptionError):
+    """The Whisper model could not be downloaded or loaded.
+
+    Raised when ``faster_whisper.WhisperModel(...)`` construction fails — for
+    example on first run with no network, a Hugging Face rate-limit, a full
+    disk, or a misconfigured model name. The message names the failure as a
+    Whisper model download/load problem and suggests a remedy so the user can
+    act rather than read a raw traceback.
+    """
+
+
 class NoteGenerationError(ChirpException):
     pass
 

--- a/recorder/audio_recorder.py
+++ b/recorder/audio_recorder.py
@@ -10,7 +10,6 @@ from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from threading import Timer
-from typing import TYPE_CHECKING
 
 import numpy as np
 import tomli_w
@@ -31,12 +30,6 @@ from utils.file_utils import (
 )
 from utils.time_utils import get_recording_duration
 
-if TYPE_CHECKING:
-    # Imported only for type hints. `recorder.device_manager` pulls in
-    # PyAudio at import time, which would defeat this module's
-    # platform-neutral import goal on hosts where PyAudio is unavailable.
-    from recorder.device_manager import DeviceManager
-
 logger = logging.getLogger(__name__)
 
 OUTPUT_SAMPLE_RATE = 16000
@@ -45,9 +38,8 @@ OUTPUT_SAMPLE_WIDTH_BYTES = 2
 
 
 class AudioRecorder:
-    def __init__(self, settings: ChirpSettings, device_manager: DeviceManager):
+    def __init__(self, settings: ChirpSettings):
         self.settings = settings
-        self.device_manager = device_manager
         self._is_recording_event = threading.Event()
         self._frame_count: int = 0
         self.recording_thread: Timer | None = None

--- a/recorder/live_audio.py
+++ b/recorder/live_audio.py
@@ -10,7 +10,6 @@ import time
 import wave
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -27,12 +26,6 @@ from recorder.audio_mixer import (
 )
 from recorder.live_types import AudioFrame
 
-if TYPE_CHECKING:
-    # Imported only for type hints. `recorder.device_manager` pulls in
-    # PyAudio at import time, which would defeat this module's
-    # platform-neutral import goal on hosts where PyAudio is unavailable.
-    from recorder.device_manager import DeviceManager
-
 logger = logging.getLogger(__name__)
 
 _LIVE_SAMPLE_RATE = 16000
@@ -44,7 +37,6 @@ class LiveAudioStream:
     def __init__(
         self,
         settings: ChirpSettings,
-        device_manager: DeviceManager | None = None,
         frame_queue: queue.Queue[AudioFrame] | None = None,
         stop_event: threading.Event | None = None,
         level_queue: queue.Queue[float] | None = None,
@@ -57,6 +49,8 @@ class LiveAudioStream:
         self.stop_event = stop_event or threading.Event()
         self.level_queue: queue.Queue[float] = level_queue or queue.Queue()
         self.frame_ms = frame_ms
+        self._dropped_frames = 0
+        self._dropped_frames_lock = threading.Lock()
         # `channels` constructor arg is retained for backward compatibility;
         # AudioCapture always produces mono mixed output.
         self.channels = _LIVE_CHANNELS
@@ -85,6 +79,11 @@ class LiveAudioStream:
     @property
     def mic_device_name(self) -> str | None:
         return self._mic_device_name
+
+    @property
+    def dropped_frames(self) -> int:
+        with self._dropped_frames_lock:
+            return self._dropped_frames
 
     @property
     def sample_rate(self) -> int:
@@ -222,10 +221,14 @@ class LiveAudioStream:
         try:
             self.frame_queue.put_nowait(frame)
         except queue.Full:
-            pass
+            # The WAV is already written above; a full frame_queue only
+            # degrades the live transcript, never the saved recording.
+            with self._dropped_frames_lock:
+                self._dropped_frames += 1
         try:
             self.level_queue.put_nowait(peak)
         except queue.Full:
+            # Level meter is cosmetic; a dropped peak is not user-visible loss.
             pass
 
     def stop(self) -> None:

--- a/recorder/live_dashboard.py
+++ b/recorder/live_dashboard.py
@@ -56,6 +56,7 @@ class LiveDashboard:
         self._vad_speech_frames = 0
         self._vad_triggered = False
         self._vad_chunks_emitted = 0
+        self._dropped_chunks = 0
         self._scroll_offset = 0
         self._auto_scroll = True
         self._stdin_fd: int | None = None
@@ -212,6 +213,11 @@ class LiveDashboard:
         elif event.type == "chunk_emitted":
             with self._lock:
                 self._vad_chunks_emitted = int(event.payload.get("chunk_id", 0))
+        elif event.type == "dropped":
+            with self._lock:
+                self._dropped_chunks = int(
+                    event.payload.get("dropped_chunks", self._dropped_chunks)
+                )
 
     def _render_layout(self) -> Layout:
         layout = Layout()
@@ -286,11 +292,19 @@ class LiveDashboard:
         language = self._language or "Detecting…"
         speech_state = "Speaking" if self._vad_triggered else "Silent"
 
+        with self._lock:
+            dropped_chunks = self._dropped_chunks
+
         table.add_row("Status ", speech_state)
         table.add_row("Duration ", self._format_elapsed(elapsed))
         table.add_row("Language ", language)
         table.add_row("Words ", str(self._total_words))
         table.add_row("Audio ", level_bar)
+        if dropped_chunks > 0:
+            table.add_row(
+                "Dropped ",
+                Text(f"{dropped_chunks} (transcript only)", style="bold yellow"),
+            )
 
         return Panel(table, title="Status", border_style="magenta", box=box.ROUNDED)
 

--- a/recorder/live_session.py
+++ b/recorder/live_session.py
@@ -11,10 +11,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    # Imported only for type hints. `recorder.device_manager` pulls in
-    # PyAudio at import time, which would defeat platform-neutral imports
-    # of this module on hosts without PyAudio.
-    from recorder.device_manager import DeviceManager
     from recorder.vad_chunker import VADChunker
 
 import tomli_w
@@ -37,13 +33,14 @@ class LiveSessionResult:
     transcript_path: Path | None
     duration_seconds: float
     total_words: int
+    dropped_chunks: int = 0
+    dropped_frames: int = 0
 
 
 class LiveTranscriptionSession:
     def __init__(
         self,
         settings: ChirpSettings,
-        device_manager: DeviceManager,
         console: Console,
         title: str | None = None,
         duration_minutes: int | None = None,
@@ -51,7 +48,6 @@ class LiveTranscriptionSession:
         tags: list[str] | None = None,
     ):
         self.settings = settings
-        self.device_manager = device_manager
         self.console = console
         self.title = title
         self.duration_minutes = duration_minutes
@@ -74,16 +70,30 @@ class LiveTranscriptionSession:
         self.start_time = time.monotonic()
         self.audio_stream = LiveAudioStream(
             settings=self.settings,
-            device_manager=self.device_manager,
             frame_queue=self.frame_queue,
             stop_event=self.stop_event,
             level_queue=self.level_queue,
             debug_dir=self._debug_dir if self.debug else None,
         )
 
+        # Load/validate the Whisper model before opening capture. A download
+        # failure must surface as WhisperModelLoadError before the mic/screen
+        # helper is opened, never abort an already-capturing session.
+        self.transcriber = LiveTranscriber(
+            settings=self.settings,
+            chunk_queue=self.chunk_queue,
+            event_queue=self.event_queue,
+            stop_event=self.stop_event,
+            meeting_name=self.title,
+            sample_rate=self.audio_stream.sample_rate,
+            debug_dir=self._debug_dir if self.debug else None,
+            transcription_interval=1.0,
+        )
+
         try:
             self.audio_stream.start()
         except Exception as exc:  # pragma: no cover - hardware dependent
+            self.transcriber.close()
             raise RecordingError(str(exc)) from exc
 
         self._publish_event(
@@ -114,16 +124,6 @@ class LiveTranscriptionSession:
             )
             self.vad_chunker.start()
 
-        self.transcriber = LiveTranscriber(
-            settings=self.settings,
-            chunk_queue=self.chunk_queue,
-            event_queue=self.event_queue,
-            stop_event=self.stop_event,
-            meeting_name=self.title,
-            sample_rate=self.audio_stream.sample_rate,
-            debug_dir=self._debug_dir if self.debug else None,
-            transcription_interval=1.0,
-        )
         self.transcriber.start()
 
         self.dashboard = LiveDashboard(
@@ -160,9 +160,14 @@ class LiveTranscriptionSession:
         note_dir.mkdir(parents=True, exist_ok=True)
         audio_path = note_dir / AUDIO_FILENAME
 
+        dropped_frames = self.audio_stream.dropped_frames
+        dropped_chunks = self.vad_chunker.dropped_chunks if self.vad_chunker else 0
+
         if capture_error is not None:
             logger.error("live capture failed mid-recording", exc_info=capture_error)
             self.audio_stream.close()
+            if self.transcriber:
+                self.transcriber.close()
             shutil.rmtree(note_dir, ignore_errors=True)
             raise RecordingError("live capture failed mid-recording") from capture_error
 
@@ -178,6 +183,7 @@ class LiveTranscriptionSession:
             if self.transcriber.segments:
                 transcript_path = note_dir / "transcript.live.txt"
                 self.transcriber.export_transcript(transcript_path)
+            self.transcriber.close()
 
         duration_seconds = time.monotonic() - self.start_time
 
@@ -186,6 +192,8 @@ class LiveTranscriptionSession:
             transcript_path=transcript_path,
             duration_seconds=duration_seconds,
             total_words=total_words,
+            dropped_chunks=dropped_chunks,
+            dropped_frames=dropped_frames,
         )
 
     def _stop_pipeline(self):
@@ -195,12 +203,18 @@ class LiveTranscriptionSession:
         if self.vad_chunker:
             self.vad_chunker.join(timeout=1)
         if self.transcriber:
-            self.transcriber.join(timeout=1)
+            # Join unbounded: the worker's final _maybe_transcribe(force=True)
+            # is a full CPU-int8 Whisper pass that can run for several seconds,
+            # and the exported segments must reflect it. Bounding this join
+            # would let export read a half-written transcript.
+            self.transcriber.join()
 
     def stop(self):
         self._stop_pipeline()
         if self.audio_stream:
             self.audio_stream.close()
+        if self.transcriber:
+            self.transcriber.close()
 
     def _wait_for_completion(self):
         if self.duration_minutes is None:

--- a/recorder/live_transcriber.py
+++ b/recorder/live_transcriber.py
@@ -264,14 +264,21 @@ class LiveTranscriber(threading.Thread):
         self._debug_index += 1
 
     def export_transcript(self, output_path: Path):
-        if not self._segments:
+        segments = self.segments
+        if not segments:
             return
         output_path.parent.mkdir(parents=True, exist_ok=True)
         lines = []
-        for segment in self._segments:
+        for segment in segments:
             timestamp = self._format_timestamp(segment.start)
             lines.append(f"[{timestamp}] {segment.text}")
         output_path.write_text("\n".join(lines), encoding="utf-8")
+
+    def close(self) -> None:
+        """Release the underlying Whisper model. Idempotent."""
+        transcriber = getattr(self, "transcriber", None)
+        if transcriber is not None:
+            transcriber.close()
 
     @staticmethod
     def _format_timestamp(seconds: float) -> str:

--- a/recorder/vad_chunker.py
+++ b/recorder/vad_chunker.py
@@ -55,6 +55,13 @@ class VADChunker(threading.Thread):
         self._frame_count = 0
         self._speech_frame_count = 0
         self._chunk_count = 0
+        self._dropped_chunks = 0
+        self._dropped_chunks_lock = threading.Lock()
+
+    @property
+    def dropped_chunks(self) -> int:
+        with self._dropped_chunks_lock:
+            return self._dropped_chunks
 
     def run(self):
         while not self.stop_event.is_set():
@@ -151,7 +158,16 @@ class VADChunker(threading.Thread):
                 },
             )
         except queue.Full:
-            pass
+            # The transcriber can't keep up; this speech chunk is lost from the
+            # live transcript only. The saved WAV is written upstream and stays
+            # complete. Count and surface the loss instead of dropping silently.
+            with self._dropped_chunks_lock:
+                self._dropped_chunks += 1
+                dropped = self._dropped_chunks
+            # The dashboard event is best-effort (it can itself be queue-dropped);
+            # the authoritative total is `dropped_chunks`, read into
+            # LiveSessionResult and the final summary at end of session.
+            self._publish_event("dropped", {"dropped_chunks": dropped})
 
     def _publish_event(self, event_type: str, payload: dict):
         if self.event_queue is None:

--- a/scripts/test_live_vad.py
+++ b/scripts/test_live_vad.py
@@ -16,9 +16,9 @@ from recorder.vad_chunker import VADChunker
 
 def main():
     settings = get_settings()
-    device_manager = DeviceManager()
 
-    device_index = device_manager.get_recommended_device()
+    with DeviceManager() as device_manager:
+        device_index = device_manager.get_recommended_device()
     if device_index is None:
         print("No suitable audio input device found.")
         return 1
@@ -35,7 +35,6 @@ def main():
 
     audio_stream = LiveAudioStream(
         settings=settings,
-        device_manager=device_manager,
         frame_queue=frame_queue,
         stop_event=stop_event,
         level_queue=level_queue,

--- a/tests/test_audio_capture.py
+++ b/tests/test_audio_capture.py
@@ -558,6 +558,33 @@ def test_check_permissions_raises_on_missing_keys(tmp_path: Path) -> None:
         assert "expected screen_recording and microphone" in str(excinfo.value)
 
 
+def test_check_permissions_raises_actionable_error_on_timeout(tmp_path: Path) -> None:
+    # AC-7: a wedged helper must surface a typed, actionable error rather than
+    # letting a raw subprocess.TimeoutExpired escape to the callers.
+    from audio_capture import AudioCaptureStartTimeout, check_permissions
+
+    fake_binary = tmp_path / "capture_audio"
+    fake_binary.write_text("#!/bin/sh\nsleep 10\n")
+    fake_binary.chmod(0o755)
+
+    with (
+        mock.patch(
+            "audio_capture.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(
+                cmd=["capture_audio", "--check-permissions"], timeout=3
+            ),
+        ),
+        mock.patch(
+            "audio_capture._resolve_binary_path",
+            return_value=contextlib.nullcontext(fake_binary),
+        ),
+    ):
+        with pytest.raises(AudioCaptureStartTimeout) as excinfo:
+            check_permissions()
+
+    assert "did not respond" in str(excinfo.value)
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only wheel build")
 def test_wheel_bundles_executable_helper(tmp_path: Path) -> None:

--- a/tests/test_audio_recorder.py
+++ b/tests/test_audio_recorder.py
@@ -30,14 +30,6 @@ def _build_settings(notes_root):
     return settings
 
 
-def _build_device_manager():
-    device_manager = Mock()
-    device_manager.list_devices.return_value = [
-        {"index": 0, "name": "Built-in Microphone"}
-    ]
-    return device_manager
-
-
 def _paired_float_frames(
     pair_count: int, samples_per_frame: int = 512, frame_us: int = 32_000
 ) -> list[tuple[int, int, np.ndarray]]:
@@ -90,28 +82,20 @@ def mock_settings(tmp_path):
     return _build_settings(tmp_path)
 
 
-@pytest.fixture
-def mock_device_manager():
-    return _build_device_manager()
-
-
 class TestAudioRecorder:
-    def test_initialization(self, mock_settings, mock_device_manager):
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+    def test_initialization(self, mock_settings):
+        recorder = AudioRecorder(mock_settings)
 
         assert recorder.settings == mock_settings
-        assert recorder.device_manager == mock_device_manager
         assert recorder.is_recording is False
         assert recorder.title is None
         assert recorder.current_level == 0.0
         assert recorder.slug is None
 
-    def test_write_initial_meta_writes_toml_fields(
-        self, tmp_path, mock_settings, mock_device_manager
-    ):
+    def test_write_initial_meta_writes_toml_fields(self, tmp_path, mock_settings):
         from datetime import datetime
 
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
 
         note_dir = tmp_path / "standup-2026-04-20"
         note_dir.mkdir()
@@ -131,12 +115,10 @@ class TestAudioRecorder:
         assert meta["tags"] == ["ops"]
         assert meta["date"].startswith("2026-04-20")
 
-    def test_update_meta_duration_merges_with_existing(
-        self, tmp_path, mock_settings, mock_device_manager
-    ):
+    def test_update_meta_duration_merges_with_existing(self, tmp_path, mock_settings):
         import tomli_w
 
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
 
         note_dir = tmp_path / "standup-2026-04-20"
         note_dir.mkdir()
@@ -152,13 +134,13 @@ class TestAudioRecorder:
         assert meta["duration_s"] == pytest.approx(123.4)
 
     def test_zero_frames_clean_eof_raises_recording_error(
-        self, tmp_path, mock_settings, mock_device_manager
+        self, tmp_path, mock_settings
     ):
         # A FakeAudioCapture that yields zero frames finishes immediately
         # (clean EOF). H6: the worker treats clean EOF while still recording
         # as an unexpected end, so RecordingError is raised with the
         # "audio capture worker crashed mid-recording" message.
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
         fake_cap = FakeAudioCapture(frames=[], mic_device_name="MockMic")
 
         with patch("recorder.audio_recorder.AudioCapture", return_value=fake_cap):
@@ -170,9 +152,9 @@ class TestAudioRecorder:
         assert recorder.is_recording is False
 
     def test_start_recording_cleans_up_note_dir_when_no_audio_captured(
-        self, tmp_path, mock_settings, mock_device_manager
+        self, tmp_path, mock_settings
     ):
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
 
         fake_cap = FakeAudioCapture(frames=[], mic_device_name="MockMic")
 
@@ -197,11 +179,10 @@ class TestAudioRecorder:
         self,
         tmp_path,
         mock_settings,
-        mock_device_manager,
         mic_device_name,
         expected_meta_mic,
     ):
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
         pair_count = 5
         frames = _paired_float_frames(pair_count=pair_count)
         fake_cap = FakeAudioCapture(
@@ -235,10 +216,8 @@ class TestAudioRecorder:
             meta = tomllib.load(fh)
         assert meta["mic"] == expected_meta_mic
 
-    def test_start_recording_raises_on_non_macos(
-        self, mock_settings, mock_device_manager
-    ):
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+    def test_start_recording_raises_on_non_macos(self, mock_settings):
+        recorder = AudioRecorder(mock_settings)
         with (
             patch("sys.platform", "linux"),
             pytest.raises(
@@ -248,9 +227,9 @@ class TestAudioRecorder:
             recorder.start_recording(title="non-mac")
 
     def test_start_recording_cleans_up_when_audio_capture_fails_to_start(
-        self, tmp_path, mock_settings, mock_device_manager
+        self, tmp_path, mock_settings
     ):
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
 
         class FailingCapture:
             def __enter__(self):
@@ -271,12 +250,12 @@ class TestAudioRecorder:
         assert list(tmp_path.iterdir()) == []
 
     def test_start_recording_unblocks_when_helper_eofs_cleanly(
-        self, tmp_path, mock_settings, mock_device_manager
+        self, tmp_path, mock_settings
     ):
         # H6: clean EOF while is_recording is still set is treated as an
         # unexpected end, so RecordingError is raised. The note dir is
         # cleaned up and is_recording is False.
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
         frames = _paired_float_frames(pair_count=3)
         fake_cap = FakeAudioCapture(frames=frames, mic_device_name="MockMic")
 
@@ -290,14 +269,14 @@ class TestAudioRecorder:
         assert list(tmp_path.iterdir()) == []
 
     def test_start_recording_surfaces_worker_crash_after_partial_capture(
-        self, tmp_path, mock_settings, mock_device_manager
+        self, tmp_path, mock_settings
     ):
         # Feeds 4 paired sys+mic chunks (drives the mixer to produce
         # output frames) and *then* raises mid-iteration.
         # Without crash propagation the recorder would silently truncate
         # and return success — this test pins the new behavior of raising
         # and discarding the partial recording.
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
 
         class CrashAfterPartial:
             def __init__(self):
@@ -349,7 +328,7 @@ class TestAudioRecorder:
 class TestAudioRecorderPause:
     def test_pause_drops_frames_in_capture_worker(self, tmp_path):
         settings = _build_settings(tmp_path)
-        recorder = AudioRecorder(settings, _build_device_manager())
+        recorder = AudioRecorder(settings)
 
         pair_count = 8
         frames = _paired_float_frames(pair_count=pair_count)
@@ -389,12 +368,10 @@ class TestAudioRecorderPause:
 
 
 class TestPartialRecordingTruncationCrash:
-    def test_partial_wav_not_left_on_disk_after_crash(
-        self, tmp_path, mock_settings, mock_device_manager
-    ):
+    def test_partial_wav_not_left_on_disk_after_crash(self, tmp_path, mock_settings):
         # M19: FakeAudioCapture yields several normal frames then raises.
         # The note dir (including the partial WAV) must be deleted.
-        recorder = AudioRecorder(mock_settings, mock_device_manager)
+        recorder = AudioRecorder(mock_settings)
 
         class CrashMidStream:
             def __init__(self):

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -572,3 +572,59 @@ class TestNotesReviewPatches:
         flat = " ".join(result.stdout.split())
         assert "failed to delete" in flat
         assert "simulated permission denied" in flat
+
+
+class TestDevicesReleasesHandle:
+    """AC-1a: `chirp devices` must release the PortAudio handle deterministically."""
+
+    def test_devices_closes_pyaudio_handle(self, tmp_path, monkeypatch):
+        from unittest.mock import Mock, patch
+
+        from typer.testing import CliRunner
+
+        import chirp.cli
+
+        monkeypatch.setattr("chirp.cli.get_settings", lambda: _make_settings(tmp_path))
+        monkeypatch.setattr("chirp.cli.platform.system", lambda: "Linux")
+
+        with patch("recorder.device_manager.pyaudio.PyAudio") as mock_pyaudio:
+            mock_audio = Mock()
+            mock_audio.get_device_count.return_value = 0
+            mock_audio.get_default_input_device_info.return_value = {"index": 0}
+            mock_audio.get_default_output_device_info.return_value = {"index": 0}
+            mock_pyaudio.return_value = mock_audio
+
+            result = CliRunner().invoke(chirp.cli.app, ["devices"])
+
+        assert result.exit_code == 0
+        mock_audio.terminate.assert_called_once()
+
+
+class TestTranscribeSurfacesModelLoadError:
+    """AC-2: offline transcribe surfaces the typed Whisper load error cleanly."""
+
+    def test_transcribe_reports_model_load_error(self, tmp_path, monkeypatch):
+        from typer.testing import CliRunner
+
+        import chirp.cli
+        from chirp.exceptions import WhisperModelLoadError
+
+        TestTranscribeCli()._seed_note_with_audio(tmp_path)
+        monkeypatch.setattr("chirp.cli.get_settings", lambda: _make_settings(tmp_path))
+
+        class _BoomProcessor:
+            def __init__(self, settings, model_override=None):
+                raise WhisperModelLoadError(
+                    "Could not download or load the Whisper model 'small'. "
+                    "Check your network connection and free disk space."
+                )
+
+        monkeypatch.setattr(
+            "transcriber.batch_processor.BatchProcessor", _BoomProcessor
+        )
+
+        result = CliRunner().invoke(chirp.cli.app, ["transcribe"])
+
+        assert result.exit_code == 1
+        flat = " ".join(result.stdout.split())
+        assert "Could not download or load the Whisper model" in flat

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -281,3 +281,25 @@ class TestDeviceManager:
 
                 assert result == 3
                 mock_default.assert_called_once()
+
+    def test_context_manager_terminates_once_on_exit(self):
+        with patch("recorder.device_manager.pyaudio.PyAudio") as mock_pyaudio:
+            mock_audio = Mock()
+            mock_pyaudio.return_value = mock_audio
+
+            with DeviceManager() as device_manager:
+                assert device_manager.audio is mock_audio
+
+            mock_audio.terminate.assert_called_once()
+
+    def test_close_is_idempotent(self):
+        with patch("recorder.device_manager.pyaudio.PyAudio") as mock_pyaudio:
+            mock_audio = Mock()
+            mock_pyaudio.return_value = mock_audio
+
+            device_manager = DeviceManager()
+            device_manager.close()
+            device_manager.close()
+
+            mock_audio.terminate.assert_called_once()
+            assert device_manager.audio is None

--- a/tests/test_live_audio.py
+++ b/tests/test_live_audio.py
@@ -36,10 +36,8 @@ def _make_stream(
     stop_event = threading.Event()
     settings = mock.MagicMock()
     settings.audio.sample_rate = 16000
-    device_manager = mock.MagicMock()
     stream = LiveAudioStream(
         settings=settings,
-        device_manager=device_manager,
         frame_queue=frame_queue,
         stop_event=stop_event,
         level_queue=level_queue,
@@ -307,7 +305,6 @@ def test_frame_samples_derived_from_frame_ms() -> None:
     settings.audio.sample_rate = 16000
     stream = LiveAudioStream(
         settings=settings,
-        device_manager=mock.MagicMock(),
         frame_queue=frame_queue,
         stop_event=stop_event,
         level_queue=level_queue,
@@ -360,3 +357,30 @@ def test_audio_frame_timestamps_are_synthesized_from_frame_index() -> None:
     assert len(timestamps) >= 5
     for index, ts in enumerate(timestamps):
         assert ts == pytest.approx(index * 0.032, abs=1e-9)
+
+
+def test_full_frame_queue_increments_drop_counter() -> None:
+    # AC-4: a full frame_queue is counted, not silently dropped. The WAV write
+    # happens inside _publish_mixed_frame before the enqueue, so the saved
+    # recording is independent of these drops.
+    frame_queue: queue.Queue[AudioFrame] = queue.Queue(maxsize=1)
+    level_queue: queue.Queue[float] = queue.Queue(maxsize=1)
+    stop_event = threading.Event()
+    settings = mock.MagicMock()
+    settings.audio.sample_rate = 16000
+    stream = LiveAudioStream(
+        settings=settings,
+        frame_queue=frame_queue,
+        stop_event=stop_event,
+        level_queue=level_queue,
+    )
+
+    mixed = np.full(512, 0.1, dtype=np.float32)
+    stream._publish_mixed_frame(mixed)
+    assert stream.dropped_frames == 0
+
+    stream._publish_mixed_frame(mixed)
+    stream._publish_mixed_frame(mixed)
+
+    assert stream.dropped_frames == 2
+    assert frame_queue.qsize() == 1

--- a/tests/test_live_session.py
+++ b/tests/test_live_session.py
@@ -55,7 +55,6 @@ def test_run_raises_recording_error_when_audio_stream_capture_error_set(
     ):
         session = LiveTranscriptionSession(
             settings=settings,
-            device_manager=mock.MagicMock(),
             console=mock.MagicMock(),
             duration_minutes=None,
         )
@@ -95,7 +94,6 @@ def test_run_succeeds_when_audio_stream_capture_error_is_none(
 
         session = LiveTranscriptionSession(
             settings=settings,
-            device_manager=mock.MagicMock(),
             console=mock.MagicMock(),
             duration_minutes=None,
             title="ok",
@@ -129,7 +127,6 @@ def test_run_does_not_call_saver_or_transcriber_on_capture_error(
     ):
         session = LiveTranscriptionSession(
             settings=settings,
-            device_manager=mock.MagicMock(),
             console=mock.MagicMock(),
             duration_minutes=None,
             title="abort-test",
@@ -142,3 +139,165 @@ def test_run_does_not_call_saver_or_transcriber_on_capture_error(
     fake_stream.save_recording.assert_not_called()
     saver.assert_not_called()
     transcriber_mock.export_transcript.assert_not_called()
+
+
+def test_capture_not_started_when_model_load_fails(tmp_path: Path) -> None:
+    # AC-2 ordering: the Whisper model is loaded before capture opens, so a
+    # download/load failure surfaces WhisperModelLoadError without ever
+    # starting the mic/screen-recording helper.
+    from chirp.exceptions import WhisperModelLoadError
+
+    settings = _build_settings(tmp_path)
+    fake_stream = _make_fake_stream(capture_error=None)
+
+    with (
+        mock.patch("recorder.live_session.LiveAudioStream", return_value=fake_stream),
+        mock.patch("recorder.live_session.LiveDashboard"),
+        mock.patch(
+            "recorder.live_session.LiveTranscriber",
+            side_effect=WhisperModelLoadError("no network"),
+        ),
+        mock.patch("recorder.vad_chunker.VADChunker"),
+    ):
+        session = LiveTranscriptionSession(
+            settings=settings,
+            console=mock.MagicMock(),
+            duration_minutes=None,
+        )
+
+        with pytest.raises(WhisperModelLoadError):
+            session.run()
+
+    fake_stream.start.assert_not_called()
+
+
+def test_slow_final_pass_is_included_in_export(tmp_path: Path) -> None:
+    # AC-3: the worker's final pass can run past the old 1s join bound; the
+    # session must join unbounded so export reflects the final segments and no
+    # exception is raised.
+    #
+    # The transcriber is a *real* thread whose final _maybe_transcribe(force=True)
+    # pass sleeps PAST 1s before appending the final segment. This is a
+    # regression guard: under the old `join(timeout=1)` the session would read
+    # segments while the thread is still mid-pass (final segment missing,
+    # total_words == 0, no transcript written) — fail; under the unbounded
+    # `join()` it completes first — pass.
+    import threading
+    import time
+
+    from recorder.live_types import TranscriptSegment
+
+    settings = _build_settings(tmp_path)
+    fake_stream = _make_fake_stream(capture_error=None)
+
+    _FINAL_PASS_SECONDS = 1.5
+
+    class SlowTranscriber(threading.Thread):
+        def __init__(self, *args, **kwargs):
+            super().__init__(daemon=True)
+            self._segments: list[TranscriptSegment] = []
+            self._lock = threading.Lock()
+            self.total_words = 0
+            self.started = threading.Event()
+
+        def run(self):
+            self.started.set()
+            # Simulate a multi-second final Whisper pass on CPU int8.
+            time.sleep(_FINAL_PASS_SECONDS)
+            with self._lock:
+                self._segments.append(
+                    TranscriptSegment(text="final", start=0.0, end=1.0, words=1)
+                )
+                self.total_words = 1
+
+        @property
+        def segments(self):
+            with self._lock:
+                return list(self._segments)
+
+        def export_transcript(self, path):
+            segments = self.segments
+            path.write_text("\n".join(s.text for s in segments), encoding="utf-8")
+
+        def close(self):
+            pass
+
+    with (
+        mock.patch("recorder.live_session.LiveAudioStream", return_value=fake_stream),
+        mock.patch("recorder.live_session.LiveDashboard"),
+        mock.patch("recorder.live_session.LiveTranscriber", SlowTranscriber),
+        mock.patch("recorder.vad_chunker.VADChunker"),
+    ):
+        session = LiveTranscriptionSession(
+            settings=settings,
+            console=mock.MagicMock(),
+            duration_minutes=None,
+            title="slow",
+        )
+        session.stop_event.set()
+        result = session.run()
+
+    # Under the unbounded join, the multi-second final pass completes before
+    # segments are read: the final segment is present and the transcript is
+    # written. Under join(timeout=1) this assertion fails (segment missing).
+    assert result.total_words == 1
+    assert result.transcript_path is not None
+    assert result.transcript_path.read_text(encoding="utf-8") == "final"
+
+
+def test_drop_counters_surface_in_result(tmp_path: Path) -> None:
+    # AC-4: queue-full drops counted by the producers are reported back through
+    # the session result so the CLI can warn the user.
+    settings = _build_settings(tmp_path)
+    fake_stream = _make_fake_stream(capture_error=None)
+    fake_stream.dropped_frames = 4
+
+    fake_chunker = mock.MagicMock()
+    fake_chunker.dropped_chunks = 7
+
+    with (
+        mock.patch("recorder.live_session.LiveAudioStream", return_value=fake_stream),
+        mock.patch("recorder.live_session.LiveDashboard"),
+        mock.patch("recorder.live_session.LiveTranscriber") as transcriber_cls,
+        mock.patch("recorder.vad_chunker.VADChunker", return_value=fake_chunker),
+    ):
+        transcriber_cls.return_value.total_words = 0
+        transcriber_cls.return_value.segments = []
+
+        session = LiveTranscriptionSession(
+            settings=settings,
+            console=mock.MagicMock(),
+            duration_minutes=None,
+            title="drops",
+        )
+        session.stop_event.set()
+        result = session.run()
+
+    assert result.dropped_frames == 4
+    assert result.dropped_chunks == 7
+
+
+def test_transcriber_closed_during_cleanup(tmp_path: Path) -> None:
+    # AC-5: the live session releases the Whisper model on the clean path.
+    settings = _build_settings(tmp_path)
+    fake_stream = _make_fake_stream(capture_error=None)
+
+    with (
+        mock.patch("recorder.live_session.LiveAudioStream", return_value=fake_stream),
+        mock.patch("recorder.live_session.LiveDashboard"),
+        mock.patch("recorder.live_session.LiveTranscriber") as transcriber_cls,
+        mock.patch("recorder.vad_chunker.VADChunker"),
+    ):
+        transcriber_cls.return_value.total_words = 0
+        transcriber_cls.return_value.segments = []
+
+        session = LiveTranscriptionSession(
+            settings=settings,
+            console=mock.MagicMock(),
+            duration_minutes=None,
+            title="cleanup",
+        )
+        session.stop_event.set()
+        session.run()
+
+    transcriber_cls.return_value.close.assert_called()

--- a/tests/test_live_transcriber.py
+++ b/tests/test_live_transcriber.py
@@ -291,3 +291,80 @@ def test_force_transcription_on_stop():
         transcriber.join(timeout=2)
 
     assert any(s.text == "forced" for s in transcriber.segments)
+
+
+def test_export_transcript_is_race_free_under_concurrent_mutation(tmp_path: Path):
+    # AC-3: export_transcript reads through the lock-guarded `segments`
+    # property, so a worker mutating _segments concurrently can never trigger
+    # "RuntimeError: list changed size during iteration" or a torn write.
+    settings = Mock()
+    chunk_queue: queue.Queue[SpeechChunk] = queue.Queue()
+    event_queue: queue.Queue[DashboardEvent] = queue.Queue()
+    stop_event = threading.Event()
+
+    with patch("recorder.live_transcriber.WhisperTranscriber") as mock_cls:
+        mock_cls.return_value.transcribe_file.return_value = {
+            "segments": [],
+            "metadata": {},
+        }
+        transcriber = LiveTranscriber(
+            settings=settings,
+            chunk_queue=chunk_queue,
+            event_queue=event_queue,
+            stop_event=stop_event,
+            sample_rate=16000,
+        )
+
+    errors: list[BaseException] = []
+    mutate_stop = threading.Event()
+
+    def mutate() -> None:
+        index = 0
+        while not mutate_stop.is_set():
+            with transcriber._lock:  # type: ignore[attr-defined]
+                transcriber._segments.append(  # type: ignore[attr-defined]
+                    TranscriptSegment(
+                        text=f"seg-{index}", start=index, end=index + 1, words=1
+                    )
+                )
+            index += 1
+
+    def export() -> None:
+        try:
+            for _ in range(200):
+                transcriber.export_transcript(tmp_path / "transcript.txt")
+        except BaseException as exc:  # noqa: BLE001 - capturing any race failure
+            errors.append(exc)
+
+    mutator = threading.Thread(target=mutate, daemon=True)
+    exporter = threading.Thread(target=export, daemon=True)
+    mutator.start()
+    exporter.start()
+    exporter.join(timeout=5)
+    mutate_stop.set()
+    mutator.join(timeout=5)
+
+    assert not errors, f"export raced with mutation: {errors!r}"
+
+
+def test_close_tears_down_underlying_whisper_transcriber():
+    # AC-5: LiveTranscriber.close() releases the wrapped WhisperTranscriber.
+    settings = Mock()
+    chunk_queue: queue.Queue[SpeechChunk] = queue.Queue()
+    event_queue: queue.Queue[DashboardEvent] = queue.Queue()
+    stop_event = threading.Event()
+
+    with patch("recorder.live_transcriber.WhisperTranscriber") as mock_cls:
+        mock_instance = mock_cls.return_value
+        transcriber = LiveTranscriber(
+            settings=settings,
+            chunk_queue=chunk_queue,
+            event_queue=event_queue,
+            stop_event=stop_event,
+            sample_rate=16000,
+        )
+
+        transcriber.close()
+        transcriber.close()
+
+    assert mock_instance.close.call_count == 2

--- a/tests/test_record_view.py
+++ b/tests/test_record_view.py
@@ -121,7 +121,7 @@ class TestRecordTagFlag:
         captured: dict = {}
 
         class FakeRecorder:
-            def __init__(self, settings, device_manager):
+            def __init__(self, settings):
                 self.note_dir = tmp_path / "fake-2026-04-27"
                 self.note_dir.mkdir()
                 self.start_time = None
@@ -153,6 +153,12 @@ class TestRecordTagFlag:
                 return str(self.note_dir / "audio.wav")
 
         class FakeDeviceManager:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
             def get_default_input_device(self):
                 return 0
 

--- a/tests/test_vad_chunker.py
+++ b/tests/test_vad_chunker.py
@@ -209,3 +209,37 @@ def test_stop_event_flushes_active_speech():
     assert not chunk_queue.empty()
     chunk = chunk_queue.get()
     assert len(chunk.data) > 0
+
+
+def test_full_chunk_queue_increments_drop_counter_and_emits_event():
+    # AC-4: a full chunk_queue must count the dropped speech chunk and surface
+    # a `dropped` dashboard event rather than discarding it silently.
+    frame_queue: queue.Queue[AudioFrame] = queue.Queue()
+    chunk_queue: queue.Queue = queue.Queue(maxsize=1)
+    event_queue: queue.Queue = queue.Queue()
+    stop_event = threading.Event()
+
+    chunker = VADChunker(
+        frame_queue=frame_queue,
+        chunk_queue=chunk_queue,
+        stop_event=stop_event,
+        sample_rate=SAMPLE_RATE,
+        frame_ms=FRAME_MS,
+        vad_factory=lambda: DummyVAD([True]),
+        event_queue=event_queue,
+        poll_timeout=0.02,
+    )
+
+    chunker._voiced_frames = [_make_frame(0.0), _make_frame(0.01)]
+    chunker._emit_chunk()
+    assert chunker.dropped_chunks == 0
+
+    chunker._voiced_frames = [_make_frame(0.02), _make_frame(0.03)]
+    chunker._emit_chunk()
+
+    assert chunker.dropped_chunks == 1
+    dropped_events = [
+        event for event in list(event_queue.queue) if event.type == "dropped"
+    ]
+    assert dropped_events
+    assert dropped_events[-1].payload["dropped_chunks"] == 1

--- a/tests/test_whisper_transcriber.py
+++ b/tests/test_whisper_transcriber.py
@@ -457,3 +457,57 @@ class TestWhisperTranscriber:
             "max_speech_duration_s": 30,
             "speech_pad_ms": 300,
         }
+
+    def test_model_load_failure_raises_typed_actionable_error(self, mock_settings):
+        from chirp.exceptions import WhisperModelLoadError
+
+        with (
+            patch(
+                "transcriber.whisper_transcriber.WhisperModel",
+                side_effect=OSError("connection reset"),
+            ),
+            patch.object(WhisperTranscriber, "_get_optimal_device", return_value="cpu"),
+            patch.object(WhisperTranscriber, "_get_compute_type", return_value="int8"),
+            patch.object(WhisperTranscriber, "_get_cpu_threads", return_value=4),
+        ):
+            with pytest.raises(WhisperModelLoadError) as excinfo:
+                WhisperTranscriber(mock_settings)
+
+        message = str(excinfo.value)
+        assert "Whisper model" in message
+        assert "small" in message
+        assert isinstance(excinfo.value.__cause__, OSError)
+
+    def test_close_is_idempotent_and_nulls_model(self, mock_settings):
+        with (
+            patch(
+                "transcriber.whisper_transcriber.WhisperModel",
+                return_value=Mock(),
+            ),
+            patch.object(WhisperTranscriber, "_get_optimal_device", return_value="cpu"),
+            patch.object(WhisperTranscriber, "_get_compute_type", return_value="int8"),
+            patch.object(WhisperTranscriber, "_get_cpu_threads", return_value=4),
+        ):
+            transcriber = WhisperTranscriber(mock_settings)
+
+        assert transcriber.model is not None
+        transcriber.close()
+        transcriber.close()
+        assert transcriber.model is None
+
+    def test_get_model_info_reports_cpu_int8_on_darwin(self, mock_settings):
+        with (
+            patch(
+                "transcriber.whisper_transcriber.WhisperModel",
+                return_value=Mock(),
+            ),
+            patch(
+                "transcriber.whisper_transcriber.platform.system", return_value="Darwin"
+            ),
+            patch.object(WhisperTranscriber, "_get_cpu_threads", return_value=4),
+        ):
+            transcriber = WhisperTranscriber(mock_settings)
+            info = transcriber.get_model_info()
+
+        assert info["device"] == "cpu"
+        assert info["compute_type"] == "int8"

--- a/transcriber/batch_processor.py
+++ b/transcriber/batch_processor.py
@@ -188,7 +188,8 @@ class BatchProcessor:
     ) -> dict[str, int]:
         # TODO: pipeline across notes if profiling justifies it (note B in
         #       Whisper while note A is in note generation). Strict-sequential
-        #       for now — both Whisper and chirpd target Metal, so concurrency
+        #       for now — Whisper runs CPU int8 here while chirpd/MLX targets
+        #       Metal, so they contend for different resources; concurrency
         #       buys little and complicates UI + failure recovery.
         console = console or Console()
         records = self._select_queue(n=n, force=force)

--- a/transcriber/whisper_transcriber.py
+++ b/transcriber/whisper_transcriber.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from faster_whisper import WhisperModel
 
+from chirp.exceptions import WhisperModelLoadError
 from config.settings import ChirpSettings
 from notes.constants import DEFAULT_MEETING_NAME
 from utils.file_utils import META_FILENAME, get_file_size_mb
@@ -23,18 +24,29 @@ class WhisperTranscriber:
     def _load_model(self):
         device = self._get_optimal_device()
         compute_type = self._get_compute_type()
+        model_name = self.settings.models.whisper
 
-        self.model = WhisperModel(
-            self.settings.models.whisper,
-            device=device,
-            compute_type=compute_type,
-            cpu_threads=self._get_cpu_threads(),
-        )
+        try:
+            self.model = WhisperModel(
+                model_name,
+                device=device,
+                compute_type=compute_type,
+                cpu_threads=self._get_cpu_threads(),
+            )
+        except Exception as exc:
+            raise WhisperModelLoadError(
+                f"Could not download or load the Whisper model {model_name!r}. "
+                "Check your network connection and free disk space, then retry. "
+                "If the problem persists, set a valid model name in your config "
+                f"(models.whisper). Underlying error: {exc}"
+            ) from exc
 
     def _get_optimal_device(self) -> str:
-        system = platform.system()
-
-        if system == "Darwin":
+        # chirp targets macOS only (see epic-audio-capture decision 1), where
+        # faster-whisper runs on CPU. The non-Darwin branch is not exercised on
+        # the supported platform and exists only as a portability hint; it does
+        # not promise GPU acceleration.
+        if platform.system() == "Darwin":
             return "cpu"
         try:
             import torch
@@ -44,11 +56,9 @@ class WhisperTranscriber:
             return "cpu"
 
     def _get_compute_type(self) -> str:
-        device = self._get_optimal_device()
-
-        if device == "cpu":
-            return "int8"
-        return "float16"
+        # int8 on CPU (the macOS path); float16 only on the unexercised
+        # non-Darwin CUDA branch above.
+        return "int8" if self._get_optimal_device() == "cpu" else "float16"
 
     def _get_cpu_threads(self) -> int:
         import os
@@ -325,6 +335,10 @@ class WhisperTranscriber:
                 return title.strip()
         return DEFAULT_MEETING_NAME
 
+    def close(self) -> None:
+        """Release the loaded CTranslate2 model. Idempotent."""
+        if getattr(self, "model", None) is not None:
+            self.model = None
+
     def __del__(self):
-        if hasattr(self, "model") and self.model:
-            del self.model
+        self.close()


### PR DESCRIPTION
Part of **EPIC-PRODUCTION-HARDENING** (epic 8). Merges into `epic/8-production-hardening`.

### Changes
- **PyAudio leak fixed (the permission-prompt regression risk):** `DeviceManager` is removed from the three capture constructors (verified dead code there — capture is 100% via the Swift helper), and the surviving cosmetic `devices`/mic-name uses are `with`-scoped so PortAudio is released deterministically instead of via `__del__`.
- **Whisper load failure is actionable, not a mid-session crash:** typed `WhisperModelLoadError`; in the live path the model is loaded/validated **before** capture starts, so a first-run download failure can't abort an already-recording session.
- **Live-transcript finalize race fixed:** the transcriber is joined unbounded (final Whisper pass completes) and `_segments` is read under the lock — no `RuntimeError`/torn transcript.
- **Dropped audio is surfaced:** queue-full drops are counted and reported (dashboard + final summary), with an explicit note that `audio.wav` is complete (it's written before the queue).
- Explicit Whisper teardown on every exit path; dead-CUDA/Metal comment fixes; `TimeoutExpired` caught in `check_permissions`; fixed a broken `scripts/test_live_vad.py` call site.

### Verification
- `make check` clean; `make test` **1518 passed**. All audio tests are mocked (PyAudio patched, Whisper mocked, fake helper); no real device/Swift/model access.
- Subagent review: APPROVE-WITH-NITS → addressed. Caught a missed broken call site (`scripts/test_live_vad.py`) and a tautological AC-3 test (its mock `join` ignored the timeout) — rewritten with a real thread that outlives the timeout (fail-before/pass-after verified).

Story spec + Dev Agent Record: `_bmad-output/planning-artifacts/epic-production-hardening/stories/8.4-audio-capture-and-transcription-reliability.md`