### PR TITLE
Story 8.5 — CLI/TUI best-practices conformance

### DIFF
--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.5-cli-tui-best-practices-conformance.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.5-cli-tui-best-practices-conformance.md
@@ -187,15 +187,58 @@ Existing suites to extend (verified to exist): `tests/test_cli_commands.py`, `te
 
 ### Agent Model Used
 
-_TBD_
+Opus 4.8 (1M context) — claude-opus-4-8[1m]
 
 ### Debug Log References
 
+- `uv run chirp --version` / `-V` → `chirp 0.0.1a0`, exit 0.
+- `uv run chirp --help` lists `--version`/`-V` and `--no-color`/`--plain`; still exactly 7 visible commands; `--install-completion`/`--show-completion`/`daemon`/`config`/`devices`/`index` all hidden.
+- `chirp notes --json | jq` → parseable JSON array (`id`/`slug`/`title`/`date`/`tags`/`notes_path`), no Rich box chars, nothing on stderr.
+- `chirp ask --json "q"` → `{question, answer, sources}`; `Markdown` never instantiated under `--json` (asserted).
+- `chirp search --json` → raw JSON via `sys.stdout.write`, nothing on stderr.
+- `chirp notes` (human): table on stdout; "Your notes" preamble + 4 `›` hints + empty-state on stderr.
+- `chirp search "pricing"`: excerpts/table on stdout; preamble/scope/summary/footer hints on stderr.
+- `NO_COLOR=1 chirp notes` and `chirp --no-color notes`: no `\x1b[` escapes on either stream.
+- `chirp about --plain`: static info panel, no spinner frames.
+
 ### Completion Notes List
 
+- **AC-1 (stdout/stderr split): DONE.** Added `chirp/_console.py` re-exporting `llm/cli/_console.py`'s `console` (stderr) as `stderr_console` and `stdout_console` — single shared instances, not duplicated. `chirp/cli.py`, `notes_chat/cli.py`, `notes_chat/interactive.py` now alias `console = stderr_console`; data (notes table, devices tables, config panel, search excerpts, ask/interactive answer body) routes to `stdout_console`; diagnostics/hints/errors/prompts to stderr. `search_keyword.render_results` was split to take both consoles. Existing `tests/test_cli_commands.py` and `tests/test_ask_sources.py` stdout assertions moved to `result.stderr` (not weakened).
+- **AC-2 (`--json` for notes + ask; raw + fixed search): DONE.** `chirp notes --json` emits a raw JSON array; `chirp ask --json` emits a raw `{question, answer, sources}` object (one-shot only; markdown/streaming suppressed; no `Markdown` instantiated). `chirp search`'s JSON now goes through new `search_keyword.write_json` (raw `sys.stdout.write`) instead of `console.print(emit_json(...))`. **Decision (documented):** `--json` is strictly opt-in via the flag for these three commands; auto-on-pipe was NOT adopted (it would have turned the `CliRunner`-driven human-render tests into JSON). `daemon`/`models` keep their existing auto-on-pipe behavior (out of scope).
+- **AC-3 (`--version`/`-V` + `about --plain`): DONE.** Added top-level `@app.callback` with an eager `--version`/`-V` printing `chirp <version>` to stdout via `print()` and exiting 0. Lifted `about._installed_version()` into a public `about.installed_version()` shared by the callback. Added `chirp about --plain`/`--no-animate` → new `about.render_about_plain()` prints the same final info panel with no Live/spinner loop.
+- **AC-4 (uniform prompt escape): DONE.** `_prompt_timeframe`/`_prompt_tags` now re-raise `typer.Exit(RUNTIME_ERROR)` on Ctrl-C/EOF (matching `_prompt_title`); empty-Enter still returns `None`/`[]`. Unit-tested both ways.
+- **AC-5 (NO_COLOR + `--no-color`/`--plain`; editor force_terminal): DONE.** `--no-color`/`--plain` global option on the callback calls `apply_color_mode()` which sets `no_color=True` on both shared consoles. Rich's built-in `NO_COLOR`/`FORCE_COLOR`/non-TTY handling is now respected (no overriding `force_terminal`/`no_color` in the first-party consoles). `note_editor._ensure_view_cache` keeps `force_terminal=True` (load-bearing for offscreen width measurement) but drops `color_system` to `None` when `NO_COLOR`/`--no-color` is active (new `_no_color_active()` helper) — width measurement preserved, color suppressed.
+- **AC-6 (centralized exit-code table): DONE.** Added `chirp/exit_codes.py` with `SUCCESS/RUNTIME_ERROR/USAGE_ERROR/DAEMON_UNREACHABLE/MODEL_LOAD_FAILED/MODEL_NOT_FOUND/NOT_APPLE_SILICON` (0/1/2/3/4/5/7) and a documented table in the module docstring. Applied at every `typer.Exit(...)` site in `chirp/cli.py`, `notes_chat/cli.py`, and `chirp/init_flow.py` (`EXIT_NOT_APPLE_SILICON` now aliases `exit_codes.NOT_APPLE_SILICON`). Observable codes 3/4/5/7 unchanged. `record`'s runtime errors stay 1 (its model-load is Whisper, distinct from the LLM `MODEL_LOAD_FAILED=4` path); bad `--timeframe` and other usage errors are 2. `transcribe`'s Whisper-load error kept at 1 (its existing observable contract — encoded by `test_transcribe_reports_model_load_error`).
+- **AC-7 (SIGTERM/SIGWINCH + terminal restore): DONE.** Extracted `_restore_terminal(fd, old_settings)` (tcsetattr + `console.show_cursor(True)`, idempotent, exception-safe), called from the `record` `finally` and a new SIGTERM handler installed/restored around the cbreak+Live block. A SIGWINCH handler sets a resize flag that the per-tick render consumes (busts cached width + `live.update(refresh=True)`), so a mid-record resize reflows. Signals are restored in a `finally`. `recorder/live_dashboard._raw_mode` already restores termios in its own `finally`. Signal/resize paths verified by the extractable `_restore_terminal` unit test; the live TTY behavior is manual-only (repo memory: no unit tests for termios paths).
+- **AC-8 (editor help + `$EDITOR`/`$VISUAL`): DONE.** Added a persistent `KEYBINDING_HINT` row above the status line, a `:help` command and `?` key (normal/view mode) showing a modal `HELP_LINES` overlay (any key dismisses), and the unknown-command message now appends "— type :help". The built-in editor stays the default (locked decision). Shipped the opt-in `chirp notes edit N --editor` escape hatch honoring `$VISUAL`/`$EDITOR` (re-reads `notes.md` on exit, re-indexes; errors actionably if neither var is set).
+- **AC-9 (glyphs/voice + completion): DONE.** Added `chirp/glyphs.py` (SUCCESS `✓` / FAILURE `✗` / PENDING `—` / DEFAULT_MARKER `★` / ACTIVE_MARKER `●` / INPUT_ARROW `›`). `devices` emoji `✅`/`❌` replaced with `✓`/`✗`; `models.list` `★`/`●`/`—` and `init_flow._print_status` `✓`/`✗`/`—` now use the constants. User-facing messages normalized toward the lowercase house voice (record/notes/config/etc.). Completion: `add_completion=True`; `OrderedCommandsGroup.get_params` hides the two generated `--install-completion`/`--show-completion` meta-options so the surface stays 7 commands while the `chirp models` `_complete_alias` completer is now reachable.
+- **AC-10 (AppleScript escaping): DONE.** Added `utils/popup_manager._escape_applescript` (escapes `\` then `"`); both `_show_macos_notification` and `ask_yes_no` escape title + body before interpolation. Unit-tested with `"` and `\` in args.
+- **AC-11 (ask dual-input warning): DONE.** `chirp ask` warns to stderr ("both a positional question and --question given; using the positional.") when both are passed, then uses the positional. `--question`/`-q` retained (locked decision). Unit-tested both the conflict and option-alone paths.
+- **AC-12 (live help validation): DONE.** Ran the full AC-12 command list (see Debug Log); 7 visible commands unchanged, hidden commands stay hidden, all new flags present.
+- **AC-13 (quality gates): DONE.** `make check` passes (validate + ruff lint + ruff format-check + codespell + mypy). Full `uv run pytest` = 1555 passed, 0 failed.
+
+**Pre-existing issue noted (not introduced, out of scope):** running `tests/test_cli_startup.py` (which `patch.dict(sys.modules, ..., clear=True)`) immediately before `tests/notes_chat/test_search_keyword.py` (which `importlib.reload(chirp.cli)`) in the same session yields 7 `ImportError: module chirp.cli not in sys.modules` failures. Confirmed identical on the base branch with story 8.5 changes stashed. It does NOT occur in the default `uv run pytest` (full-suite) run order, so `make test` is green; flagged for a follow-up test-isolation fix.
+
 ### File List
+
+- `chirp/_console.py` (new) — shared stdout/stderr consoles + `apply_color_mode`/`no_color_active`.
+- `chirp/exit_codes.py` (new) — centralized exit-code constants + documented table.
+- `chirp/glyphs.py` (new) — shared status glyph constants.
+- `chirp/cli.py` — top-level callback (`--version`/`-V`, `--no-color`/`--plain`), completion enabled + meta-commands hidden, stdout/stderr split, `notes --json`, `ask --json`+conflict warning, `search` raw JSON + split renderer call, prompt-escape, SIGTERM/SIGWINCH + `_restore_terminal`, `about --plain`, `notes edit --editor`, glyphs/voice, centralized exit codes.
+- `chirp/about.py` — public `installed_version()`; `render_about_plain()`.
+- `chirp/init_flow.py` — `EXIT_NOT_APPLE_SILICON` aliases `exit_codes.NOT_APPLE_SILICON`; `_print_status` uses glyph constants.
+- `notes_chat/cli.py` — console split, `ask --json` (raw, markdown suppressed), centralized exit codes.
+- `notes_chat/interactive.py` — console split (answer body → stdout, diagnostics → stderr); REPL interrupt semantics untouched.
+- `notes_chat/search_keyword.py` — `render_results` split across stdout/stderr consoles; new `write_json` raw emitter.
+- `notes/note_editor.py` — keybinding hint row, `:help`/`?` overlay, unknown-command points at `:help`, NO_COLOR-aware render cache.
+- `utils/popup_manager.py` — `_escape_applescript` applied to notification + dialog scripts.
+- `llm/cli/models.py` — `list` table uses shared glyph constants.
+- `tests/test_cli_conformance.py` (new) — AC-1/2/3/4/5/6/7/8/9/10/11 coverage.
+- `tests/test_cli_commands.py` — moved hint/error assertions to `result.stderr`; lowercase voice.
+- `tests/test_ask_sources.py` — sources-footer assertion moved to `result.stderr`.
 
 ## Change Log
 
 - 2026-06-14: Story 8.5 drafted from the 2026-06-14 production-readiness audit. Eleven CLI/TUI conformance findings (4 HIGH, 5 MED, 2 LOW) mapped to AC-1…AC-13. Theme: back-port the `llm/cli` console/`--json`/`--version` patterns to the older first-party commands. All cited line numbers verified against source; three finding inaccuracies corrected in Dev notes (`init` glyphs, usage-vs-runtime partial separation, `search_keyword` console origin). Status → ready-for-dev.
 - 2026-06-15: Maintainer resolved OQs — enable shell completion + hide the two completion meta-commands (AC-9); keep the built-in editor as default with `$EDITOR`/`$VISUAL` as an opt-in follow-on (AC-8); `ask` keeps `--question/-q` but warns when both it and the positional are passed (AC-11).
+- 2026-06-16: Implemented all 13 ACs (Dev Agent Record above). New `chirp/_console.py`, `chirp/exit_codes.py`, `chirp/glyphs.py`; stdout/stderr split + `--json` (notes/ask/search-raw) + `--version`/`-V` + `--no-color`/`--plain` + uniform prompt-escape + centralized exit codes + SIGTERM/SIGWINCH terminal restore + editor `:help`/`?`/hint + opt-in `--editor` handoff + glyph/voice normalization + completion-enabled-with-hidden-meta + AppleScript escaping + ask dual-input warning. `--json` chosen strictly opt-in (documented). `make check` green; `uv run pytest` 1555 passed. Flagged a pre-existing (base-branch) test-isolation failure between `test_cli_startup` and `test_search_keyword`'s `importlib.reload` that does not occur in the default run order. Status → ready-for-review.

--- a/chirp/_console.py
+++ b/chirp/_console.py
@@ -1,0 +1,45 @@
+"""Shared stdout/stderr Rich consoles for the first-party ``chirp`` commands.
+
+The newer ``llm/cli`` subsystem already splits its output the clig.dev way —
+data on stdout, diagnostics on stderr — via :mod:`llm.cli._console`. Rather than
+re-create that pattern, the older commands (``record``, ``transcribe``,
+``notes``, ``ask``, ``search``, the note editor) re-export the *same* instances
+here so width, theme, and terminal detection stay consistent across every chirp
+surface.
+
+- ``stderr_console`` — progress, status, hints, prompts, and errors.
+- ``stdout_console`` — data and rendered artifacts (tables, note bodies).
+
+``--no-color`` / ``--plain`` and ``NO_COLOR`` flow through :func:`apply_color_mode`,
+which rebuilds both consoles with color forced off. Rich already honors
+``NO_COLOR`` / ``FORCE_COLOR`` and non-TTY detection on construction, so the only
+job here is to stop overriding that and to expose a single switch for the flag.
+"""
+
+from __future__ import annotations
+
+import os
+
+from llm.cli._console import console as stderr_console
+from llm.cli._console import stdout_console
+
+__all__ = ["apply_color_mode", "no_color_active", "stderr_console", "stdout_console"]
+
+
+def no_color_active() -> bool:
+    """True when ``NO_COLOR`` is set to any non-empty value (de-facto contract)."""
+    return bool(os.environ.get("NO_COLOR"))
+
+
+def apply_color_mode(no_color: bool) -> None:
+    """Force color off on both shared consoles for the rest of the run.
+
+    Called from the top-level callback when ``--no-color`` / ``--plain`` is
+    passed. ``NO_COLOR`` in the environment is honored by Rich automatically, so
+    this only handles the explicit flag; passing ``no_color=False`` is a no-op so
+    a normal run keeps Rich's auto-detection intact.
+    """
+    if not no_color:
+        return
+    stderr_console.no_color = True
+    stdout_console.no_color = True

--- a/chirp/about.py
+++ b/chirp/about.py
@@ -61,6 +61,11 @@ def _installed_version() -> str:
         return "dev"
 
 
+def installed_version() -> str:
+    """Public alias for the installed version, shared with ``chirp --version``."""
+    return _installed_version()
+
+
 def _prompt_line() -> Text:
     line = Text()
     line.append("$", style="cyan bold")
@@ -212,3 +217,20 @@ def run_about(
             lines[beak_idx] = _logo_line(beak_row, beak_open=open_state)
             live.update(Group(*lines))
             sleep(CHIRP_INTERVAL * scale)
+
+
+def render_about_plain(console: Console, settings) -> None:
+    """Print the static info panel (version, notes, models, root) without animation.
+
+    Same content as the final frame of :func:`run_about` (the ``_info_lines``
+    block) but with no spinner / Live loop, so ``chirp about --plain`` is safe to
+    pipe and scrape on a non-TTY.
+    """
+    notes_root = settings.directories.notes_root
+    notes_count = _count_notes(notes_root)
+    chat_model = settings.models.llm
+    embed_model = settings.notes_chat.emb_model
+    version = _installed_version()
+
+    for line in _info_lines(version, notes_count, chat_model, embed_model, notes_root):
+        console.print(line)

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import math
 import platform
@@ -7,7 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import typer
-from rich.console import Console, Group, RenderableType
+from rich.console import Group, RenderableType
 from rich.live import Live
 from rich.panel import Panel
 from rich.spinner import Spinner
@@ -16,6 +17,8 @@ from rich.text import Text
 from typer.core import TyperGroup
 
 import audio_capture
+from chirp import exit_codes, glyphs
+from chirp._console import apply_color_mode, stderr_console, stdout_console
 from chirp.exceptions import AudioDeviceError, ConfigurationError, RecordingError
 from config.settings import ChirpSettings, get_settings
 from llm.cli.daemon import daemon_app
@@ -43,23 +46,84 @@ class OrderedCommandsGroup(TyperGroup):
                 ordered.append(name)
         return ordered
 
+    def get_params(self, ctx):
+        # Completion is enabled so the `chirp models` alias completers work, but
+        # the generated --install-completion / --show-completion meta-options are
+        # hidden to keep the top-level surface to the documented 7 commands.
+        params = super().get_params(ctx)
+        for param in params:
+            opts = set(getattr(param, "opts", [])) | set(
+                getattr(param, "secondary_opts", [])
+            )
+            if opts & _COMPLETION_META_COMMANDS:
+                param.hidden = True
+        return params
+
 
 app = typer.Typer(
     name="chirp",
     help="Chirp · AI notes for your terminal.",
     epilog="run `chirp COMMAND --help` for details",
     rich_markup_mode="rich",
-    add_completion=False,
+    add_completion=True,
     context_settings={
         "help_option_names": ["-h", "--help"],
         "max_content_width": 120,
     },
     cls=OrderedCommandsGroup,
 )
-console = Console()
+
+# Diagnostics/prompts/errors go to stderr; data and rendered artifacts go to
+# stdout. ``console`` aliases the stderr console because the overwhelming
+# majority of legacy ``console.print`` sites are diagnostics; the handful of
+# data outputs (note tables, search results) print to ``stdout_console``
+# explicitly.
+console = stderr_console
+
+# Shell completion is enabled (so the registered ``chirp models`` alias
+# completers are reachable), but the two generated meta-commands are hidden so
+# they don't bloat the documented 7-command surface.
+_COMPLETION_META_COMMANDS = frozenset(
+    {
+        "--install-completion",
+        "--show-completion",
+        "install-completion",
+        "show-completion",
+    }
+)
 
 MAIN_PANEL = "Commands"
 MODELS_PANEL = "Models"
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        from chirp.about import installed_version
+
+        # Plain single line on stdout so `chirp --version` pipes cleanly.
+        print(f"chirp {installed_version()}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        None,
+        "--version",
+        "-V",
+        is_eager=True,
+        callback=_version_callback,
+        help="Show the chirp version and exit.",
+    ),
+    no_color: bool = typer.Option(
+        False,
+        "--no-color",
+        "--plain",
+        help="Disable colored output (also honors the NO_COLOR env var).",
+    ),
+) -> None:
+    """Chirp · AI notes for your terminal."""
+    apply_color_mode(no_color)
 
 
 def _prompt_title() -> str:
@@ -70,7 +134,7 @@ def _prompt_title() -> str:
             value: str = console.input(" [green]›[/green] ").strip()
         except (EOFError, KeyboardInterrupt):
             console.print()
-            raise typer.Exit(1)
+            raise typer.Exit(exit_codes.RUNTIME_ERROR)
         if value:
             return value
         console.print(" [dim]title can't be empty[/dim]")
@@ -88,7 +152,7 @@ def _prompt_timeframe() -> int | None:
         value = console.input(" [green]›[/green] ").strip()
     except (EOFError, KeyboardInterrupt):
         console.print()
-        return None
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     if not value:
         return None
     return parse_timeframe(value)
@@ -104,7 +168,7 @@ def _prompt_tags() -> list[str]:
         value = console.input(" [green]›[/green] ").strip()
     except (EOFError, KeyboardInterrupt):
         console.print()
-        return []
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     return _parse_tag_input(value)
 
 
@@ -112,6 +176,26 @@ def _parse_tag_input(value: str) -> list[str]:
     if not value:
         return []
     return [piece.strip() for piece in value.split(",") if piece.strip()]
+
+
+def _restore_terminal(fd: int | None, old_settings) -> None:
+    """Restore cooked mode and show the cursor — safe to call more than once.
+
+    Shared by the ``record`` ``finally`` block and its SIGTERM handler so a
+    ``kill <pid>`` mid-recording leaves the TTY usable instead of stuck in
+    cbreak with a hidden cursor.
+    """
+    if old_settings is not None and fd is not None:
+        import termios
+
+        try:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        except (termios.error, OSError):
+            pass
+    try:
+        console.show_cursor(True)
+    except Exception:  # noqa: BLE001 - cursor restore is best-effort on teardown
+        pass
 
 
 def _resolve_mic_name(device_manager) -> str:
@@ -273,13 +357,13 @@ def record(
             duration = _prompt_timeframe()
         except ValueError as exc:
             console.print(f"[red]{exc}[/red]")
-            raise typer.Exit(1)
+            raise typer.Exit(exit_codes.USAGE_ERROR)
     elif timeframe is not None and duration is None:
         try:
             duration = parse_timeframe(timeframe)
         except ValueError as exc:
             console.print(f"[red]{exc}[/red]")
-            raise typer.Exit(1)
+            raise typer.Exit(exit_codes.USAGE_ERROR)
 
     resolved_tags: list[str] = list(tags) if tags else []
     if not resolved_tags and is_tty:
@@ -305,10 +389,17 @@ def record(
     )
     control = {"discard": False}
 
+    import signal
+
+    fd: int | None = None
+    old_settings = None
+    previous_sigterm = None
+    previous_sigwinch = None
+    resize_pending = {"flag": False}
+
     try:
         use_cbreak = sys.stdin.isatty() and hasattr(sys.stdin, "fileno")
 
-        old_settings = None
         if use_cbreak:
             import select
             import termios
@@ -317,6 +408,17 @@ def record(
             fd = sys.stdin.fileno()
             old_settings = termios.tcgetattr(fd)
             tty.setcbreak(fd)
+
+        def _on_sigterm(_signum, _frame):
+            _restore_terminal(fd, old_settings)
+            recorder.stop_recording()
+
+        def _on_sigwinch(_signum, _frame):
+            resize_pending["flag"] = True
+
+        previous_sigterm = signal.signal(signal.SIGTERM, _on_sigterm)
+        if hasattr(signal, "SIGWINCH"):
+            previous_sigwinch = signal.signal(signal.SIGWINCH, _on_sigwinch)
 
         def _on_tick(level: float):
             if use_cbreak and select.select([sys.stdin], [], [], 0)[0]:
@@ -338,7 +440,14 @@ def record(
                 state.elapsed_seconds = (
                     datetime.now() - recorder.start_time
                 ).total_seconds()
-            live.update(_render_record_view(state))
+            if resize_pending["flag"]:
+                # A resize happened mid-record: drop any cached width so Rich
+                # remeasures the terminal and the waveform reflows cleanly, then
+                # force a refresh against the new size.
+                resize_pending["flag"] = False
+                if hasattr(console, "_width"):
+                    console._width = None
+            live.update(_render_record_view(state), refresh=True)
 
         try:
             with Live(
@@ -353,10 +462,7 @@ def record(
                     tags=resolved_tags,
                 )
         finally:
-            if old_settings is not None:
-                import termios
-
-                termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+            _restore_terminal(fd, old_settings)
 
         note_dir = recorder.note_dir
         if control["discard"]:
@@ -370,23 +476,31 @@ def record(
             return
 
         console.print(f"[green]saved to {note_dir}[/green]")
-        console.print(" [dim]› chirp transcribe    · turn this into notes[/dim]")
+        console.print(
+            f" [dim]{glyphs.INPUT_ARROW} chirp transcribe    "
+            "· turn this into notes[/dim]"
+        )
 
     except KeyboardInterrupt:
-        console.print("[yellow]Recording stopped by user[/yellow]")
+        console.print("[yellow]recording stopped by user[/yellow]")
     except AudioDeviceError as e:
-        console.print(f"[red]Audio device error: {e!s}[/red]")
-        raise typer.Exit(1)
+        console.print(f"[red]audio device error: {e!s}[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     except RecordingError as e:
-        console.print(f"[red]Recording error: {e!s}[/red]")
-        raise typer.Exit(1)
+        console.print(f"[red]recording error: {e!s}[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     except ConfigurationError as e:
-        console.print(f"[red]Configuration error: {e!s}[/red]")
-        raise typer.Exit(1)
+        console.print(f"[red]configuration error: {e!s}[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     except Exception as e:  # noqa: BLE001 - top-level CLI handler; all specific errors caught above
         logger.debug("Unexpected error in record command: %s", e, exc_info=True)
-        console.print(f"[red]Unexpected error: {e!s}[/red]")
-        raise typer.Exit(1)
+        console.print(f"[red]unexpected error: {e!s}[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
+    finally:
+        if previous_sigterm is not None:
+            signal.signal(signal.SIGTERM, previous_sigterm)
+        if previous_sigwinch is not None and hasattr(signal, "SIGWINCH"):
+            signal.signal(signal.SIGWINCH, previous_sigwinch)
 
 
 def _run_live_transcription(
@@ -417,13 +531,13 @@ def _run_live_transcription(
         result: LiveSessionResult = session.run()
     except ImportError as e:
         console.print(f"[red]{e}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     except WhisperModelLoadError as e:
         console.print(f"[red]{e!s}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.MODEL_LOAD_FAILED)
     except RecordingError as e:
-        console.print(f"[red]Live recording error: {e!s}[/red]")
-        raise typer.Exit(1)
+        console.print(f"[red]live recording error: {e!s}[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     from utils.time_utils import format_duration
 
@@ -479,19 +593,19 @@ def transcribe(
             console.print(
                 "[red]--regen processes all transcribed records; do not pass N.[/red]"
             )
-            raise typer.Exit(2)
+            raise typer.Exit(exit_codes.USAGE_ERROR)
         if force:
             console.print(
                 "[red]--regen and --force are mutually exclusive (--force re-transcribes; "
                 "--regen reuses existing transcripts).[/red]"
             )
-            raise typer.Exit(2)
+            raise typer.Exit(exit_codes.USAGE_ERROR)
         _run_regen_pipeline(settings)
         return
 
     if n is not None and n < 1:
         console.print("[red]N must be a positive integer.[/red]")
-        raise typer.Exit(2)
+        raise typer.Exit(exit_codes.USAGE_ERROR)
 
     if model:
         console.print(f"[cyan]Using Whisper model: {model}[/cyan]")
@@ -502,7 +616,7 @@ def transcribe(
         processor = BatchProcessor(settings, model_override=model)
     except WhisperModelLoadError as e:
         console.print(f"[red]{e!s}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     processor.run_queue(n=n, force=force, console=console)
 
 
@@ -538,7 +652,7 @@ def _run_regen_pipeline(settings) -> None:
         for failure in failed:
             slug = failure.get("slug", "<unknown>")
             error = failure.get("error", "unknown error")
-            console.print(f"[red]  ✗ {slug}: {error}[/red]")
+            console.print(f"[red]  {glyphs.FAILURE} {slug}: {error}[/red]")
 
 
 notes_app = typer.Typer(help="Browse, view, edit, or delete your notes")
@@ -575,14 +689,17 @@ def notes_callback(
         "--tag",
         help="Filter by tag (comma-separated values are AND-combined).",
     ),
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit the note list as JSON to stdout."
+    ),
 ):
     """Browse, view, edit, or delete your notes"""
     if ctx.invoked_subcommand is not None:
         if tag is not None:
             console.print("[red]--tag is only valid when listing notes.[/red]")
-            raise typer.Exit(2)
+            raise typer.Exit(exit_codes.USAGE_ERROR)
         return
-    _list_notes(tag)
+    _list_notes(tag, json_output=json_output)
 
 
 def _parse_tag_filter(tag: str | None) -> list[str]:
@@ -591,7 +708,18 @@ def _parse_tag_filter(tag: str | None) -> list[str]:
     return [piece.strip() for piece in tag.split(",") if piece.strip()]
 
 
-def _list_notes(tag: str | None) -> None:
+def _note_to_json(idx: int, record: NoteRecord) -> dict:
+    return {
+        "id": idx,
+        "slug": record.slug,
+        "title": _resolve_display_title(record),
+        "date": record.created_at.date().isoformat(),
+        "tags": list(record.tags),
+        "notes_path": str(record.notes) if record.notes else None,
+    }
+
+
+def _list_notes(tag: str | None, json_output: bool = False) -> None:
     settings = get_settings()
     all_records = [
         record
@@ -607,6 +735,14 @@ def _list_notes(tag: str | None) -> None:
         ]
     else:
         records = all_records
+
+    if json_output:
+        payload = [
+            _note_to_json(idx, record)
+            for idx, record in enumerate(reversed(records), start=1)
+        ]
+        sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+        return
 
     if not all_records:
         console.print(
@@ -669,15 +805,18 @@ def _list_notes(tag: str | None) -> None:
             date_str = "?"
             length_str = "?"
 
-        tag_cell = ", ".join(record.tags) if record.tags else "—"
+        tag_cell = ", ".join(record.tags) if record.tags else glyphs.PENDING
         table.add_row(str(idx), title, date_str, length_str, tag_cell)
 
-    console.print(table)
+    stdout_console.print(table)
+    arrow = glyphs.INPUT_ARROW
     console.print()
-    console.print(" [dim]› chirp notes view <id>      · open a note read-only[/dim]")
-    console.print(" [dim]› chirp notes edit <id>      · edit a note[/dim]")
-    console.print(" [dim]› chirp notes delete <id>    · delete a note[/dim]")
-    console.print(" [dim]› chirp notes --tag meeting  · filter by tag[/dim]")
+    console.print(
+        f" [dim]{arrow} chirp notes view <id>      · open a note read-only[/dim]"
+    )
+    console.print(f" [dim]{arrow} chirp notes edit <id>      · edit a note[/dim]")
+    console.print(f" [dim]{arrow} chirp notes delete <id>    · delete a note[/dim]")
+    console.print(f" [dim]{arrow} chirp notes --tag meeting  · filter by tag[/dim]")
 
 
 def _resolve_note(records: list[NoteRecord], note_id: str) -> NoteRecord:
@@ -714,7 +853,7 @@ def _load_notes_or_exit() -> list[NoteRecord]:
         console.print(
             f"[yellow]No notes found in {settings.directories.notes_root}[/yellow]"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     return records
 
 
@@ -723,16 +862,16 @@ def _resolve_or_exit(note_id: str) -> NoteRecord:
     try:
         return _resolve_note(records, note_id)
     except NoteNotFound:
-        console.print(f"[red]✗ no note matching '{note_id}'[/red]")
-        raise typer.Exit(1)
+        console.print(f"[red]{glyphs.FAILURE} no note matching '{note_id}'[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     except AmbiguousNoteId as exc:
         console.print(
-            f"[red]✗ '{note_id}' matches {len(exc.matches)} notes — "
+            f"[red]{glyphs.FAILURE} '{note_id}' matches {len(exc.matches)} notes — "
             "be more specific[/red]"
         )
         for slug in exc.matches:
             console.print(f"[dim]  • {slug}[/dim]")
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
 
 @notes_app.command("view")
@@ -742,15 +881,17 @@ def notes_view(note_id: str = typer.Argument(..., help="Note id (slug or prefix)
 
     record = _resolve_or_exit(note_id)
     if record.notes is None:
-        console.print(f"[red]✗ note '{record.slug}' has no notes.md[/red]")
-        raise typer.Exit(1)
+        console.print(
+            f"[red]{glyphs.FAILURE} note '{record.slug}' has no notes.md[/red]"
+        )
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         console.print(
-            "[yellow]Interactive editor requires a terminal. "
-            "Please run from an interactive shell.[/yellow]"
+            "[yellow]interactive editor requires a terminal. "
+            "please run from an interactive shell.[/yellow]"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     title = _resolve_display_title(record)
     content = record.notes.read_text(encoding="utf-8")
@@ -758,26 +899,80 @@ def notes_view(note_id: str = typer.Argument(..., help="Note id (slug or prefix)
     try:
         editor.run()
     except KeyboardInterrupt:
-        console.print("\n[dim]Editor cancelled[/dim]")
+        console.print("\n[dim]editor cancelled[/dim]")
+
+
+def _external_editor_command() -> str | None:
+    """The user's preferred external editor, if ``$VISUAL`` / ``$EDITOR`` is set."""
+    import os
+
+    return os.environ.get("VISUAL") or os.environ.get("EDITOR") or None
+
+
+def _edit_in_external_editor(notes_path: Path, command: str) -> bool:
+    """Open ``notes_path`` in the external editor; True if it edited the file.
+
+    Returns False if the editor could not be launched so the caller can fall
+    back to the built-in modal editor.
+    """
+    import shlex
+    import subprocess
+
+    argv = [*shlex.split(command), str(notes_path)]
+    try:
+        completed = subprocess.run(argv, check=False)
+    except (OSError, ValueError) as exc:
+        console.print(f"[red]could not launch external editor '{command}': {exc}[/red]")
+        return False
+    if completed.returncode != 0:
+        console.print(
+            f"[yellow]external editor exited with status "
+            f"{completed.returncode}; notes.md left as the editor saved it.[/yellow]"
+        )
+    return True
 
 
 @notes_app.command("edit")
-def notes_edit(note_id: str = typer.Argument(..., help="Note id (slug or prefix)")):
+def notes_edit(
+    note_id: str = typer.Argument(..., help="Note id (slug or prefix)"),
+    use_external_editor: bool = typer.Option(
+        False,
+        "--editor",
+        help="Open notes.md in $VISUAL/$EDITOR instead of the built-in editor.",
+    ),
+):
     """Edit a note in the terminal editor; saves rewrite notes.md and re-index."""
     from notes.note_editor import ManualNoteEditor
 
     settings = get_settings()
     record = _resolve_or_exit(note_id)
     if record.notes is None:
-        console.print(f"[red]✗ note '{record.slug}' has no notes.md[/red]")
-        raise typer.Exit(1)
+        console.print(
+            f"[red]{glyphs.FAILURE} note '{record.slug}' has no notes.md[/red]"
+        )
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     if not sys.stdin.isatty() or not sys.stdout.isatty():
         console.print(
-            "[yellow]Interactive editor requires a terminal. "
-            "Please run from an interactive shell.[/yellow]"
+            "[yellow]interactive editor requires a terminal. "
+            "please run from an interactive shell.[/yellow]"
         )
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
+
+    if use_external_editor:
+        command = _external_editor_command()
+        if command is None:
+            console.print(
+                "[red]--editor needs $VISUAL or $EDITOR set; "
+                "neither is. drop --editor to use the built-in editor.[/red]"
+            )
+            raise typer.Exit(exit_codes.USAGE_ERROR)
+        if _edit_in_external_editor(record.notes, command):
+            console.print(f"[green]updated note: {record.notes}[/green]")
+            if settings.notes_chat.auto_index:
+                _reindex_after_edit(settings, record)
+            return
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     title = _resolve_display_title(record)
     content = record.notes.read_text(encoding="utf-8")
@@ -785,15 +980,15 @@ def notes_edit(note_id: str = typer.Argument(..., help="Note id (slug or prefix)
     try:
         result = editor.run()
     except KeyboardInterrupt:
-        console.print("\n[dim]Editor cancelled[/dim]")
-        raise typer.Exit(1)
+        console.print("\n[dim]editor cancelled[/dim]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     if not result.saved:
-        console.print("[yellow]Changes not saved.[/yellow]")
+        console.print("[yellow]changes not saved.[/yellow]")
         return
 
     record.notes.write_text(result.content, encoding="utf-8")
-    console.print(f"[green]Updated note: {record.notes}[/green]")
+    console.print(f"[green]updated note: {record.notes}[/green]")
 
     if settings.notes_chat.auto_index:
         _reindex_after_edit(settings, record)
@@ -815,11 +1010,13 @@ def _reindex_after_edit(settings: ChirpSettings, record: NoteRecord) -> None:
                 manifest[file_path] = current_files[file_path]
                 index_manager._save_manifest(manifest)
             index_manager._rebuild_bm25()
-            console.print(f"[dim green]✓ Re-indexed {notes_path.name}[/dim green]")
+            console.print(
+                f"[dim green]{glyphs.SUCCESS} re-indexed {notes_path.name}[/dim green]"
+            )
     except Exception as exc:  # noqa: BLE001 - defensive auto-index; IndexManager can raise many types
         logger.debug("Auto-indexing failed for %s: %s", notes_path.name, exc)
         console.print(
-            f"[dim yellow]Auto-indexing failed for "
+            f"[dim yellow]auto-indexing failed for "
             f"{notes_path.name}: {exc}[/dim yellow]"
         )
 
@@ -842,16 +1039,18 @@ def notes_delete(
             default=False,
         )
         if not confirmed:
-            console.print("[yellow]Deletion cancelled.[/yellow]")
+            console.print("[yellow]deletion cancelled.[/yellow]")
             return
 
     notes_path = record.notes
     try:
         shutil.rmtree(record.dir, ignore_errors=False)
     except OSError as exc:
-        console.print(f"[red]✗ failed to delete {record.dir}: {exc}[/red]")
-        raise typer.Exit(1)
-    console.print(f"[green]Deleted {record.dir}[/green]")
+        console.print(
+            f"[red]{glyphs.FAILURE} failed to delete {record.dir}: {exc}[/red]"
+        )
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
+    console.print(f"[green]deleted {record.dir}[/green]")
 
     if notes_path is not None:
         _drop_from_index(settings, notes_path)
@@ -869,7 +1068,7 @@ def _drop_from_index(settings: ChirpSettings, notes_path: Path) -> None:
         index_manager._rebuild_bm25()
     except Exception as exc:  # noqa: BLE001 - defensive auto-index; IndexManager can raise many types
         logger.debug("Failed to update index after delete: %s", exc)
-        console.print(f"[dim yellow]Failed to update index: {exc}[/dim yellow]")
+        console.print(f"[dim yellow]failed to update index: {exc}[/dim yellow]")
 
 
 def _resolve_display_title(record: NoteRecord) -> str:
@@ -910,10 +1109,20 @@ def ask(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Show prompt without calling LLM"
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the answer and sources as JSON to stdout (one-shot only).",
+    ),
 ):
     """Chat with your notes"""
     from notes_chat.cli import ask
 
+    if question is not None and question_option is not None:
+        console.print(
+            "[yellow]both a positional question and --question given; "
+            "using the positional.[/yellow]"
+        )
     resolved = question if question is not None else question_option
     ask(
         question=resolved,
@@ -922,6 +1131,7 @@ def ask(
         sources=sources,
         dry_run=dry_run,
         markdown=markdown,
+        json_output=json_output,
     )
 
 
@@ -943,17 +1153,17 @@ def search(
     """Keyword search across transcripts and notes."""
     from notes_chat.search_keyword import (
         SearchOptions,
-        emit_json,
         render_no_matches,
         render_results,
         run_search,
         suggest_close_keywords,
+        write_json,
     )
     from utils.time_utils import parse_since
 
     if not query or not query.strip():
         console.print("[red]search query is required.[/red]")
-        raise typer.Exit(2)
+        raise typer.Exit(exit_codes.USAGE_ERROR)
 
     since_minutes: int | None = None
     if since is not None:
@@ -961,14 +1171,14 @@ def search(
             since_minutes = parse_since(since)
         except ValueError as exc:
             console.print(f"[red]invalid --since: {exc}[/red]")
-            raise typer.Exit(2)
+            raise typer.Exit(exit_codes.USAGE_ERROR)
 
     if regex:
         try:
             __import__("re").compile(query)
         except __import__("re").error as exc:
             console.print(f"[red]invalid regex: {exc.msg}[/red]")
-            raise typer.Exit(2)
+            raise typer.Exit(exit_codes.USAGE_ERROR)
 
     settings = get_settings()
     options = SearchOptions(
@@ -981,11 +1191,11 @@ def search(
     result = run_search(settings, options)
 
     if json_output:
-        console.print(emit_json(result))
+        write_json(result)
         return
 
     if result["matches"]:
-        render_results(console, options, result)
+        render_results(stdout_console, console, options, result)
         return
 
     bm25_path = settings.notes_chat.index_dir / "bm25.json"
@@ -1024,11 +1234,21 @@ if __name__ == "__main__":
 
 
 @app.command(rich_help_panel=MAIN_PANEL)
-def about():
+def about(
+    plain: bool = typer.Option(
+        False,
+        "--plain",
+        "--no-animate",
+        help="Print the static info panel without the animation (scripted/non-TTY).",
+    ),
+):
     """Show the bird 🐦"""
-    from chirp.about import run_about
+    from chirp.about import render_about_plain, run_about
 
     settings = get_settings()
+    if plain:
+        render_about_plain(stdout_console, settings)
+        return
     try:
         run_about(console, settings)
     except KeyboardInterrupt:
@@ -1089,7 +1309,7 @@ Warning: {settings.monitoring.warning_minutes} minutes
 Interval: {settings.monitoring.warning_interval} minutes""",
             title="Chirp Configuration",
         )
-        console.print(panel)
+        stdout_console.print(panel)
         return
 
     changes_made = False
@@ -1113,7 +1333,7 @@ Interval: {settings.monitoring.warning_interval} minutes""",
     if changes_made:
         settings.save_to_file(ChirpSettings.get_config_path())
         settings.ensure_directories_exist()
-        console.print("[green]Configuration updated[/green]")
+        console.print("[green]configuration updated[/green]")
 
 
 @app.command(hidden=True)
@@ -1149,8 +1369,8 @@ def devices():
             f"{device['default_sample_rate']:.0f} Hz",
         )
 
-    console.print(input_table)
-    console.print()
+    stdout_console.print(input_table)
+    stdout_console.print()
 
     output_table = Table(title="Output Devices (speakers & routing)")
     output_table.add_column("", style="bold")
@@ -1172,7 +1392,7 @@ def devices():
             f"{device['default_sample_rate']:.0f} Hz",
         )
 
-    console.print(output_table)
+    stdout_console.print(output_table)
 
     console.print()
     console.print(
@@ -1183,29 +1403,35 @@ def devices():
             perms = audio_capture.check_permissions()
             state = perms.get("screen_recording")
             if state == "granted":
-                console.print("[green]✅ capture ready[/green]")
+                console.print(f"[green]{glyphs.SUCCESS} capture ready[/green]")
             elif state == "undetermined":
-                console.print("[yellow]— capture will prompt on first record[/yellow]")
+                console.print(
+                    f"[yellow]{glyphs.PENDING} capture will prompt on first "
+                    "record[/yellow]"
+                )
             elif state == "denied":
                 console.print(
-                    "[red]❌ screen recording permission denied[/red]"
+                    f"[red]{glyphs.FAILURE} screen recording permission denied[/red]"
                     " — open System Settings → Privacy & Security → Screen Recording"
                 )
             else:
                 console.print(
-                    "[red]❌ capture_audio probe returned unexpected state[/red]"
-                    " — rebuild with python -m audio_capture.build"
+                    f"[red]{glyphs.FAILURE} capture_audio probe returned unexpected "
+                    "state[/red] — rebuild with python -m audio_capture.build"
                 )
         except FileNotFoundError:
             console.print(
-                "[red]❌ capture_audio binary missing[/red] — run python -m audio_capture.build"
+                f"[red]{glyphs.FAILURE} capture_audio binary missing[/red] — "
+                "run python -m audio_capture.build"
             )
         except RuntimeError as exc:
             console.print(
-                f"[red]❌ permission probe failed[/red]: {exc} — try rebuilding with python -m audio_capture.build"
+                f"[red]{glyphs.FAILURE} permission probe failed[/red]: {exc} — "
+                "try rebuilding with python -m audio_capture.build"
             )
     else:
         console.print(
-            f"[dim]— capture status not applicable on {platform.system()}[/dim]"
+            f"[dim]{glyphs.PENDING} capture status not applicable on "
+            f"{platform.system()}[/dim]"
         )
     console.print("[dim]Run 'chirp init' for first-run setup.[/dim]")

--- a/chirp/exit_codes.py
+++ b/chirp/exit_codes.py
@@ -1,0 +1,48 @@
+"""Centralized exit codes for the ``chirp`` CLI.
+
+One source of truth for every ``typer.Exit(code=...)`` site so the numbers stay
+a stable, documented contract instead of scattered literals. The observable
+codes ``2``/``3``/``4``/``5``/``7`` predate this module (stories 3.7, 5.x, 7.1)
+and must not be renumbered — they are gathered here, not changed.
+
+================  ====  ===========================================================
+Name              Code  Meaning
+================  ====  ===========================================================
+SUCCESS           0     Command completed.
+RUNTIME_ERROR     1     Generic runtime failure (also Ctrl-C / interrupted).
+USAGE_ERROR       2     Bad arguments or flags (Click's own convention).
+DAEMON_UNREACHABLE 3    The chirpd daemon is not running and could not be started.
+MODEL_LOAD_FAILED 4     A model was found but could not be loaded.
+MODEL_NOT_FOUND   5     No model is registered for the requested role.
+NOT_APPLE_SILICON 7     ``chirp init`` ran on a non-arm64 machine.
+================  ====  ===========================================================
+
+``6`` is intentionally unused (reserved). Ctrl-C / EOF keeps the current
+behavior of exiting ``1`` rather than claiming a dedicated "interrupted" slot.
+
+``MODEL_LOAD_FAILED`` (4) is the LLM-daemon (chirpd) path. Whisper transcription
+model-load failures are deliberately separate: live ``record --live-transcribe``
+surfaces them as ``4``, but batch ``transcribe`` keeps ``1`` by existing
+contract (``test_transcribe_reports_model_load_error``) — the difference is
+intentional, not an oversight.
+"""
+
+from __future__ import annotations
+
+SUCCESS = 0
+RUNTIME_ERROR = 1
+USAGE_ERROR = 2
+DAEMON_UNREACHABLE = 3
+MODEL_LOAD_FAILED = 4
+MODEL_NOT_FOUND = 5
+NOT_APPLE_SILICON = 7
+
+__all__ = [
+    "DAEMON_UNREACHABLE",
+    "MODEL_LOAD_FAILED",
+    "MODEL_NOT_FOUND",
+    "NOT_APPLE_SILICON",
+    "RUNTIME_ERROR",
+    "SUCCESS",
+    "USAGE_ERROR",
+]

--- a/chirp/glyphs.py
+++ b/chirp/glyphs.py
@@ -1,0 +1,26 @@
+"""Shared status glyphs for the ``chirp`` CLI.
+
+Glyphs drifted across commands — ``devices`` used the emoji ``✅`` / ``❌`` while
+``init`` and ``search`` already used the terser text marks ``✓`` / ``✗`` / ``—``.
+This module is the single source so every command speaks the same visual
+vocabulary; the house voice is lowercase and terse (see the story 1.8 ``search``
+copy), so messages alongside these marks stay sentence-case, not Title Case.
+"""
+
+from __future__ import annotations
+
+SUCCESS = "✓"
+FAILURE = "✗"
+PENDING = "—"
+DEFAULT_MARKER = "★"
+ACTIVE_MARKER = "●"
+INPUT_ARROW = "›"
+
+__all__ = [
+    "ACTIVE_MARKER",
+    "DEFAULT_MARKER",
+    "FAILURE",
+    "INPUT_ARROW",
+    "PENDING",
+    "SUCCESS",
+]

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -40,9 +40,10 @@ from rich.console import Console
 from rich.text import Text
 
 import audio_capture
+from chirp import exit_codes, glyphs
 from config.settings import ChirpSettings, _stringify_paths
 
-EXIT_NOT_APPLE_SILICON = 7
+EXIT_NOT_APPLE_SILICON = exit_codes.NOT_APPLE_SILICON
 
 # Single source of truth for the recommended first model — story 7.2's
 # migration plan and the README sweep (7.5) reference these constants.
@@ -268,11 +269,11 @@ def verify(settings: ChirpSettings, console: Console) -> list[DependencyStatus]:
 
 def _print_status(console: Console, status: DependencyStatus) -> None:
     if status.installed:
-        icon = "[green]✓[/green]"
+        icon = f"[green]{glyphs.SUCCESS}[/green]"
     elif status.required:
-        icon = "[red]✗[/red]"
+        icon = f"[red]{glyphs.FAILURE}[/red]"
     else:
-        icon = "[yellow]—[/yellow]"
+        icon = f"[yellow]{glyphs.PENDING}[/yellow]"
     label = status.name.ljust(22)
     console.print(f" {icon} {label} [dim]· {status.detail}[/dim]")
 

--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -28,6 +28,7 @@ from typing import Any, Literal, NoReturn
 import typer
 from rich.table import Table
 
+from chirp import glyphs
 from chirpd.paths import MODELS_TOML_PATH
 from llm import hf
 from llm.cli._console import console, stdout_console
@@ -221,8 +222,8 @@ def _render_list_table(rows: list[ListRow], daemon_reachable: bool) -> None:
         table.add_row(
             row.alias,
             row.role,
-            "★" if row.is_default else "",
-            "●" if daemon_reachable and row.loaded else "—",
+            glyphs.DEFAULT_MARKER if row.is_default else "",
+            glyphs.ACTIVE_MARKER if daemon_reachable and row.loaded else glyphs.PENDING,
             row.hf_repo,
         )
     stdout_console.print(table)

--- a/notes/note_editor.py
+++ b/notes/note_editor.py
@@ -43,6 +43,29 @@ class DisplayLine:
     source_line: int
 
 
+KEYBINDING_HINT = "i insert · Esc normal · :wq save · :q! quit · ? :help"
+
+HELP_LINES = (
+    "  chirp note editor — help",
+    "",
+    "  modes",
+    "    i           enter insert mode",
+    "    Esc         return to normal/view mode",
+    "",
+    "  commands (normal mode, type with :)",
+    "    :wq         save and quit",
+    "    :q!         quit without saving",
+    "    :help       show this help",
+    "",
+    "  keys",
+    "    ?           show this help (normal/view mode)",
+    "    arrows/hjkl move the cursor",
+    "    PgUp/PgDn   scroll a page",
+    "",
+    "  press any key to close this help",
+)
+
+
 class ManualNoteEditor:
     """A minimal modal text editor with view/insert modes."""
 
@@ -77,6 +100,7 @@ class ManualNoteEditor:
         self.dirty = False
         self.readonly = readonly
         self._readonly_notified = False
+        self.show_help = False
 
         self._has_colors = False
         self._color_pairs: dict[tuple[int, int], int] = {}
@@ -114,6 +138,11 @@ class ManualNoteEditor:
             except curses.error:
                 continue
 
+            if self.show_help:
+                # The help overlay is modal: any key dismisses it.
+                self.show_help = False
+                continue
+
             if self.command_active:
                 if self._handle_command_input(key):
                     break
@@ -138,9 +167,16 @@ class ManualNoteEditor:
 
     def _render(self, stdscr: curses.window) -> None:
         height, width = stdscr.getmaxyx()
-        text_height = max(1, height - 1)
+        # Reserve the bottom-most row for the status line and the row above it for
+        # the persistent keybinding hint, so neither overwrites the text body.
+        hint_row = max(0, height - 2)
+        text_height = max(1, height - 2)
         text_width = max(1, width - 1)
         self._last_text_height = text_height
+
+        if self.show_help:
+            self._render_help_overlay(stdscr, height, width)
+            return
 
         if self.mode == "view":
             self._ensure_view_cache(text_width)
@@ -155,6 +191,8 @@ class ManualNoteEditor:
             self._render_view_mode(stdscr, text_height, text_width)
         else:
             self._render_insert_mode(stdscr, text_height, text_width)
+
+        self._render_keybinding_hint(stdscr, hint_row, width)
 
         status = self._status_line(width)
         status_attr = self._status_pairs.get(self.mode, curses.A_REVERSE)
@@ -178,6 +216,30 @@ class ManualNoteEditor:
         except curses.error:
             pass
 
+        stdscr.refresh()
+
+    def _render_keybinding_hint(
+        self, stdscr: curses.window, hint_row: int, width: int
+    ) -> None:
+        attr = curses.A_DIM if hasattr(curses, "A_DIM") else curses.A_NORMAL
+        hint = KEYBINDING_HINT[: max(1, width - 1)]
+        try:
+            stdscr.addstr(hint_row, 0, " " * max(1, width - 1))
+            stdscr.addstr(hint_row, 0, hint, attr)
+        except curses.error:
+            pass
+
+    def _render_help_overlay(
+        self, stdscr: curses.window, height: int, width: int
+    ) -> None:
+        stdscr.erase()
+        for row, line in enumerate(HELP_LINES):
+            if row >= height:
+                break
+            try:
+                stdscr.addstr(row, 0, line[: max(1, width - 1)])
+            except curses.error:
+                continue
         stdscr.refresh()
 
     def _render_insert_mode(
@@ -304,6 +366,10 @@ class ManualNoteEditor:
             self.message = ""
             return False
 
+        if key == "?":
+            self.show_help = True
+            return False
+
         return self._handle_navigation(key)
 
     def _handle_insert_mode(self, key) -> bool:
@@ -394,7 +460,12 @@ class ManualNoteEditor:
             self.dirty = False
             return True
 
-        self.message = f"Unknown command: {command}" if command else ""
+        if command == "help":
+            self.show_help = True
+            self.command_buffer = ""
+            return False
+
+        self.message = f"Unknown command: {command} — type :help" if command else ""
         self.command_buffer = ""
         return False
 
@@ -633,8 +704,14 @@ class ManualNoteEditor:
         if not self._view_cache_dirty and self._view_cache_width == text_width:
             return
 
-        console = Console(
-            width=text_width, color_system="standard", force_terminal=True
+        # ``force_terminal=True`` keeps render_lines producing width-correct
+        # segments offscreen (the editor re-emits them through curses), but it
+        # must not override NO_COLOR — so drop the color system entirely when
+        # color is disabled while keeping the same width measurement.
+        console = (
+            Console(width=text_width, color_system=None, force_terminal=True)
+            if self._no_color_active()
+            else Console(width=text_width, color_system="standard", force_terminal=True)
         )
         options = console.options.update(width=text_width)
 
@@ -725,6 +802,19 @@ class ManualNoteEditor:
         top_index = min(self._view_top_index, len(self._display_lines) - 1)
         top_display = self._display_lines[top_index]
         self.top_line = top_display.source_line
+
+    def _no_color_active(self) -> bool:
+        """Whether color is disabled via NO_COLOR or the --no-color/--plain flag."""
+        import os
+
+        if os.environ.get("NO_COLOR"):
+            return True
+        try:
+            from chirp._console import stdout_console
+
+            return bool(stdout_console.no_color)
+        except Exception:  # noqa: BLE001 - color detection must never break the editor
+            return False
 
     def _notify_readonly(self) -> None:
         if not self._readonly_notified:

--- a/notes_chat/cli.py
+++ b/notes_chat/cli.py
@@ -1,10 +1,12 @@
+import json
 import logging
 import sys
 
 import typer
-from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from chirp import exit_codes
+from chirp._console import stderr_console, stdout_console
 from llm.exceptions import (
     LLMCancelled,
     LLMDaemonSpawnFailed,
@@ -17,7 +19,8 @@ from notes_chat.config import get_notes_config
 
 logger = logging.getLogger(__name__)
 
-console = Console()
+# Diagnostics/progress/errors → stderr; the answer body and JSON → stdout.
+console = stderr_console
 app = typer.Typer()
 
 
@@ -64,12 +67,12 @@ def index(
             console.print(
                 f"[red]Index build failed: {result.get('error', 'Unknown error')}[/red]"
             )
-            raise typer.Exit(1)
+            raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     except Exception as e:  # noqa: BLE001 - top-level CLI handler for index build
         logger.debug("Index build failed: %s", e, exc_info=True)
         console.print(f"[red]Index build failed: {e}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
 
 @app.command()
@@ -100,6 +103,11 @@ def ask(
         "--markdown/--no-markdown",
         help="Render answers as markdown (code blocks, bullets, bold).",
     ),
+    json_output: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit the answer and sources as JSON to stdout (one-shot only).",
+    ),
 ):
     """Ask questions about your meeting notes. Run without a question for interactive chat."""
     config = get_notes_config()
@@ -119,7 +127,8 @@ def ask(
         from notes_chat.prompting import generate_answer, stream_answer_tokens
         from notes_chat.retrieval import retrieve_context
 
-        console.print(f"[dim]searching for: {question}[/dim]")
+        if not json_output:
+            console.print(f"[dim]searching for: {question}[/dim]")
 
         context_result = retrieve_context(config, question, when_filter=when)
 
@@ -129,16 +138,27 @@ def ask(
                 console.print("[yellow]No relevant documents found.[/yellow]")
                 if context_result.get("suggestion"):
                     console.print(f"[dim]try: {context_result['suggestion']}[/dim]")
-                raise typer.Exit(2)
+                raise typer.Exit(exit_codes.USAGE_ERROR)
             console.print(f"[red]Context retrieval failed: {error}[/red]")
             if context_result.get("suggestion"):
                 console.print(f"[dim]{context_result['suggestion']}[/dim]")
-            raise typer.Exit(1)
+            raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
         context = context_result["context"]
         retrieved_ids = context_result["retrieved_ids"]
 
         if dry_run:
+            if json_output:
+                payload = {
+                    "dry_run": True,
+                    "question": question,
+                    "context": context,
+                    "retrieved_chunks": len(retrieved_ids),
+                }
+                sys.stdout.write(
+                    json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+                )
+                return
             console.print("[yellow]dry run — showing context and prompt:[/yellow]")
             console.print(f"[dim]Context length: {len(context)} characters[/dim]")
             console.print(f"[dim]Retrieved chunks: {len(retrieved_ids)}[/dim]")
@@ -148,28 +168,32 @@ def ask(
 
         cached_answer = get_cached_answer(question, retrieved_ids)
         if cached_answer:
-            console.print("[dim]using cached answer[/dim]")
-            console.print("\n[magenta bold]chirp ›[/magenta bold]")
-            if markdown:
-                from rich.markdown import Markdown
-
-                console.print(Markdown(cached_answer))
-            else:
-                console.print(cached_answer)
             answer = cached_answer
-        elif markdown:
+            if not json_output:
+                console.print("[dim]using cached answer[/dim]")
+                console.print("\n[magenta bold]chirp ›[/magenta bold]")
+                if markdown:
+                    from rich.markdown import Markdown
+
+                    stdout_console.print(Markdown(cached_answer))
+                else:
+                    stdout_console.print(cached_answer)
+        elif json_output or markdown:
+            # Under --json the answer is collected, not streamed/rendered, so no
+            # Markdown is ever instantiated; the raw JSON is emitted at the end.
             answer_result = generate_answer(config, question, context)
             if not answer_result.get("success"):
                 console.print(
                     f"[red]Answer generation failed: {answer_result.get('error', 'Unknown error')}[/red]"
                 )
-                raise typer.Exit(1)
+                raise typer.Exit(exit_codes.RUNTIME_ERROR)
             answer = answer_result["answer"]
             cache_answer(question, retrieved_ids, answer)
-            console.print("\n[magenta bold]chirp ›[/magenta bold]")
-            from rich.markdown import Markdown
+            if not json_output:
+                console.print("\n[magenta bold]chirp ›[/magenta bold]")
+                from rich.markdown import Markdown
 
-            console.print(Markdown(answer))
+                stdout_console.print(Markdown(answer))
         else:
             console.print("\n[magenta bold]chirp ›[/magenta bold]")
             tokens: list[str] = []
@@ -182,11 +206,24 @@ def ask(
             answer = "".join(tokens).strip()
             if not answer:
                 console.print("[red]Answer generation failed: empty response[/red]")
-                raise typer.Exit(1)
+                raise typer.Exit(exit_codes.RUNTIME_ERROR)
             cache_answer(question, retrieved_ids, answer)
 
-        if sources and context_result.get("sources"):
-            joined = ", ".join(context_result["sources"])
+        answer_sources = (
+            list(context_result["sources"]) if context_result.get("sources") else []
+        )
+
+        if json_output:
+            payload = {
+                "question": question,
+                "answer": answer,
+                "sources": answer_sources if sources else [],
+            }
+            sys.stdout.write(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+            return
+
+        if sources and answer_sources:
+            joined = ", ".join(answer_sources)
             console.print(f"\n[dim]sources: {joined}[/dim]")
 
     except typer.Exit:
@@ -196,26 +233,26 @@ def ask(
             f"[red]chirpd is not running and could not be started: {exc.message}[/red]"
         )
         console.print("[dim]run `chirp daemon status` for diagnostics[/dim]")
-        raise typer.Exit(3) from exc
+        raise typer.Exit(exit_codes.DAEMON_UNREACHABLE) from exc
     except LLMModelNotFound as exc:
         console.print(f"[red]{exc.message}[/red]")
         console.print(
             "[dim]run `chirp models add <hf-repo>` to register a chat model[/dim]"
         )
-        raise typer.Exit(5) from exc
+        raise typer.Exit(exit_codes.MODEL_NOT_FOUND) from exc
     except LLMModelLoadFailed as exc:
         console.print(f"[red]{exc.message}[/red]")
-        raise typer.Exit(4) from exc
+        raise typer.Exit(exit_codes.MODEL_LOAD_FAILED) from exc
     except LLMCancelled:
         console.print("[yellow]Interrupted.[/yellow]")
-        raise typer.Exit(1) from None
+        raise typer.Exit(exit_codes.RUNTIME_ERROR) from None
     except LLMError as exc:
         console.print(f"[red]{exc.message}[/red]")
-        raise typer.Exit(1) from exc
+        raise typer.Exit(exit_codes.RUNTIME_ERROR) from exc
     except Exception as e:  # noqa: BLE001 - top-level CLI handler for ask command
         logger.debug("Query failed: %s", e, exc_info=True)
         console.print(f"[red]Query failed: {e}[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
 
 if __name__ == "__main__":

--- a/notes_chat/interactive.py
+++ b/notes_chat/interactive.py
@@ -7,17 +7,20 @@ from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import ANSI
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.styles import Style
-from rich.console import Console
 from rich.markdown import Markdown
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from chirp._console import stderr_console, stdout_console
 from config.settings import ChirpSettings
 from llm.client import LLMClient
 from llm.exceptions import LLMError
 from notes_chat.prompting import enhanced_search_and_answer_stream
 
 logger = logging.getLogger(__name__)
-console = Console()
+
+# Diagnostics (banner, hints, errors, spinners) → stderr; the answer body
+# rendered while streaming → stdout. The REPL interrupt semantics are unchanged.
+console = stderr_console
 
 
 class InteractiveChatSession:
@@ -185,7 +188,7 @@ class InteractiveChatSession:
             initial = Markdown("") if self.markdown else Text("")
             new_live = Live(
                 initial,
-                console=console,
+                console=stdout_console,
                 refresh_per_second=10,
                 vertical_overflow="visible",
             )

--- a/notes_chat/search_keyword.py
+++ b/notes_chat/search_keyword.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
@@ -94,36 +95,48 @@ def run_search(settings: Any, options: SearchOptions) -> dict:
     }
 
 
-def render_results(console: Console, options: SearchOptions, result: dict) -> None:
+def render_results(
+    stdout_console: Console,
+    stderr_console: Console,
+    options: SearchOptions,
+    result: dict,
+) -> None:
+    """Render a search result with output split per clig.dev.
+
+    The result table and per-note excerpt blocks are *data* → ``stdout_console``;
+    the searching-preamble, optional scope line, match summary, and footer hints
+    are *chrome* → ``stderr_console`` so ``chirp search ... 2>/dev/null`` leaves
+    only the matches in the data stream.
+    """
     query = options.query
     total = result["total_notes_scanned"]
     matches = result["matches"]
 
-    console.print()
-    console.print(
+    stderr_console.print()
+    stderr_console.print(
         f" [dim]searching {total} {_plural(total, 'note')} for[/dim] "
         f'[bold yellow]"{query}"[/bold yellow] '
         f"[dim]· keyword (ripgrep over transcripts + notes)[/dim]"
     )
-    console.print()
+    stderr_console.print()
 
     if options.since_minutes is not None:
-        console.print(
+        stderr_console.print(
             f" [dim]scope: last {_humanize_duration(options.since_minutes)}[/dim]"
         )
-        console.print()
+        stderr_console.print()
 
     if not matches:
         return
 
     note_count = len(matches)
     match_count = sum(m["hits"] for m in matches)
-    console.print(
+    stderr_console.print(
         f" [bold white]{note_count} {_plural(note_count, 'note')}[/bold white] "
         f"[dim]· {match_count} {_plural(match_count, 'match', 'matches')} "
         f"· {result['duration_seconds']:.2f}s[/dim]"
     )
-    console.print()
+    stderr_console.print()
 
     table = Table(
         show_header=True,
@@ -143,11 +156,11 @@ def render_results(console: Console, options: SearchOptions, result: dict) -> No
             _format_date(match["date"]),
             str(match["hits"]),
         )
-    console.print(table)
-    console.print()
+    stdout_console.print(table)
+    stdout_console.print()
 
     for match in matches:
-        console.print(
+        stdout_console.print(
             f" [bold yellow]› #{match['id']} {match['title']}[/bold yellow] "
             f"[dim]· {_format_date(match['date'])}[/dim]"
         )
@@ -158,12 +171,14 @@ def render_results(console: Console, options: SearchOptions, result: dict) -> No
                 else f"notes.md:{excerpt['line']}"
             )
             text = _markup_excerpt(excerpt["text"], options.query, options.regex)
-            console.print(f"   [dim]{prefix}[/dim]  {text}")
-        console.print()
+            stdout_console.print(f"   [dim]{prefix}[/dim]  {text}")
+        stdout_console.print()
 
     top_id = matches[0]["id"]
-    console.print(f" [dim]› chirp notes view {top_id}      · open a result[/dim]")
-    console.print(
+    stderr_console.print(
+        f" [dim]› chirp notes view {top_id}      · open a result[/dim]"
+    )
+    stderr_console.print(
         f' [dim]› chirp ask "{query}"          · semantic answer instead[/dim]'
     )
 
@@ -398,3 +413,13 @@ def _levenshtein(a: str, b: str) -> int:
 
 def emit_json(result: dict) -> str:
     return json.dumps(result, indent=2)
+
+
+def write_json(result: dict) -> None:
+    """Write the search result as raw JSON to stdout (no Rich console).
+
+    Routing JSON through a Rich console risks reflow/markup mangling, so the
+    document is written straight to ``sys.stdout`` (mirrors
+    ``llm/cli/daemon.py`` and ``models.py``).
+    """
+    sys.stdout.write(emit_json(result) + "\n")

--- a/tests/test_ask_sources.py
+++ b/tests/test_ask_sources.py
@@ -230,8 +230,10 @@ class TestAskMarkdownToggle:
         self._stub_pipeline(monkeypatch, answer="answer")
         result = CliRunner().invoke(app, ["ask", "-q", "what?", "--no-markdown"])
         assert result.exit_code == 0
-        assert "sources: note #1" in result.stdout
-        assert "Sources:" not in result.stdout
+        # The sources footer is a diagnostic → stderr (AC-1); the answer is data.
+        assert "sources: note #1" in result.stderr
+        assert "Sources:" not in result.output
+        assert "answer" in result.stdout
 
     def test_no_sources_flag_omits_footer(self, monkeypatch):
         from typer.testing import CliRunner
@@ -243,4 +245,22 @@ class TestAskMarkdownToggle:
             app, ["ask", "-q", "what?", "--no-markdown", "--no-sources"]
         )
         assert result.exit_code == 0
-        assert "sources:" not in result.stdout
+        assert "sources:" not in result.output
+
+    def test_json_dry_run_emits_parseable_json(self, monkeypatch):
+        import json as _json
+
+        from typer.testing import CliRunner
+
+        from notes_chat.cli import app
+
+        # dry-run + --json must still emit valid JSON on stdout (not the human
+        # diagnostics), so a `jq` consumer never gets empty input.
+        self._stub_pipeline(monkeypatch, answer="unused")
+        result = CliRunner().invoke(app, ["ask", "-q", "what?", "--json", "--dry-run"])
+        assert result.exit_code == 0
+        payload = _json.loads(result.stdout)
+        assert payload["dry_run"] is True
+        assert payload["question"] == "what?"
+        assert payload["context"] == "ctx"
+        assert payload["retrieved_chunks"] == 1

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -51,13 +51,15 @@ class TestListNotes:
         runner, app = self._runner(tmp_path, monkeypatch)
         result = runner.invoke(app, ["notes"])
         assert result.exit_code == 0
-        assert "No notes found" in result.stdout
+        # Empty-state message is a diagnostic → stderr (AC-1).
+        assert "No notes found" in result.stderr
 
     def test_list_notes_shows_title_from_header(self, tmp_path, monkeypatch):
         _write_note(tmp_path, "team-standup-2026-01-15", "Team Standup", "Content")
         runner, app = self._runner(tmp_path, monkeypatch)
         result = runner.invoke(app, ["notes"])
         assert result.exit_code == 0
+        # The table is data → stdout (AC-1).
         assert "Team Standup" in result.stdout
 
     def test_list_notes_shows_total_count(self, tmp_path, monkeypatch):
@@ -66,17 +68,20 @@ class TestListNotes:
         runner, app = self._runner(tmp_path, monkeypatch)
         result = runner.invoke(app, ["notes"])
         assert result.exit_code == 0
-        assert "2 total" in result.stdout
+        # The "N total" preamble is a diagnostic → stderr (AC-1).
+        assert "2 total" in result.stderr
 
     def test_list_notes_shows_subcommand_hints(self, tmp_path, monkeypatch):
         _write_note(tmp_path, "team-standup-2026-01-15", "Team Standup", "Content")
         runner, app = self._runner(tmp_path, monkeypatch)
         result = runner.invoke(app, ["notes"])
         assert result.exit_code == 0
-        assert "chirp notes view <id>" in result.stdout
-        assert "chirp notes edit <id>" in result.stdout
-        assert "chirp notes delete <id>" in result.stdout
-        assert "chirp notes --tag meeting" in result.stdout
+        # Hint lines are diagnostics → stderr (AC-1); never on the data stream.
+        assert "chirp notes view <id>" in result.stderr
+        assert "chirp notes edit <id>" in result.stderr
+        assert "chirp notes delete <id>" in result.stderr
+        assert "chirp notes --tag meeting" in result.stderr
+        assert "chirp notes view <id>" not in result.stdout
 
 
 class TestTranscribeCli:
@@ -174,7 +179,7 @@ class TestTranscribeCli:
         runner = CliRunner()
         result = runner.invoke(chirp.cli.app, ["transcribe", "0"])
         assert result.exit_code == 2
-        assert "must be a positive integer" in result.stdout
+        assert "must be a positive integer" in result.stderr
 
     def test_no_stream_flag_removed(self, tmp_path, monkeypatch):
         settings = _make_settings(tmp_path)
@@ -187,7 +192,8 @@ class TestTranscribeCli:
         runner = CliRunner()
         result = runner.invoke(chirp.cli.app, ["transcribe", "--no-stream"])
         assert result.exit_code != 0
-        assert "no such option" in result.stdout.lower() or result.exit_code == 2
+        # Click usage errors land on stderr; result.output is the combined stream.
+        assert "no such option" in result.output.lower() or result.exit_code == 2
 
 
 class TestTranscribeRegen:
@@ -241,7 +247,7 @@ class TestTranscribeRegen:
         assert result.exit_code == 0
         assert captured.get("force") is True
         assert len(captured.get("records", [])) == 2
-        assert "Regenerated notes for 2/2" in result.stdout
+        assert "Regenerated notes for 2/2" in result.stderr
 
     def test_regen_with_n_rejected(self, tmp_path, monkeypatch):
         settings = _make_settings(tmp_path)
@@ -255,7 +261,7 @@ class TestTranscribeRegen:
         result = runner.invoke(chirp.cli.app, ["transcribe", "--regen", "1"])
 
         assert result.exit_code == 2
-        assert "do not pass N" in result.stdout
+        assert "do not pass N" in result.stderr
 
     def test_regen_with_force_rejected(self, tmp_path, monkeypatch):
         settings = _make_settings(tmp_path)
@@ -269,7 +275,7 @@ class TestTranscribeRegen:
         result = runner.invoke(chirp.cli.app, ["transcribe", "--regen", "--force"])
 
         assert result.exit_code == 2
-        assert "mutually exclusive" in result.stdout
+        assert "mutually exclusive" in result.stderr
 
     def test_regen_when_no_transcripts(self, tmp_path, monkeypatch):
         settings = _make_settings(tmp_path)
@@ -283,7 +289,7 @@ class TestTranscribeRegen:
         result = runner.invoke(chirp.cli.app, ["transcribe", "--regen"])
 
         assert result.exit_code == 0
-        assert "No transcripts found" in result.stdout
+        assert "No transcripts found" in result.stderr
 
 
 class TestNotesResolveAndTagFilter:
@@ -304,16 +310,16 @@ class TestNotesResolveAndTagFilter:
 
         result = runner.invoke(app, ["notes", "--tag", "meeting"])
         assert result.exit_code == 0
-        assert "2 of 3" in result.stdout
-        assert "tag: meeting" in result.stdout
+        assert "2 of 3" in result.stderr
+        assert "tag: meeting" in result.stderr
 
         result = runner.invoke(app, ["notes", "--tag", "meeting,pricing"])
         assert result.exit_code == 0
-        assert "1 of 3" in result.stdout
+        assert "1 of 3" in result.stderr
 
         result = runner.invoke(app, ["notes", "--tag", "nope"])
         assert result.exit_code == 0
-        assert "No notes matching tag 'nope'" in result.stdout
+        assert "No notes matching tag 'nope'" in result.stderr
 
     def test_tag_with_subcommand_rejected(self, tmp_path, monkeypatch):
         _write_note(tmp_path, "a-2026-04-20", "A", "x")
@@ -321,7 +327,7 @@ class TestNotesResolveAndTagFilter:
 
         result = runner.invoke(app, ["notes", "--tag", "meeting", "view", "a"])
         assert result.exit_code == 2
-        assert "--tag is only valid when listing notes" in result.stdout
+        assert "--tag is only valid when listing notes" in result.stderr
 
     def test_unknown_id(self, tmp_path, monkeypatch):
         _write_note(tmp_path, "a-2026-04-20", "A", "x")
@@ -329,7 +335,7 @@ class TestNotesResolveAndTagFilter:
 
         result = runner.invoke(app, ["notes", "view", "missing"])
         assert result.exit_code == 1
-        assert "no note matching 'missing'" in result.stdout
+        assert "no note matching 'missing'" in result.stderr
 
     def test_ambiguous_prefix(self, tmp_path, monkeypatch):
         _write_note(tmp_path, "standup-monday-2026-04-20", "M", "x")
@@ -338,7 +344,7 @@ class TestNotesResolveAndTagFilter:
 
         result = runner.invoke(app, ["notes", "view", "standup"])
         assert result.exit_code == 1
-        assert "matches 2 notes" in result.stdout
+        assert "matches 2 notes" in result.stderr
 
     def test_resolve_full_id(self, tmp_path, monkeypatch):
         import chirp.cli
@@ -424,7 +430,8 @@ class TestNotesDelete:
 
         result = runner.invoke(app, ["notes", "delete", "doomed", "--yes"])
         assert result.exit_code == 0
-        assert "Deleted" in result.stdout
+        # Status message is a diagnostic → stderr (AC-1).
+        assert "deleted" in result.stderr.lower()
         assert not (tmp_path / "doomed-2026-04-20").exists()
         assert "doomed-2026-04-20/notes.md" in captured.get("dropped", "")
 
@@ -435,7 +442,7 @@ class TestNotesDelete:
 
         result = runner.invoke(app, ["notes", "delete", "safe"], input="n\n")
         assert result.exit_code == 0
-        assert "Deletion cancelled" in result.stdout
+        assert "deletion cancelled" in result.stderr.lower()
         assert (tmp_path / "safe-2026-04-20").exists()
 
 
@@ -544,6 +551,7 @@ class TestNotesReviewPatches:
 
         result = runner.invoke(app, ["notes"])
         assert result.exit_code == 0
+        # The table (and its em-dash tag cell) is data → stdout.
         assert "—" in result.stdout
 
     def test_empty_note_id_reports_not_found(self, tmp_path, monkeypatch):
@@ -552,8 +560,8 @@ class TestNotesReviewPatches:
 
         result = runner.invoke(app, ["notes", "view", ""])
         assert result.exit_code == 1
-        assert "no note matching" in result.stdout
-        assert "matches" not in result.stdout
+        assert "no note matching" in result.stderr
+        assert "matches" not in result.stderr
 
     def test_delete_handles_rmtree_error(self, tmp_path, monkeypatch):
         import shutil
@@ -569,7 +577,7 @@ class TestNotesReviewPatches:
         result = runner.invoke(app, ["notes", "delete", "doomed", "--yes"])
         assert result.exit_code == 1
         # Rich wraps long lines so flatten whitespace before asserting.
-        flat = " ".join(result.stdout.split())
+        flat = " ".join(result.stderr.split())
         assert "failed to delete" in flat
         assert "simulated permission denied" in flat
 
@@ -626,5 +634,5 @@ class TestTranscribeSurfacesModelLoadError:
         result = CliRunner().invoke(chirp.cli.app, ["transcribe"])
 
         assert result.exit_code == 1
-        flat = " ".join(result.stdout.split())
+        flat = " ".join(result.stderr.split())
         assert "Could not download or load the Whisper model" in flat

--- a/tests/test_cli_conformance.py
+++ b/tests/test_cli_conformance.py
@@ -1,0 +1,615 @@
+"""Story 8.5 — CLI/TUI best-practices conformance tests.
+
+Covers the stdout/stderr split, ``--json`` schemas, ``--version``, prompt
+escape, NO_COLOR, exit-code constants, editor help, completion, AppleScript
+escaping, the ``ask`` dual-input warning, and the extractable terminal-restore
+seam. TTY/termios signal paths are verified manually (repo memory: no unit tests
+for OS-touching TTY code), but the restore seam is unit-tested directly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import tomli_w
+from typer.testing import CliRunner
+
+from config.settings import ChirpSettings
+
+
+def _make_settings(tmp_path: Path) -> ChirpSettings:
+    settings = ChirpSettings()
+    settings.directories.notes_root = tmp_path
+    settings.notes_chat.auto_index = False
+    return settings
+
+
+def _write_note(
+    tmp_path: Path,
+    slug: str,
+    title: str,
+    body: str = "body",
+    tags: list[str] | None = None,
+) -> Path:
+    note_dir = tmp_path / slug
+    note_dir.mkdir()
+    notes_path = note_dir / "notes.md"
+    notes_path.write_text(f"# {title}\n\n{body}\n", encoding="utf-8")
+    with (note_dir / "meta.toml").open("wb") as fh:
+        tomli_w.dump(
+            {"title": title, "date": "2026-04-20T09:00:00", "tags": tags or []}, fh
+        )
+    return notes_path
+
+
+def _runner(tmp_path, monkeypatch):
+    import chirp.cli
+
+    monkeypatch.setattr("chirp.cli.get_settings", lambda: _make_settings(tmp_path))
+    return CliRunner(), chirp.cli.app
+
+
+def typer_main_command(app):
+    import typer.main
+
+    return typer.main.get_command(app)
+
+
+# ---------------------------------------------------------------------------
+# AC-3 — --version / -V and about --plain
+# ---------------------------------------------------------------------------
+
+
+class TestVersion:
+    def test_version_flag_prints_one_line_and_exits_0(self):
+        import chirp.cli
+        from chirp.about import _installed_version
+
+        result = CliRunner().invoke(chirp.cli.app, ["--version"])
+        assert result.exit_code == 0
+        line = result.stdout.strip()
+        assert line == f"chirp {_installed_version()}"
+
+    def test_short_version_flag_is_identical(self):
+        import chirp.cli
+
+        long_ = CliRunner().invoke(chirp.cli.app, ["--version"])
+        short = CliRunner().invoke(chirp.cli.app, ["-V"])
+        assert short.exit_code == 0
+        assert short.stdout.strip() == long_.stdout.strip()
+
+    def test_help_lists_version(self):
+        import chirp.cli
+
+        result = CliRunner().invoke(chirp.cli.app, ["--help"])
+        assert "--version" in result.stdout
+
+    def test_about_plain_renders_static_panel(self, tmp_path, monkeypatch):
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["about", "--plain"])
+        assert result.exit_code == 0
+        # The static panel carries the credits line; no spinner frames.
+        assert "Colby Timm" in result.stdout
+        assert "⠋" not in result.stdout
+        assert "⠙" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# AC-1 — stdout/stderr split (search)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchStreamSplit:
+    def _seed(self, tmp_path):
+        note_dir = tmp_path / "pricing-call-2026-04-20"
+        note_dir.mkdir()
+        (note_dir / "transcript.txt").write_text(
+            "we discussed pricing at length", encoding="utf-8"
+        )
+        (note_dir / "notes.md").write_text(
+            "# Pricing Call\n\npricing was the topic\n", encoding="utf-8"
+        )
+        with (note_dir / "meta.toml").open("wb") as fh:
+            tomli_w.dump(
+                {
+                    "title": "Pricing Call",
+                    "date": "2026-04-20T09:00:00",
+                    "tags": [],
+                },
+                fh,
+            )
+
+    def test_table_to_stdout_header_to_stderr(self, tmp_path, monkeypatch):
+        self._seed(tmp_path)
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["search", "pricing"])
+        assert result.exit_code == 0
+        # Excerpt/table data on stdout; preamble + footer hints on stderr.
+        assert "Pricing Call" in result.stdout
+        assert "searching 1 note for" in result.stderr
+        assert "chirp ask" in result.stderr
+        assert "searching 1 note for" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# AC-2 — --json for notes / ask / search (raw, no Rich chrome)
+# ---------------------------------------------------------------------------
+
+
+class TestNotesJson:
+    def test_notes_json_schema_and_no_box(self, tmp_path, monkeypatch):
+        _write_note(tmp_path, "alpha-2026-04-20", "Alpha", tags=["x"])
+        _write_note(tmp_path, "beta-2026-04-21", "Beta")
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["notes", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+        assert len(payload) == 2
+        for row in payload:
+            assert set(row) == {"id", "slug", "title", "date", "tags", "notes_path"}
+        # newest-first id == 1 is the most recent note (beta).
+        assert payload[0]["id"] == 1
+        assert payload[0]["slug"] == "beta-2026-04-21"
+        # No Rich box-drawing characters in the JSON stream.
+        assert "─" not in result.stdout
+        assert "│" not in result.stdout
+
+    def test_notes_json_empty_is_empty_array(self, tmp_path, monkeypatch):
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["notes", "--json"])
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == []
+
+
+class TestAskJson:
+    def _patch_one_shot(self, monkeypatch):
+        import notes_chat.cli as nc_cli
+
+        monkeypatch.setattr(nc_cli, "get_notes_config", lambda: MagicMock())
+
+        def fake_retrieve(config, question, when_filter=None):
+            return {
+                "success": True,
+                "context": "ctx",
+                "sources": ["note #1"],
+                "retrieved_ids": ["c1"],
+            }
+
+        def fake_generate(config, question, context):
+            return {"success": True, "answer": "the decision was X"}
+
+        monkeypatch.setattr("notes_chat.retrieval.retrieve_context", fake_retrieve)
+        monkeypatch.setattr("notes_chat.prompting.generate_answer", fake_generate)
+        monkeypatch.setattr("notes_chat.cache.get_cached_answer", lambda *a: None)
+        monkeypatch.setattr("notes_chat.cache.cache_answer", lambda *a: None)
+
+    def test_ask_json_object_schema(self, monkeypatch):
+        import chirp.cli
+
+        self._patch_one_shot(monkeypatch)
+        result = CliRunner().invoke(
+            chirp.cli.app, ["ask", "--json", "what did we decide?"]
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert set(payload) == {"question", "answer", "sources"}
+        assert payload["question"] == "what did we decide?"
+        assert payload["answer"] == "the decision was X"
+        assert payload["sources"] == ["note #1"]
+
+    def test_ask_json_never_instantiates_markdown(self, monkeypatch):
+        import chirp.cli
+
+        self._patch_one_shot(monkeypatch)
+        with patch("rich.markdown.Markdown") as md:
+            result = CliRunner().invoke(chirp.cli.app, ["ask", "--json", "q?"])
+        assert result.exit_code == 0
+        md.assert_not_called()
+
+
+class TestSearchJsonRaw:
+    def _seed(self, tmp_path):
+        note_dir = tmp_path / "pricing-2026-04-20"
+        note_dir.mkdir()
+        (note_dir / "notes.md").write_text("# P\n\npricing\n", encoding="utf-8")
+        with (note_dir / "meta.toml").open("wb") as fh:
+            tomli_w.dump({"title": "P", "date": "2026-04-20T09:00:00", "tags": []}, fh)
+
+    def test_search_json_is_raw_parseable(self, tmp_path, monkeypatch):
+        self._seed(tmp_path)
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["search", "--json", "pricing"])
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["query"] == "pricing"
+        assert isinstance(payload["matches"], list)
+        # Nothing on stderr — JSON path emits no chrome.
+        assert result.stderr == ""
+
+
+# ---------------------------------------------------------------------------
+# AC-4 — uniform prompt escape in record
+# ---------------------------------------------------------------------------
+
+
+class TestPromptEscape:
+    @pytest.mark.parametrize("exc", [KeyboardInterrupt, EOFError])
+    def test_prompt_timeframe_aborts(self, exc, monkeypatch):
+        import typer
+
+        import chirp.cli
+
+        monkeypatch.setattr(chirp.cli.console, "input", MagicMock(side_effect=exc))
+        with pytest.raises(typer.Exit) as caught:
+            chirp.cli._prompt_timeframe()
+        assert caught.value.exit_code == chirp.cli.exit_codes.RUNTIME_ERROR
+
+    @pytest.mark.parametrize("exc", [KeyboardInterrupt, EOFError])
+    def test_prompt_tags_aborts(self, exc, monkeypatch):
+        import typer
+
+        import chirp.cli
+
+        monkeypatch.setattr(chirp.cli.console, "input", MagicMock(side_effect=exc))
+        with pytest.raises(typer.Exit) as caught:
+            chirp.cli._prompt_tags()
+        assert caught.value.exit_code == chirp.cli.exit_codes.RUNTIME_ERROR
+
+    def test_prompt_timeframe_empty_enter_skips(self, monkeypatch):
+        import chirp.cli
+
+        monkeypatch.setattr(chirp.cli.console, "input", MagicMock(return_value="  "))
+        assert chirp.cli._prompt_timeframe() is None
+
+    def test_prompt_tags_empty_enter_skips(self, monkeypatch):
+        import chirp.cli
+
+        monkeypatch.setattr(chirp.cli.console, "input", MagicMock(return_value=""))
+        assert chirp.cli._prompt_tags() == []
+
+
+# ---------------------------------------------------------------------------
+# AC-5 — NO_COLOR and --no-color
+# ---------------------------------------------------------------------------
+
+
+class TestNoColor:
+    def test_no_color_env_strips_ansi(self, tmp_path, monkeypatch):
+        _write_note(tmp_path, "alpha-2026-04-20", "Alpha")
+        monkeypatch.setenv("NO_COLOR", "1")
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["notes"])
+        assert result.exit_code == 0
+        assert "\x1b[" not in result.stdout
+        assert "\x1b[" not in result.stderr
+
+    def test_no_color_flag_strips_ansi(self, tmp_path, monkeypatch):
+        _write_note(tmp_path, "alpha-2026-04-20", "Alpha")
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["--no-color", "notes"])
+        assert result.exit_code == 0
+        assert "\x1b[" not in result.stdout
+        assert "\x1b[" not in result.stderr
+
+    def test_editor_render_cache_honors_no_color(self, monkeypatch):
+        from notes.note_editor import ManualNoteEditor
+
+        monkeypatch.setenv("NO_COLOR", "1")
+        editor = ManualNoteEditor("T", "# Heading\n\n**bold** text\n")
+        editor._ensure_view_cache(80)
+        # Width measurement still works (display lines built), but no styled
+        # segments carry color when NO_COLOR is in effect.
+        assert editor._display_lines
+        for display in editor._display_lines:
+            for segment in display.segments:
+                if segment.style is not None:
+                    assert segment.style.color is None
+
+
+# ---------------------------------------------------------------------------
+# AC-6 — centralized exit-code constants
+# ---------------------------------------------------------------------------
+
+
+class TestExitCodes:
+    def test_constants_match_documented_table(self):
+        from chirp import exit_codes
+
+        assert exit_codes.SUCCESS == 0
+        assert exit_codes.RUNTIME_ERROR == 1
+        assert exit_codes.USAGE_ERROR == 2
+        assert exit_codes.DAEMON_UNREACHABLE == 3
+        assert exit_codes.MODEL_LOAD_FAILED == 4
+        assert exit_codes.MODEL_NOT_FOUND == 5
+        assert exit_codes.NOT_APPLE_SILICON == 7
+
+    def test_init_flow_uses_central_not_apple_silicon(self):
+        from chirp import exit_codes, init_flow
+
+        assert init_flow.EXIT_NOT_APPLE_SILICON == exit_codes.NOT_APPLE_SILICON
+
+    def test_search_usage_error_is_2(self, tmp_path, monkeypatch):
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["search", "   "])
+        assert result.exit_code == 2
+
+    def test_notes_view_missing_is_1(self, tmp_path, monkeypatch):
+        _write_note(tmp_path, "alpha-2026-04-20", "Alpha")
+        runner, app = _runner(tmp_path, monkeypatch)
+        result = runner.invoke(app, ["notes", "view", "nope"])
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# AC-7 — extractable terminal-restore seam
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalRestore:
+    def test_restore_terminal_calls_tcsetattr_and_show_cursor(self, monkeypatch):
+        import chirp.cli
+
+        calls = {"tcsetattr": False, "cursor": None}
+
+        fake_termios = MagicMock()
+        fake_termios.TCSADRAIN = 1
+        fake_termios.error = Exception
+
+        def fake_tcsetattr(fd, when, settings):
+            calls["tcsetattr"] = True
+
+        fake_termios.tcsetattr = fake_tcsetattr
+        monkeypatch.setitem(__import__("sys").modules, "termios", fake_termios)
+        monkeypatch.setattr(
+            chirp.cli.console,
+            "show_cursor",
+            lambda visible: calls.__setitem__("cursor", visible),
+        )
+
+        chirp.cli._restore_terminal(0, object())
+        assert calls["tcsetattr"] is True
+        assert calls["cursor"] is True
+
+    def test_restore_terminal_noop_without_settings(self, monkeypatch):
+        import chirp.cli
+
+        cursor = {"shown": None}
+        monkeypatch.setattr(
+            chirp.cli.console,
+            "show_cursor",
+            lambda visible: cursor.__setitem__("shown", visible),
+        )
+        chirp.cli._restore_terminal(None, None)
+        # Still shows the cursor even when there were no termios settings.
+        assert cursor["shown"] is True
+
+
+# ---------------------------------------------------------------------------
+# AC-8 — note editor help / keybinding hint
+# ---------------------------------------------------------------------------
+
+
+class TestEditorHelp:
+    def test_keybinding_hint_constant_present(self):
+        from notes.note_editor import KEYBINDING_HINT
+
+        assert ":wq save" in KEYBINDING_HINT
+        assert ":help" in KEYBINDING_HINT
+
+    def test_question_mark_opens_help_in_view(self):
+        from notes.note_editor import ManualNoteEditor
+
+        editor = ManualNoteEditor("T", "body\n")
+        editor.mode = "view"
+        editor._handle_view_mode("?")
+        assert editor.show_help is True
+
+    def test_help_command_opens_overlay(self):
+        from notes.note_editor import ManualNoteEditor
+
+        editor = ManualNoteEditor("T", "body\n")
+        editor.command_buffer = ":help"
+        result = editor._execute_command()
+        assert result is False
+        assert editor.show_help is True
+
+    def test_unknown_command_points_at_help(self):
+        from notes.note_editor import ManualNoteEditor
+
+        editor = ManualNoteEditor("T", "body\n")
+        editor.command_buffer = ":frobnicate"
+        editor._execute_command()
+        assert ":help" in editor.message
+
+
+class TestExternalEditorHatch:
+    def test_external_editor_command_prefers_visual(self, monkeypatch):
+        import chirp.cli
+
+        monkeypatch.setenv("VISUAL", "code --wait")
+        monkeypatch.setenv("EDITOR", "nano")
+        assert chirp.cli._external_editor_command() == "code --wait"
+
+    def test_external_editor_command_falls_back_to_editor(self, monkeypatch):
+        import chirp.cli
+
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.setenv("EDITOR", "nano")
+        assert chirp.cli._external_editor_command() == "nano"
+
+    def test_external_editor_command_none_when_unset(self, monkeypatch):
+        import chirp.cli
+
+        monkeypatch.delenv("VISUAL", raising=False)
+        monkeypatch.delenv("EDITOR", raising=False)
+        assert chirp.cli._external_editor_command() is None
+
+    def test_edit_in_external_editor_passes_notes_path(self, tmp_path, monkeypatch):
+        import chirp.cli
+
+        notes_path = tmp_path / "notes.md"
+        notes_path.write_text("# x\n", encoding="utf-8")
+        captured = {}
+
+        def fake_run(argv, check=False):
+            captured["argv"] = argv
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        ok = chirp.cli._edit_in_external_editor(notes_path, "nano")
+        assert ok is True
+        assert captured["argv"] == ["nano", str(notes_path)]
+
+    def test_edit_in_external_editor_handles_launch_failure(
+        self, tmp_path, monkeypatch
+    ):
+        import chirp.cli
+
+        notes_path = tmp_path / "notes.md"
+        notes_path.write_text("# x\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "subprocess.run", MagicMock(side_effect=OSError("no such editor"))
+        )
+        assert chirp.cli._edit_in_external_editor(notes_path, "ghost-editor") is False
+
+
+# ---------------------------------------------------------------------------
+# AC-9 — shell completion enabled (alias completer reachable)
+# ---------------------------------------------------------------------------
+
+
+class TestCompletion:
+    def test_completion_meta_commands_hidden_but_present(self):
+        import chirp.cli
+
+        result = CliRunner().invoke(chirp.cli.app, ["--help"])
+        assert result.exit_code == 0
+        # Hidden from the 7-command surface...
+        assert "--install-completion" not in result.stdout
+        assert "--show-completion" not in result.stdout
+
+    def test_completion_enabled_meta_options_exist_but_hidden(self):
+        import click
+
+        import chirp.cli
+
+        command = typer_main_command(chirp.cli.app)
+        ctx = click.Context(command)
+        params = command.get_params(ctx)
+        meta = {
+            opt
+            for param in params
+            for opt in getattr(param, "opts", [])
+            if opt in {"--install-completion", "--show-completion"}
+        }
+        # Completion is enabled, so both meta-options are present on the app...
+        assert meta == {"--install-completion", "--show-completion"}
+        # ...but every one of them is hidden (kept off the 7-command surface).
+        for param in params:
+            if set(getattr(param, "opts", [])) & meta:
+                assert param.hidden is True
+
+    def test_show_completion_is_not_an_unknown_option(self):
+        import chirp.cli
+
+        # add_completion=True means --show-completion is a recognized option
+        # (the generated completer is reachable), not an unknown-option error.
+        result = CliRunner().invoke(chirp.cli.app, ["--show-completion"])
+        assert "No such option" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC-10 — AppleScript escaping
+# ---------------------------------------------------------------------------
+
+
+class TestAppleScriptEscaping:
+    def test_escape_helper_escapes_quotes_and_backslashes(self):
+        from utils.popup_manager import _escape_applescript
+
+        assert _escape_applescript('say "hi"') == 'say \\"hi\\"'
+        assert _escape_applescript("a\\b") == "a\\\\b"
+
+    def test_notification_script_has_escaped_args(self):
+        from utils.popup_manager import PopupManager
+
+        with patch("utils.popup_manager.platform.system", return_value="Darwin"):
+            popup = PopupManager()
+        with patch("utils.popup_manager.subprocess.run") as run:
+            run.return_value = MagicMock()
+            popup._show_macos_notification('Ti"tle', 'mes"sage\\x')
+            script = run.call_args[0][0][2]
+        # The raw unescaped quote must never appear bare in the literal.
+        assert '\\"' in script
+        assert 'mes\\"sage' in script
+
+    def test_dialog_script_has_escaped_args(self):
+        from utils.popup_manager import PopupManager
+
+        with patch("utils.popup_manager.platform.system", return_value="Darwin"):
+            popup = PopupManager()
+        mock_result = MagicMock()
+        mock_result.stdout = "button returned:Yes"
+        with patch(
+            "utils.popup_manager.subprocess.run", return_value=mock_result
+        ) as run:
+            popup.ask_yes_no('Ti"tle', 'ques"tion')
+            script = run.call_args[0][0][2]
+        assert 'ques\\"tion' in script
+
+
+# ---------------------------------------------------------------------------
+# AC-11 — ask dual-input conflict warning
+# ---------------------------------------------------------------------------
+
+
+class TestAskDualInput:
+    def _patch(self, monkeypatch):
+        import notes_chat.cli as nc_cli
+
+        monkeypatch.setattr(nc_cli, "get_notes_config", lambda: MagicMock())
+
+        def fake_retrieve(config, question, when_filter=None):
+            return {
+                "success": True,
+                "context": "ctx",
+                "sources": [],
+                "retrieved_ids": ["c1"],
+            }
+
+        def fake_generate(config, question, context):
+            return {"success": True, "answer": f"answered: {question}"}
+
+        monkeypatch.setattr("notes_chat.retrieval.retrieve_context", fake_retrieve)
+        monkeypatch.setattr("notes_chat.prompting.generate_answer", fake_generate)
+        monkeypatch.setattr("notes_chat.cache.get_cached_answer", lambda *a: None)
+        monkeypatch.setattr("notes_chat.cache.cache_answer", lambda *a: None)
+
+    def test_both_inputs_warns_and_uses_positional(self, monkeypatch):
+        import chirp.cli
+
+        self._patch(monkeypatch)
+        result = CliRunner().invoke(
+            chirp.cli.app,
+            ["ask", "--json", "positional-q", "--question", "option-q"],
+        )
+        assert result.exit_code == 0
+        # The warning lands on stderr; the positional wins.
+        assert "using the positional" in result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["question"] == "positional-q"
+
+    def test_option_alone_still_works(self, monkeypatch):
+        import chirp.cli
+
+        self._patch(monkeypatch)
+        result = CliRunner().invoke(
+            chirp.cli.app, ["ask", "--json", "--question", "option-q"]
+        )
+        assert result.exit_code == 0
+        assert "using the positional" not in result.stderr
+        assert json.loads(result.stdout)["question"] == "option-q"

--- a/utils/popup_manager.py
+++ b/utils/popup_manager.py
@@ -2,6 +2,16 @@ import platform
 import subprocess
 
 
+def _escape_applescript(value: str) -> str:
+    """Escape a string for safe interpolation inside an AppleScript "..." literal.
+
+    Backslashes and double quotes are the two characters that break (or could be
+    used to inject into) a quoted AppleScript string, so both are backslash-
+    escaped. Backslash must be escaped first to avoid double-escaping.
+    """
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 class PopupManager:
     def __init__(self):
         self.is_macos = platform.system() == "Darwin"
@@ -41,8 +51,10 @@ class PopupManager:
             return False
 
     def _show_macos_notification(self, title: str, message: str) -> bool:
+        safe_message = _escape_applescript(message)
+        safe_title = _escape_applescript(title)
         applescript = f"""
-        display notification "{message}" with title "{title}"
+        display notification "{safe_message}" with title "{safe_title}"
         """
         try:
             subprocess.run(
@@ -65,8 +77,10 @@ class PopupManager:
         if not self.is_macos:
             return None
 
+        safe_question = _escape_applescript(question)
+        safe_title = _escape_applescript(title)
         applescript = f"""
-        display dialog "{question}" with title "{title}" buttons {{"No", "Yes"}} default button "Yes"
+        display dialog "{safe_question}" with title "{safe_title}" buttons {{"No", "Yes"}} default button "Yes"
         """
         try:
             result = subprocess.run(


### PR DESCRIPTION
Part of **EPIC-PRODUCTION-HARDENING** (epic 8). Merges into `epic/8-production-hardening`.

Propagates the patterns the newer `llm/cli` subsystem already follows to the older first-party commands, per clig.dev/TUI conventions.

### Changes
- **stdout/stderr discipline:** `record`/`transcribe`/`notes`/`ask`/`search` now put data on stdout and diagnostics/hints/errors/prompts on stderr (shared consoles re-exported from `llm/cli/_console.py`).
- **`--json`** for `notes` and `ask` (raw via `sys.stdout`, never through Rich); `ask --json --dry-run` emits a JSON object too.
- **`--version`/`-V`** top-level flag; `about --plain` for a static, scriptable version panel.
- **Uniform Ctrl-C/EOF**: every `record` prompt aborts (no more silently starting a recording at the tags prompt).
- **`NO_COLOR` + `--no-color`/`--plain`** honored; `note_editor` no longer forces color.
- **Centralized exit codes** (`chirp/exit_codes.py`) with a documented table, applied uniformly (usage=2 vs runtime preserved).
- **SIGTERM handler + terminal restore** for `record`; resize-safe waveform. **Editor**: `:help`/`?` overlay + persistent keybinding hint + opt-in `$EDITOR`/`$VISUAL` handoff (built-in stays default).
- Shared glyph constants + one voice; **shell completion enabled** with the two completion meta-commands hidden (the alias completer is now reachable); AppleScript args escaped; `ask` warns on positional-vs-`-q` conflict.

### Verification
- `make check` clean; full suite **1561 passed** (independently re-run after restoring Full Disk Access — the mid-review FDA lockout had blocked the reviewer's own gate run). Live `chirp --help`/`--version`/`--json`/`NO_COLOR` outputs verified.
- Subagent review: APPROVE-WITH-NITS (no must-fix). Addressed: `ask --json --dry-run` now emits JSON (was empty stdout); exit-code doc note for the intentional Whisper-load 1-vs-4 difference.

Story spec + Dev Agent Record: `_bmad-output/planning-artifacts/epic-production-hardening/stories/8.5-cli-tui-best-practices-conformance.md`