### PR TITLE
Story 8.6 — Config resilience & CI/release quality gates

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -20,8 +20,12 @@ jobs:
       uses: ./.github/actions/quality-checks
 
     - name: Run tests
+      # Bare `--cov` uses the full [tool.coverage.run] source set in
+      # pyproject.toml (all 10 packages), matching shared-build-and-test.yaml so
+      # both gates measure the same surface. The fail_under floor lives in
+      # pyproject [tool.coverage.report].
       run: |
-        uv run pytest tests/ -v --cov=chirp --cov=config --cov=recorder --cov=transcriber --cov=notes --cov=utils --cov-report=xml
+        uv run pytest tests/ -v --cov --cov-report=xml --cov-report=term
 
     - name: Build package
       # Wheel-only distribution (see shared-build-and-test.yaml); never build an sdist.

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test-file: ## Run a single test file (FILE=tests/test_settings.py)
 test-match: ## Run tests matching a pattern (PATTERN=slugify)
 	uv run pytest -k "$(PATTERN)"
 
-test-coverage: ## Run tests with coverage report
+test-coverage: ## Run tests with coverage report (fails below the pyproject fail_under floor)
 	uv run pytest --cov --cov-report=html --cov-report=term
 
 test-failed: ## Run only failed tests from last run
@@ -120,7 +120,7 @@ validate: ## Validate code compiles and imports work
 # Quality check combination
 check: validate style-check type-check ## Run all quality checks (excluding tests)
 
-ci: lint format-check type-check test ## Run CI checks (lint, format, type-check, test)
+ci: lint format-check type-check test-coverage ## Run CI checks (lint, format, type-check, test with coverage floor)
 
 # Dependency management
 verify-deps: ## Verify dependencies via chirp init --recheck

--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.6-config-resilience-and-ci-quality-gates.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.6-config-resilience-and-ci-quality-gates.md
@@ -180,13 +180,41 @@ Files in scope:
 
 ### Agent Model Used
 
-{{agent_model_name_version}}
+claude-opus-4-8
 
 ### Debug Log References
 
+- Measured current TOTAL coverage on this branch (8.5 merged): **84%** (`uv run pytest --cov`; `coverage report` TOTAL 9370 stmts / 1534 miss = 83.63% on the floor-check run). `chirp/cli.py` now **64%** (up from the audit-era 55%), `config/settings.py` 94%, `chirp/init_flow.py` 97%.
+- Floor verification: `uv run coverage report --fail-under=99` → exit 2 (fails on regression); `--fail-under=82` → exit 0 (passes). `make test-coverage` printed "Required test coverage of 82.0% reached. Total coverage: 83.63%".
+
 ### Completion Notes List
 
+- **AC-1 (tolerant load):** DONE. `ChirpSettings.load_from_file` now wraps validation in `_validate_tolerantly`, which iteratively drops the fields named by `ValidationError.errors()[*]["loc"]` and re-validates, falling back to `cls()` only if recovery cannot converge. Each dropped field emits a STDERR warning naming `section.field`, the ignored value, and the config path. STDOUT stays clean (asserted in tests). `_coerce_non_table_init` left intact. **Review follow-up (2026-06-16):** also wrapped the preceding `tomllib.load` in `try/except tomllib.TOMLDecodeError` — entirely-malformed TOML (stray bracket / unterminated string) previously raised a raw `TOMLDecodeError` out of `get_settings()`, bricking every command (the exact UX this story kills). Now emits the same STDERR warning style (path + parse error) and falls back to `cls()`. Covered by `test_invalid_toml_does_not_block_load` (fails before the wrap with a raw `TOMLDecodeError`; passes after).
+- **AC-2 (per-field recovery):** DONE. `_drop_field` removes only the offending key from its section dict, preserving sibling valid fields. Test `test_malformed_field_preserves_other_valid_fields` confirms bad `notes_chat.k` → default 10 while custom `directories.notes_root` survives.
+- **AC-3 (schema_version + warns):** DONE. Added `SUPPORTED_CONFIG_SCHEMA_VERSION = 1` and `schema_version: int = SUPPORTED_CONFIG_SCHEMA_VERSION` on `ChirpSettings` (written by `save_to_file` via `model_dump`). Missing version → defaults to 1 and loads; unknown version (999) → STDERR warn, no crash, best-effort continue; unknown top-level keys → STDERR warn (compares parsed-TOML keys to `model_fields`). Config WARNS-and-continues — does NOT raise like `llm/registry.py` (per the locked decision). **Review nit fix (2026-06-16):** the unknown-version warning now fires only for a well-formed `int` version (`isinstance(version, int)`), so a bad-TYPE `schema_version` (e.g. `"v1"`) is handled solely by the per-field-drop path instead of double-warning. Covered by `test_bad_type_schema_version_warns_once`.
+- **AC-4 (coverage floor):** DONE. Added `fail_under = 82` to `[tool.coverage.report]`. Measured TOTAL is 84% / 83.63%; chose **82** (safely below current, tighter than the conservative 80) to absorb MLX `# pragma: no cover` + platform-skipped-audio variance while catching real regressions. Verified it fails (exit 2) above-threshold and passes (exit 0) at 82.
+- **AC-5 (align --cov sets):** DONE. `main-build.yml` test step changed from hand-listed `--cov=chirp …` (omitted chirpd/llm/notes_chat/audio_capture) to bare `--cov` + `--cov-report=xml --cov-report=term`. `shared-build-and-test.yaml` already bare `--cov` — unchanged. Both now read the full 10-package `[tool.coverage.run] source`. Guarded by `test_both_gating_workflows_use_bare_cov`.
+- **AC-6 (floor honored locally):** DONE. `make ci` now runs `test-coverage` (was bare `test`, no coverage) so local CI parity exercises the floor. `test-coverage` help text notes the floor.
+- **AC-7 (mypy staged):** DONE. Added `warn_unused_ignores = true` + `no_implicit_optional = true`; left `disallow_untyped_defs = false` and `ignore_missing_imports = true`. `warn_unused_ignores` flagged two now-redundant `# type: ignore` comments (`chirpd/logging_setup.py:151`, `notes/note_editor.py:27`) — removed both; `uv run mypy` passes clean (73 files). mypy stays on both gating paths via the `quality-checks` composite action (pr-checks + main-build). Stage-2 per-module `disallow_untyped_defs` overrides for `chirp`/`llm`/`chirpd`/registry remain a documented FOLLOW-UP (not done here).
+- **AC-8 (cli.py floor coordination):** DONE via option (a) — rely on the repo-wide `fail_under`. cli.py rose to 64% (no regression vs 55%). FOLLOW-UP: introduce a `chirp/cli.py`-specific floor and ratchet the repo floor toward 84% once coverage stabilizes.
+- **AC-9 (Renovate ML-dep exclusion):** DONE. Added a `packageRules` entry matching `["mlx-lm", "mlx-embeddings"]` with `automerge: false` + `platformAutomerge: false` and a `description` citing the `# pragma: no cover` inference path. gh-aw carve-out preserved. `huggingface_hub` (a `>=` constraint, not exact-pinned) deliberately NOT included.
+- **AC-10 (stale artifacts):** DONE. Removed `htmlcov/` (was dated 2025-09-30) and `.coverage`; both stay gitignored (`.gitignore:39,42`) and untracked. `make clean` already removes both — verified.
+- **AC-11 (OPTIONAL real-MLX smoke):** SKIPPED (deliberately, per "ship only if cheap"). The backend's real path requires a HF model download plus driving the async `stream_generate`/`embed` surface (asyncio.Event, usage_out dict, handle lifecycle) — meaningful complexity, not low-effort. The story permits skipping; the AC-9 manual-review gate already mitigates the un-covered-bump risk without it.
+- **AC-12 (quality gates pass):** DONE. `make check` green; full suite green (1573 passed after the review follow-up, +2 tests); new settings + CI-gate tests pass; workflow `--cov` alignment asserted by a parsing test. `make test-coverage` → "Required test coverage of 82.0% reached. Total coverage: 83.66%".
+
 ### File List
+
+- `config/settings.py` — tolerant `load_from_file` (per-field recovery, STDERR warnings), `schema_version` field, `SUPPORTED_CONFIG_SCHEMA_VERSION`, schema-version + unknown-key warnings.
+- `pyproject.toml` — `[tool.coverage.report] fail_under = 82`; mypy `warn_unused_ignores`/`no_implicit_optional`; `pyyaml>=6.0.0` dev dep (used by the new workflow-parsing test).
+- `Makefile` — `ci` runs `test-coverage`; `test-coverage` help notes the floor.
+- `.github/workflows/main-build.yml` — bare `--cov` (full source set) + term report.
+- `renovate.json` — MLX-dep automerge exclusion rule.
+- `chirpd/logging_setup.py` — removed now-redundant `# type: ignore[attr-defined]`.
+- `notes/note_editor.py` — removed now-redundant `# type: ignore[override]`.
+- `tests/test_settings.py` — 8 new cases (malformed value, per-field preservation, unknown/missing schema_version, round-trip, unknown top-level key, invalid-TOML fallback, bad-type schema_version single-warn).
+- `tests/test_ci_quality_gates.py` — NEW: asserts `fail_under` present, both workflows use bare `--cov`, MLX Renovate exclusion, mypy stage-1 flags.
+- `uv.lock` — re-locked for the `pyyaml` dev dep.
+- Deleted untracked artifacts: `htmlcov/`, `.coverage`.
 
 ## Change Log
 

--- a/chirpd/logging_setup.py
+++ b/chirpd/logging_setup.py
@@ -148,7 +148,7 @@ class _RedactionViolationFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         if getattr(record, "_chirp_redaction_checked", False):
             return True
-        record._chirp_redaction_checked = True  # type: ignore[attr-defined]
+        record._chirp_redaction_checked = True
         if getattr(_redaction_guard, "active", False):
             return True
         keys = _forbidden_keys(record)

--- a/config/settings.py
+++ b/config/settings.py
@@ -2,12 +2,16 @@ import os
 import tomllib
 from datetime import datetime
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import tomli_w
 from platformdirs import user_documents_dir
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 from rich.console import Console
+
+SUPPORTED_CONFIG_SCHEMA_VERSION = 1
+
+_MISSING = object()
 
 CHIRP_DAEMON_SOCKET_ENV = "CHIRP_DAEMON_SOCKET"
 CHIRP_MODEL_IDLE_TIMEOUT_ENV = "CHIRP_MODEL_IDLE_TIMEOUT"
@@ -199,6 +203,7 @@ class InitConfig(BaseModel):
 
 
 class ChirpSettings(BaseModel):
+    schema_version: int = SUPPORTED_CONFIG_SCHEMA_VERSION
     directories: DirectoriesConfig = Field(default_factory=DirectoriesConfig)
     models: ModelsConfig = Field(default_factory=ModelsConfig)
     audio: AudioConfig = Field(default_factory=AudioConfig)
@@ -241,10 +246,117 @@ class ChirpSettings(BaseModel):
             console.print(f"[dim]Edit {config_path} to customize settings[/dim]")
             return settings
 
-        with config_path.open("rb") as config_file:
-            config_data = tomllib.load(config_file)
+        warnings = Console(stderr=True)
+        try:
+            with config_path.open("rb") as config_file:
+                config_data = tomllib.load(config_file)
+        except tomllib.TOMLDecodeError as error:
+            cls._emit_warning(
+                warnings,
+                f"Warning: {config_path} is not valid TOML ({error}); falling "
+                "back to default settings. Fix the file or run `chirp init` to "
+                "reset it.",
+            )
+            return cls()
 
-        return cls(**config_data)
+        cls._warn_on_schema_version(config_data, config_path, warnings)
+        cls._warn_on_unknown_top_level_keys(config_data, config_path, warnings)
+        return cls._validate_tolerantly(config_data, config_path, warnings)
+
+    @staticmethod
+    def _emit_warning(console: Console, message: str) -> None:
+        # markup=False + soft_wrap keep file paths and bracketed section names
+        # intact (Rich would treat ``[monitoring]`` as a style tag and wrap long
+        # paths across lines, breaking the user-facing warning).
+        console.print(message, style="yellow", markup=False, soft_wrap=True)
+
+    @classmethod
+    def _warn_on_schema_version(
+        cls, config_data: dict[str, Any], config_path: Path, warnings: Console
+    ) -> None:
+        version = config_data.get("schema_version")
+        # A non-int version is a type error handled by the per-field recovery
+        # path; only warn here on a well-formed but unsupported version number
+        # so a bad type does not double-warn.
+        if isinstance(version, int) and version != SUPPORTED_CONFIG_SCHEMA_VERSION:
+            cls._emit_warning(
+                warnings,
+                f"Warning: {config_path} has schema_version {version!r}, which "
+                f"this chirp does not recognise "
+                f"(supported: {SUPPORTED_CONFIG_SCHEMA_VERSION}). Continuing with "
+                "best-effort defaults; delete the file or run `chirp init` to "
+                "reset it.",
+            )
+
+    @classmethod
+    def _warn_on_unknown_top_level_keys(
+        cls, config_data: dict[str, Any], config_path: Path, warnings: Console
+    ) -> None:
+        unknown_keys = set(config_data) - set(cls.model_fields)
+        for key in sorted(unknown_keys):
+            cls._emit_warning(
+                warnings,
+                f"Warning: unknown config section [{key}] in {config_path} was "
+                "ignored. Check for a typo or a renamed section.",
+            )
+
+    @classmethod
+    def _validate_tolerantly(
+        cls, config_data: dict[str, Any], config_path: Path, warnings: Console
+    ) -> "ChirpSettings":
+        recovered = dict(config_data)
+        for _ in range(len(recovered) + 1):
+            try:
+                return cls(**recovered)
+            except ValidationError as error:
+                dropped = cls._drop_invalid_fields(
+                    recovered, error, config_path, warnings
+                )
+                if not dropped:
+                    break
+
+        cls._emit_warning(
+            warnings,
+            f"Warning: {config_path} could not be fully parsed; falling back to "
+            "default settings.",
+        )
+        return cls()
+
+    @classmethod
+    def _drop_invalid_fields(
+        cls,
+        recovered: dict[str, Any],
+        error: ValidationError,
+        config_path: Path,
+        warnings: Console,
+    ) -> bool:
+        dropped = False
+        for entry in error.errors():
+            location = entry.get("loc", ())
+            if not location:
+                continue
+            field_path = ".".join(str(part) for part in location)
+            section = location[0]
+            if section not in recovered:
+                continue
+            if cls._drop_field(recovered, location):
+                dropped = True
+                cls._emit_warning(
+                    warnings,
+                    f"Warning: config field '{field_path}' in {config_path} is "
+                    f"invalid (value {entry.get('input')!r}); using the default "
+                    "instead.",
+                )
+        return dropped
+
+    @classmethod
+    def _drop_field(cls, recovered: dict[str, Any], location: tuple) -> bool:
+        if len(location) == 1:
+            return recovered.pop(location[0], _MISSING) is not _MISSING
+        parent = recovered.get(location[0])
+        if not isinstance(parent, dict):
+            return recovered.pop(location[0], _MISSING) is not _MISSING
+        return parent.pop(location[1], _MISSING) is not _MISSING
 
     def save_to_file(self, config_path: Path):
         config_path.parent.mkdir(parents=True, exist_ok=True)

--- a/notes/note_editor.py
+++ b/notes/note_editor.py
@@ -24,7 +24,7 @@ class EditorResult:
 class PlainHeading(Heading):
     """Render h1 headings without Rich's default border."""
 
-    def __rich_console__(self, console: Console, options):  # type: ignore[override]
+    def __rich_console__(self, console: Console, options):
         text = self.text
         text.justify = "left"
         yield text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "types-python-dateutil>=2.8.0",
     "codespell>=2.2.0",
     "pre-commit>=3.0.0",
+    "pyyaml>=6.0.0",
 ]
 
 [tool.ruff]
@@ -147,6 +148,12 @@ omit = [
 ]
 
 [tool.coverage.report]
+# Single source of truth for the coverage floor, honored by every path that
+# runs `--cov` + a report (both workflows, `make ci`, `make test-coverage`).
+# Set just below the measured TOTAL (84% with 8.5 landed) to absorb run-to-run
+# variance from the MLX `# pragma: no cover` paths and platform-skipped audio
+# tests. Ratchet toward 84%+ as cli.py coverage continues to rise.
+fail_under = 82
 exclude_lines = [
     "pragma: no cover",
     "def __repr__",
@@ -161,6 +168,13 @@ exclude_lines = [
 python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
+# Staged tightening (story 8.6, stage 1): two cheap flags that add type
+# discipline without churn. `ignore_missing_imports` stays true because
+# MLX/chromadb/silero ship no stubs. Stage 2 (follow-up): per-module
+# `[[tool.mypy.overrides]]` with `disallow_untyped_defs = true` for the new
+# typed surfaces (chirp, llm, chirpd, registry), ratcheting outward.
+warn_unused_ignores = true
+no_implicit_optional = true
 disallow_untyped_defs = false
 ignore_missing_imports = true
 files = ["audio_capture", "chirp", "chirpd", "config", "llm", "notes", "notes_chat", "recorder", "transcriber", "utils"]
@@ -176,4 +190,5 @@ dev = [
     "types-python-dateutil>=2.8.0",
     "codespell>=2.2.0",
     "pre-commit>=3.0.0",
+    "pyyaml>=6.0.0",
 ]

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,15 @@
         "github/gh-aw-actions/**"
       ],
       "enabled": false
+    },
+    {
+      "description": "Exact-pinned MLX deps drive the only real-inference code path, which is `# pragma: no cover` and never exercised by CI's FakeBackend. A green check on a bump proves nothing about real inference, so these require manual review before merge.",
+      "matchPackageNames": [
+        "mlx-lm",
+        "mlx-embeddings"
+      ],
+      "automerge": false,
+      "platformAutomerge": false
     }
   ]
 }

--- a/tests/test_ci_quality_gates.py
+++ b/tests/test_ci_quality_gates.py
@@ -1,0 +1,80 @@
+"""CI/release quality-gate invariants (story 8.6).
+
+Both gating workflows must measure the same coverage surface (the full
+``[tool.coverage.run] source`` set), the coverage floor must live in a single
+source of truth (``pyproject.toml``), and Renovate must not auto-merge the
+exact-pinned MLX deps whose real inference path is never exercised by CI.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _pyproject() -> dict:
+    with (REPO_ROOT / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _pytest_cov_flags(command: str) -> list[str]:
+    return re.findall(r"--cov(?:=[\w./-]+)?(?![\w-])", command)
+
+
+def _run_test_commands(workflow_path: Path) -> list[str]:
+    document = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    commands: list[str] = []
+    for job in document["jobs"].values():
+        for step in job.get("steps", []):
+            run = step.get("run")
+            if run and "pytest" in run and "--cov" in run:
+                commands.append(run)
+    return commands
+
+
+def test_fail_under_is_single_source_of_truth():
+    report = _pyproject()["tool"]["coverage"]["report"]
+    assert "fail_under" in report
+    assert isinstance(report["fail_under"], int)
+    assert report["fail_under"] <= 84
+
+
+def test_both_gating_workflows_use_bare_cov():
+    for workflow in ("main-build.yml", "shared-build-and-test.yaml"):
+        commands = _run_test_commands(WORKFLOWS / workflow)
+        assert commands, f"no pytest --cov step found in {workflow}"
+        for command in commands:
+            flags = _pytest_cov_flags(command)
+            assert flags, f"{workflow} pytest step is missing --cov"
+            assert flags == ["--cov"], (
+                f"{workflow} must use bare --cov (full pyproject source set), "
+                f"not a hand-listed package set: {flags}"
+            )
+
+
+def test_mlx_deps_excluded_from_renovate_automerge():
+    with (REPO_ROOT / "renovate.json").open(encoding="utf-8") as handle:
+        renovate = json.load(handle)
+
+    mlx_rules = [
+        rule
+        for rule in renovate.get("packageRules", [])
+        if {"mlx-lm", "mlx-embeddings"} <= set(rule.get("matchPackageNames", []))
+    ]
+    assert mlx_rules, "renovate.json must have a rule covering the MLX deps"
+    assert all(rule.get("automerge") is False for rule in mlx_rules)
+
+
+def test_mypy_stage_one_flags_present_without_strict_flip():
+    mypy = _pyproject()["tool"]["mypy"]
+    assert mypy["warn_unused_ignores"] is True
+    assert mypy["no_implicit_optional"] is True
+    assert mypy["disallow_untyped_defs"] is False
+    assert mypy["ignore_missing_imports"] is True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,6 +8,7 @@ from config.settings import (
     DEFAULT_INFERENCE_TIMEOUT_SECONDS,
     DEFAULT_MAX_RESIDENT_CHAT,
     DEFAULT_MAX_RESIDENT_EMBED,
+    SUPPORTED_CONFIG_SCHEMA_VERSION,
     ChirpSettings,
     resolve_inference_timeout_seconds,
     resolve_max_resident_chat,
@@ -78,6 +79,102 @@ class TestChirpSettings:
         reloaded = ChirpSettings.load_from_file(config_path)
 
         assert reloaded.init.launch_agent_prompted_at is None
+
+
+class TestTolerantConfigLoad:
+    """AC-1/AC-2/AC-3: a hand-edited config never bricks the CLI at load."""
+
+    def test_malformed_value_does_not_block_load(self, tmp_path, capsys):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            '[monitoring]\nwarning_minutes = "soon"\n', encoding="utf-8"
+        )
+
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert reloaded.monitoring.warning_minutes == 60
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "warning_minutes" in captured.err
+        assert str(config_path) in captured.err
+
+    def test_malformed_field_preserves_other_valid_fields(self, tmp_path, capsys):
+        config_path = tmp_path / "config.toml"
+        custom_root = tmp_path / "my-notes"
+        config_path.write_text(
+            f'[directories]\nnotes_root = "{custom_root}"\n\n[notes_chat]\nk = "ten"\n',
+            encoding="utf-8",
+        )
+
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert reloaded.notes_chat.k == 10
+        assert reloaded.directories.notes_root == custom_root
+        assert "k" in capsys.readouterr().err
+
+    def test_unknown_schema_version_warns_but_loads(self, tmp_path, capsys):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("schema_version = 999\n", encoding="utf-8")
+
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert isinstance(reloaded, ChirpSettings)
+        captured = capsys.readouterr()
+        assert "schema_version" in captured.err
+        assert "999" in captured.err
+
+    def test_missing_schema_version_defaults_to_current(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[monitoring]\nwarning_minutes = 30\n", encoding="utf-8")
+
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert reloaded.schema_version == SUPPORTED_CONFIG_SCHEMA_VERSION
+        assert reloaded.monitoring.warning_minutes == 30
+
+    def test_schema_version_round_trips_through_save(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        ChirpSettings().save_to_file(config_path)
+
+        with config_path.open("rb") as fh:
+            parsed = tomllib.load(fh)
+
+        assert parsed["schema_version"] == SUPPORTED_CONFIG_SCHEMA_VERSION
+
+    def test_unknown_top_level_key_warns(self, tmp_path, capsys):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text("[notez]\nfoo = 1\n", encoding="utf-8")
+
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert isinstance(reloaded, ChirpSettings)
+        assert "notez" in capsys.readouterr().err
+
+    def test_invalid_toml_does_not_block_load(self, tmp_path, capsys):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[monitoring\nwarning_minutes = "', encoding="utf-8")
+
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert isinstance(reloaded, ChirpSettings)
+        assert reloaded.monitoring.warning_minutes == 60
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "not valid TOML" in captured.err
+        assert str(config_path) in captured.err
+
+    def test_bad_type_schema_version_warns_once(self, tmp_path, capsys):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('schema_version = "v1"\n', encoding="utf-8")
+
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert reloaded.schema_version == SUPPORTED_CONFIG_SCHEMA_VERSION
+        warning_lines = [
+            line for line in capsys.readouterr().err.splitlines() if "Warning:" in line
+        ]
+        assert len(warning_lines) == 1
+        assert "does not recognise" not in "\n".join(warning_lines)
 
 
 class TestResolveInferenceTimeout:

--- a/uv.lock
+++ b/uv.lock
@@ -369,6 +369,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "types-python-dateutil" },
 ]
@@ -382,6 +383,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "types-python-dateutil" },
 ]
@@ -407,6 +409,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "python-dateutil", specifier = ">=2.8.0" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "rank-bm25", specifier = ">=0.2.0" },
     { name = "rich", specifier = ">=14.1.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
@@ -426,6 +429,7 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "types-python-dateutil", specifier = ">=2.8.0" },
 ]


### PR DESCRIPTION
Part of **EPIC-PRODUCTION-HARDENING** (epic 8). Final story. Merges into `epic/8-production-hardening`.

### Changes
- **Config can't brick the CLI:** `load_from_file` now tolerates both a bad field *value* (per-field recovery to defaults) **and** malformed TOML — emitting a stderr warning that names the field + config path instead of a `ValidationError`/`TOMLDecodeError` traceback out of `get_settings()`. Added `schema_version` (warn-and-continue, never raises).
- **Coverage is enforced:** `fail_under = 82` in `[tool.coverage.report]` (current total ~84%); `make ci` now runs coverage so local matches gated CI.
- **Both gates measure the same surface:** `main-build.yml` switched to bare `--cov` (full `[tool.coverage.run]` source set), matching the PR path — no more chirpd/llm/notes_chat/audio_capture omission.
- **mypy staged tightening:** `warn_unused_ignores` + `no_implicit_optional` (removed 2 now-redundant `# type: ignore`s); strict flip deferred to a documented follow-up.
- **Renovate** excludes `mlx-lm`/`mlx-embeddings` (the only `# pragma: no cover` path) from automerge.
- Removed stale `htmlcov/`/`.coverage`; `make clean` covers them.

### Verification
- `make check` clean; `make test-coverage` **1573 passed**, "Required test coverage of 82.0% reached. Total coverage: 83.66%" (floor enforcement confirmed). New tests: malformed-value + malformed-TOML keep the CLI running with a warning; schema_version round-trip; a YAML-parsing test asserting both workflows' `--cov` set + the `fail_under`/MLX-rule/mypy flags.
- Subagent review: APPROVE-WITH-NITS → addressed the should-fix (malformed-TOML guard — the reviewer reproduced the brick) + the schema_version double-warn nit.

Story spec + Dev Agent Record: `_bmad-output/planning-artifacts/epic-production-hardening/stories/8.6-config-resilience-and-ci-quality-gates.md`