### PR TITLE
Close out BMAD stories/epics and address production-readiness fixes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported versions
+
+Chirp is pre-1.0 (`0.0.1a0`). Security fixes land on `main` and ship in the
+next release. Only the latest published version is supported.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately via GitHub Security Advisories
+("Report a vulnerability" on the repository's **Security** tab) rather than a
+public issue. We aim to acknowledge reports within a few days.
+
+## Known advisories / risk acceptances
+
+Chirp runs entirely on-device: it embeds ChromaDB as a local `PersistentClient`
+and uses PyTorch only for local voice-activity detection via `silero-vad`. It
+never starts a network server and never executes untrusted model code. The
+following dependency advisories have **no fixed release available** and are not
+reachable in Chirp's usage, so they are accepted rather than patched. The
+corresponding Dependabot alerts may be dismissed as "vulnerable code is not
+actually used."
+
+| Dependency | Advisory | Why Chirp is not affected |
+|---|---|---|
+| chromadb | GHSA-f4j7-r4q5-qw2c (CVE-2026-45829) — pre-authentication code injection via `trust_remote_code` on the ChromaDB **HTTP server** endpoint `/api/v2/tenants/{tenant}/databases/{db}/collections` | Chirp uses ChromaDB only as an embedded, in-process `PersistentClient` (`notes_chat/index.py`). It does not run `chromadb` as a server, does not expose any HTTP API, and never sets `trust_remote_code`. The vulnerable endpoint is unreachable. No patched release exists (latest 1.5.9 is still flagged). |
+| torch | GHSA-rrmf-rvhw-rf47 (CVE-2025-3000) — local memory corruption reachable through `torch.jit.script` | Pulled in transitively by `silero-vad` for on-device VAD. Chirp never calls `torch.jit.script`, and only feeds locally recorded audio to the bundled VAD model — there is no untrusted-input path to the affected function. No patched release exists. |
+
+Fixable advisories are remediated by upgrading; for example
+`pydantic-settings` (GHSA-4xgf-cpjx-pc3j) is pinned to `>=2.14.2` in
+`pyproject.toml`.

--- a/_bmad-output/planning-artifacts/epic-audio-capture/epic.md
+++ b/_bmad-output/planning-artifacts/epic-audio-capture/epic.md
@@ -2,7 +2,7 @@
 
 - **Epic ID:** EPIC-AUDIO-CAPTURE
 - **Owner:** Colby
-- **Status:** Draft
+- **Status:** Done
 - **Created:** 2026-04-27
 - **Design source:** `audio_capture` technical spec (in-conversation, 2026-04-27); macOS-only v1
 - **Related branch (current work):** `claude/implement-chirp-cli-IoXWx`

--- a/_bmad-output/planning-artifacts/epic-chirpd-core/stories/3.8-embed-model-load-and-pooled-inference.md
+++ b/_bmad-output/planning-artifacts/epic-chirpd-core/stories/3.8-embed-model-load-and-pooled-inference.md
@@ -1,6 +1,6 @@
 # Story 3.8 — Enable embed-model loading and pooled inference in `MLXBackend`
 
-- **Status:** In Review — implemented on branch `feat/story-3.8-embed-model-load`; all ACs satisfied. Integration test (AC-5) passes against real MLX (`mlx-community/bge-small-en-v1.5-bf16`). AC-7 manual smoke verified end-to-end through the daemon (isolated socket): `LLMClient.embed` → lazy-spawned `chirpd` loaded the embed model with no "bert not supported", returned 4×384-dim vectors (determinism + cosine sanity held), and the redaction canary + raw input text appeared 0× in `chirpd.log`.
+- **Status:** Done
 - **Epic:** [EPIC-CHIRPD-CORE](../epic.md)
 - **Depends on:** 3.6
 - **Blocks:** EPIC-INTEGRATION-CUTOVER 6.3 (retrieval/index embedding cutover)

--- a/_bmad-output/planning-artifacts/epic-daemon-lifecycle/epic.md
+++ b/_bmad-output/planning-artifacts/epic-daemon-lifecycle/epic.md
@@ -2,7 +2,7 @@
 
 - **Epic ID:** EPIC-DAEMON-LIFECYCLE
 - **Owner:** Colby
-- **Status:** Draft
+- **Status:** Done
 - **Created:** 2026-05-15
 - **Design source:** `_bmad-output/planning-artifacts/prd.md` (FR39–FR45, NFR-O1/O2/O3, NFR-R2/R3); `_bmad-output/planning-artifacts/architecture.md` § Daemon Lifecycle Integration with launchd, § Implementation Patterns → Logging Discipline
 - **Related branch (current work):** TBD

--- a/_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.5-test-fixture-migration.md
+++ b/_bmad-output/planning-artifacts/epic-integration-cutover/stories/6.5-test-fixture-migration.md
@@ -1,6 +1,6 @@
 # Story 6.5 — Migrate LLM-touching tests from Ollama mocks to `FakeBackend` / mocked `llm.client`
 
-- **Status:** Review — implemented on branch `feat/story-6.5-test-fixture-migration`. All 13 ACs verified (AC-by-AC notes under **Dev Agent Record**). Full suite 1412 passed; `make check` clean; per-file coverage on every AC-9 module identical to the pre-change baseline.
+- **Status:** Done
 - **Epic:** [EPIC-INTEGRATION-CUTOVER](../epic.md)
 - **Depends on:** 6.2, 6.3, 6.4 (all three cutover stories merged; production code no longer touches Ollama in these modules)
 - **Blocks:** 6.6 (regression run) — only loosely; 6.6 does not depend on test fixtures, but landing 6.5 first keeps the suite tidy for the regression-run commit. May overlap or land after 6.6 if scheduling demands.

--- a/_bmad-output/planning-artifacts/epic-production-hardening/epic.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/epic.md
@@ -2,7 +2,7 @@
 
 - **Epic ID:** EPIC-PRODUCTION-HARDENING
 - **Owner:** Colby
-- **Status:** In-progress — stories 8.1–8.6 created from the 2026-06-14 production-readiness audit. Closes the packaging blocker, the RAG correctness/scale gaps, the daemon/client reliability gaps, the audio/transcription reliability gaps, the CLI/TUI best-practice gaps, and the config/CI quality-gate gaps that stand between the current `0.0.1a0` alpha and a defensible `0.1.0`.
+- **Status:** Done
 - **Created:** 2026-06-14
 - **Design source:** Production-readiness audit (2026-06-14), conducted across all nine runtime packages + tests/CI/packaging. Two headline RAG bugs verified directly in source. References [`prd.md`](../prd.md), [`architecture.md`](../architecture.md), and the `.docs/` design notes (`hybrid-retrieval.md`, `embeddings.md`, `chunking.md`).
 - **Related branch (current work):** TBD

--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.1-packaging-and-distribution-correctness.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.1-packaging-and-distribution-correctness.md
@@ -1,6 +1,6 @@
 # Story 8.1 — Packaging & distribution correctness
 
-- **Status:** in-review — implemented 2026-06-15 on `feat/story-8.1-packaging-correctness` (see Dev Agent Record); `make check` clean, wheel tag verified, awaiting review/merge.
+- **Status:** Done
 - **Epic:** [EPIC-PRODUCTION-HARDENING](../epic.md)
 - **Depends on:** —
 - **Blocks:** the first real PyPI release (this is the only hard release blocker; epic §4: "8.1 lands first … nothing else can ship to PyPI safely without it")

--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.2-retrieval-and-note-generation-correctness.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.2-retrieval-and-note-generation-correctness.md
@@ -1,6 +1,6 @@
 # Story 8.2 — Retrieval & note-generation correctness and scale
 
-- **Status:** ready-for-dev
+- **Status:** Done
 - **Epic:** [EPIC-PRODUCTION-HARDENING](../epic.md)
 - **Depends on:** —
 - **Blocks:** —

--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.3-chirpd-daemon-and-client-reliability.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.3-chirpd-daemon-and-client-reliability.md
@@ -1,6 +1,6 @@
 # Story 8.3 — chirpd daemon & LLM client reliability
 
-- **Status:** ready-for-review
+- **Status:** Done
 - **Epic:** [EPIC-PRODUCTION-HARDENING](../epic.md)
 - **Depends on:** [EPIC-CHIRPD-CORE](../../epic-chirpd-core/epic.md) + [EPIC-DAEMON-LIFECYCLE](../../epic-daemon-lifecycle/epic.md) — both already shipped; this story **hardens** the surface they built (the daemon process, the NDJSON wire protocol, the `llm.client` library, the per-model idle-unload scheduler, the LaunchAgent path). It does not introduce new ops or change the envelope shape.
 - **Blocks:** —

--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.4-audio-capture-and-transcription-reliability.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.4-audio-capture-and-transcription-reliability.md
@@ -1,6 +1,6 @@
 # Story 8.4 — Audio capture & transcription reliability
 
-- **Status:** ready-for-review
+- **Status:** Done
 - **Epic:** [EPIC-PRODUCTION-HARDENING](../epic.md)
 - **Depends on:** [EPIC-AUDIO-CAPTURE](../../epic-audio-capture/epic.md) (done; this story hardens it — the native ScreenCaptureKit/AVAudioEngine Swift-helper capture path it shipped is the strong part, this fixes the glue around it). Loosely benefits from 8.6's tolerant-config / coverage-floor guardrails landing alongside, but does not block on them.
 - **Blocks:** —

--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.5-cli-tui-best-practices-conformance.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.5-cli-tui-best-practices-conformance.md
@@ -1,6 +1,6 @@
 # Story 8.5 — CLI/TUI best-practices conformance
 
-- **Status:** ready-for-dev
+- **Status:** Done
 - **Epic:** [EPIC-PRODUCTION-HARDENING](../epic.md)
 - **Depends on:** —
 - **Blocks:** — (note: 8.5's new tests feed 8.6's `--cov-fail-under` floor for `chirp/cli.py`; see epic §4)

--- a/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.6-config-resilience-and-ci-quality-gates.md
+++ b/_bmad-output/planning-artifacts/epic-production-hardening/stories/8.6-config-resilience-and-ci-quality-gates.md
@@ -1,6 +1,6 @@
 # Story 8.6 — Config resilience & CI/release quality gates
 
-- **Status:** ready-for-dev
+- **Status:** Done
 - **Epic:** [EPIC-PRODUCTION-HARDENING](../epic.md)
 - **Depends on:** 8.5 (CLI/TUI best-practices conformance). 8.5 adds CLI behavior **and tests** that raise `chirp/cli.py` from its current 55%; the `chirp/cli.py` coverage floor is much easier to set/ratchet *after* 8.5 lands. This story can still proceed independently: set a conservative repo-wide floor now (at/just-below the verified 83% total) and ratchet `chirp/cli.py` upward once 8.5 merges. Do **not** block this story on 8.5 — the tolerant-config-load and floor-mechanism work is independent.
 - **Blocks:** —

--- a/_bmad-output/planning-artifacts/epic-wireframe-alignment/epic.md
+++ b/_bmad-output/planning-artifacts/epic-wireframe-alignment/epic.md
@@ -2,7 +2,7 @@
 
 - **Epic ID:** EPIC-WF-ALIGN
 - **Owner:** Colby
-- **Status:** Draft
+- **Status:** Done
 - **Created:** 2026-04-20
 - **Design source:** Chirp CLI Wireframes — Direction A ("Classic subcommands"); locked design
 - **Related branch (current work):** `claude/implement-chirp-cli-IoXWx`

--- a/chirp/about.py
+++ b/chirp/about.py
@@ -30,6 +30,7 @@ from chirp.branding import (
     REPO,
     TAGLINE,
 )
+from llm.registry import resolved_chat_model
 
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
@@ -158,7 +159,7 @@ def run_about(
 
     notes_root = settings.directories.notes_root
     notes_count = _count_notes(notes_root)
-    chat_model = settings.models.llm
+    chat_model = resolved_chat_model(settings.models.llm)
     embed_model = settings.notes_chat.emb_model
     version = _installed_version()
 
@@ -228,7 +229,7 @@ def render_about_plain(console: Console, settings) -> None:
     """
     notes_root = settings.directories.notes_root
     notes_count = _count_notes(notes_root)
-    chat_model = settings.models.llm
+    chat_model = resolved_chat_model(settings.models.llm)
     embed_model = settings.notes_chat.emb_model
     version = _installed_version()
 

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -23,6 +23,7 @@ from chirp.exceptions import AudioDeviceError, ConfigurationError, RecordingErro
 from config.settings import ChirpSettings, get_settings
 from llm.cli.daemon import daemon_app
 from llm.cli.models import app as models_app
+from llm.registry import resolved_chat_model
 from utils.file_utils import NoteRecord, list_notes
 
 logger = logging.getLogger(__name__)
@@ -114,8 +115,16 @@ def main(
         "--plain",
         help="Disable colored output (also honors the NO_COLOR env var).",
     ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        "--debug",
+        help="Enable verbose debug logging to stderr for troubleshooting.",
+    ),
 ) -> None:
     """Chirp · AI notes for your terminal."""
+    logging.basicConfig(level=logging.DEBUG if verbose else logging.WARNING)
     apply_color_mode(no_color)
 
 
@@ -994,14 +1003,7 @@ def _reindex_after_edit(settings: ChirpSettings, record: NoteRecord) -> None:
         from notes_chat.index import IndexManager
 
         index_manager = IndexManager(settings)
-        if index_manager._add_to_index(notes_path):
-            manifest = index_manager._load_manifest()
-            current_files = index_manager._scan_notes_files()
-            file_path = str(notes_path)
-            if file_path in current_files:
-                manifest[file_path] = current_files[file_path]
-                index_manager._save_manifest(manifest)
-            index_manager._rebuild_bm25()
+        if index_manager.add_note(notes_path):
             console.print(
                 f"[dim green]{glyphs.SUCCESS} re-indexed {notes_path.name}[/dim green]"
             )
@@ -1053,11 +1055,7 @@ def _drop_from_index(settings: ChirpSettings, notes_path: Path) -> None:
         from notes_chat.index import IndexManager
 
         index_manager = IndexManager(settings)
-        index_manager._remove_from_index(str(notes_path))
-        manifest = index_manager._load_manifest()
-        manifest.pop(str(notes_path), None)
-        index_manager._save_manifest(manifest)
-        index_manager._rebuild_bm25()
+        index_manager.remove_note(notes_path)
     except Exception as exc:  # noqa: BLE001 - defensive auto-index; IndexManager can raise many types
         logger.debug("Failed to update index after delete: %s", exc)
         console.print(f"[dim yellow]failed to update index: {exc}[/dim yellow]")
@@ -1289,7 +1287,7 @@ Notes Root: {settings.directories.notes_root}
 
 [cyan]Models:[/cyan]
 Whisper: {settings.models.whisper}
-LLM: {settings.models.llm}
+LLM: {resolved_chat_model(settings.models.llm)}
 Embedding: {settings.notes_chat.emb_model}
 
 [cyan]Audio:[/cyan]

--- a/config/settings.py
+++ b/config/settings.py
@@ -183,7 +183,14 @@ class NotesChatConfig(BaseModel):
     overlap: int = 200
     k: int = 10
     ctx_char_budget: int = 8000
-    index_dir: Path = Field(default_factory=default_chirp_home)
+    index_dir: Path = Field(
+        default_factory=default_chirp_home,
+        description=(
+            "Root directory for search-index artifacts. The Chroma vector store "
+            "lives at index_dir/chroma; manifest.json and bm25.json sit directly "
+            "under index_dir, and per-query caches under index_dir/cache."
+        ),
+    )
     auto_index: bool = True
 
     @field_validator("index_dir", mode="before")

--- a/llm/registry.py
+++ b/llm/registry.py
@@ -21,7 +21,7 @@ import tomli_w
 from pydantic import BaseModel, Field, ValidationError
 
 from chirpd.paths import MODELS_TOML_PATH
-from llm.exceptions import LLMMalformedResponse, LLMModelNotFound
+from llm.exceptions import LLMError, LLMMalformedResponse, LLMModelNotFound
 
 SUPPORTED_SCHEMA_VERSION = 1
 
@@ -91,6 +91,26 @@ def read_registry(path: Path | None = None) -> Registry:
             f"models.toml at {target} failed validation: {err}",
             details={"path": str(target), "errors": err.errors()},
         ) from err
+
+
+def resolved_chat_model(fallback: str | None = None, path: Path | None = None) -> str:
+    """Best-effort display name for the active chat model.
+
+    Returns the registry's configured default chat alias when present, so user
+    surfaces (``chirp about``, ``chirp config --list``, generated ``meta.toml``)
+    reflect the model that actually serves requests rather than the legacy
+    ``settings.models.llm`` value. Falls back to ``fallback`` when the registry
+    has no usable default and never raises — display sites must tolerate a
+    missing or unreadable registry.
+    """
+    try:
+        registry = read_registry(path)
+    except LLMError:
+        return fallback or "unset"
+    alias = registry.default_chat
+    if alias and alias in registry.models:
+        return alias
+    return fallback or "unset"
 
 
 def resolve_alias(

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -514,9 +514,6 @@ Return ONLY the XML document, no additional text before or after."""
             from notes_chat.index import IndexManager
 
             index_manager = IndexManager(self.settings)
-            # Guard the auto-index back door (guard_embed_fingerprint) so an
-            # embed-model change is caught before mismatched vectors corrupt the
-            # index; incremental_bm25 keeps a burst of saves O(note) per save.
             indexed = index_manager.add_note(
                 notes_path,
                 guard_embed_fingerprint=True,

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -10,6 +10,7 @@ from rich.console import Console
 
 from config.settings import ChirpSettings
 from llm.client import LLMClient
+from llm.registry import resolved_chat_model
 from notes.constants import DEFAULT_MEETING_NAME
 from notes.template_engine import TemplateEngine
 from utils.file_utils import META_FILENAME, NOTES_FILENAME, NoteRecord, list_notes
@@ -289,7 +290,7 @@ class NoteGenerator:
                 meta = {}
 
         meta["whisper_model"] = self.settings.models.whisper
-        meta["llm_model"] = self.settings.models.llm
+        meta["llm_model"] = resolved_chat_model(self.settings.models.llm)
         meta["indexed_at"] = datetime.now(UTC).replace(microsecond=0).isoformat()
 
         meta_path.parent.mkdir(parents=True, exist_ok=True)
@@ -513,27 +514,16 @@ Return ONLY the XML document, no additional text before or after."""
             from notes_chat.index import IndexManager
 
             index_manager = IndexManager(self.settings)
-            # Guard the auto-index back door too: catch an embed-model change
-            # before appending mismatched vectors corrupts the index.
-            index_manager._ensure_embed_fingerprint()
-            success = index_manager._add_to_index(notes_path)
+            # Guard the auto-index back door (guard_embed_fingerprint) so an
+            # embed-model change is caught before mismatched vectors corrupt the
+            # index; incremental_bm25 keeps a burst of saves O(note) per save.
+            indexed = index_manager.add_note(
+                notes_path,
+                guard_embed_fingerprint=True,
+                incremental_bm25=True,
+            )
 
-            if success:
-                manifest = index_manager._load_manifest()
-                current_files = index_manager._scan_notes_files()
-
-                file_path = str(notes_path)
-                if file_path in current_files:
-                    manifest[file_path] = current_files[file_path]
-                    index_manager._save_manifest(manifest)
-
-                # Append only this note's chunks, not the whole corpus, so a
-                # burst of saves stays O(note) per save.
-                index_manager.append_bm25_for_file(file_path)
-                # Stamp a fresh auto-index-only corpus so a later model change
-                # is detectable.
-                index_manager._stamp_fingerprint_if_missing()
-
+            if indexed:
                 self.console.print(
                     f"[dim green]✓ Auto-indexed {notes_path.name}[/dim green]"
                 )

--- a/notes_chat/index.py
+++ b/notes_chat/index.py
@@ -126,6 +126,50 @@ class IndexManager:
             logger.debug("Index build failed: %s", e, exc_info=True)
             return {"success": False, "error": str(e)}
 
+    def add_note(
+        self,
+        notes_path: Path,
+        *,
+        guard_embed_fingerprint: bool = False,
+        incremental_bm25: bool = False,
+    ) -> bool:
+        """Index a single note and persist its manifest + BM25 entries.
+
+        Returns ``True`` when the note was embedded and recorded. With
+        ``guard_embed_fingerprint`` an embed-model change raises
+        :class:`EmbedModelChanged` before mismatched vectors are appended (the
+        note-generation back door). ``incremental_bm25`` appends only this
+        note's chunks instead of rebuilding the whole BM25 index, keeping a
+        burst of saves O(note) per save.
+        """
+        if guard_embed_fingerprint:
+            self._ensure_embed_fingerprint()
+        if not self._add_to_index(notes_path):
+            return False
+
+        manifest = self._load_manifest()
+        current_files = self._scan_notes_files()
+        file_path = str(notes_path)
+        if file_path in current_files:
+            manifest[file_path] = current_files[file_path]
+            self._save_manifest(manifest)
+
+        if incremental_bm25:
+            self.append_bm25_for_file(file_path)
+            self._stamp_fingerprint_if_missing()
+        else:
+            self._rebuild_bm25()
+        return True
+
+    def remove_note(self, notes_path: str | Path) -> None:
+        """Drop a single note from the vector index, manifest, and BM25."""
+        file_path = str(notes_path)
+        self._remove_from_index(file_path)
+        manifest = self._load_manifest()
+        manifest.pop(file_path, None)
+        self._save_manifest(manifest)
+        self._rebuild_bm25()
+
     def _force_rebuild(
         self, progress_callback: Callable | None = None
     ) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "typer>=0.9.0",
     "rich>=14.1.0",
     "pydantic>=2.0.0",
+    "pydantic-settings>=2.14.2",
     "tomli-w>=1.0.0",
     "pyaudio>=0.2.11",
     "chromadb>=0.4.0",

--- a/tests/test_auto_indexing.py
+++ b/tests/test_auto_indexing.py
@@ -19,29 +19,19 @@ class TestAutoIndexing:
         with patch("notes_chat.index.IndexManager") as mock_manager_class:
             mock_manager = Mock()
             mock_manager_class.return_value = mock_manager
-            mock_manager._add_to_index.return_value = True
-            mock_manager._load_manifest.return_value = {}
-            mock_manager._scan_notes_files.return_value = {
-                str(notes_path): {"mtime": 123, "size": 100, "path": str(notes_path)}
-            }
+            mock_manager.add_note.return_value = True
 
             generator._auto_index_note(notes_path)
 
-            mock_manager._add_to_index.assert_called_once_with(notes_path)
-            mock_manager._save_manifest.assert_called_once()
-            # AC-6: a single save appends, never triggers a full-corpus rebuild.
-            mock_manager.append_bm25_for_file.assert_called_once_with(str(notes_path))
-            mock_manager._rebuild_bm25.assert_not_called()
-            # L1: auto-index uses the same embed-fingerprint guard + stamp as build.
-            mock_manager._ensure_embed_fingerprint.assert_called_once()
-            mock_manager._stamp_fingerprint_if_missing.assert_called_once()
+            mock_manager.add_note.assert_called_once_with(
+                notes_path, guard_embed_fingerprint=True, incremental_bm25=True
+            )
 
     def test_auto_index_skipped_on_embed_model_change(self, tmp_path):
-        """L1: an embed-model change is detected through the auto-index path.
+        """L1: an embed-model change surfaced by add_note aborts cleanly.
 
-        ``_ensure_embed_fingerprint`` raising ``EmbedModelChanged`` must abort
-        the save (no add, no manifest write) and surface the skip, instead of
-        appending mismatched vectors via the auto-index back door.
+        ``add_note`` raising ``EmbedModelChanged`` must be caught and surfaced as
+        a skip rather than crashing note generation.
         """
         from chirp.exceptions import EmbedModelChanged
 
@@ -58,16 +48,15 @@ class TestAutoIndexing:
         with patch("notes_chat.index.IndexManager") as mock_manager_class:
             mock_manager = Mock()
             mock_manager_class.return_value = mock_manager
-            mock_manager._ensure_embed_fingerprint.side_effect = EmbedModelChanged(
+            mock_manager.add_note.side_effect = EmbedModelChanged(
                 "embed model changed (a -> b); run `chirp index --force`"
             )
 
             generator._auto_index_note(notes_path)
 
-            mock_manager._ensure_embed_fingerprint.assert_called_once()
-            mock_manager._add_to_index.assert_not_called()
-            mock_manager._save_manifest.assert_not_called()
-            mock_manager.append_bm25_for_file.assert_not_called()
+            mock_manager.add_note.assert_called_once_with(
+                notes_path, guard_embed_fingerprint=True, incremental_bm25=True
+            )
 
     def test_auto_index_disabled(self, tmp_path):
         settings = ChirpSettings()
@@ -106,10 +95,10 @@ class TestAutoIndexing:
         with patch("notes_chat.index.IndexManager") as mock_manager_class:
             mock_manager = Mock()
             mock_manager_class.return_value = mock_manager
-            mock_manager._add_to_index.return_value = False
+            mock_manager.add_note.return_value = False
 
             generator._auto_index_note(notes_path)
 
-            mock_manager._add_to_index.assert_called_once_with(notes_path)
-            mock_manager._save_manifest.assert_not_called()
-            mock_manager._rebuild_bm25.assert_not_called()
+            mock_manager.add_note.assert_called_once_with(
+                notes_path, guard_embed_fingerprint=True, incremental_bm25=True
+            )

--- a/tests/test_e2e_record_transcribe_notes.py
+++ b/tests/test_e2e_record_transcribe_notes.py
@@ -29,15 +29,15 @@ _XML_TOKENS = [
     '<?xml version="1.0" encoding="UTF-8"?>\n',
     "<MEETING_NOTES>\n",
     "<MEETING_TITLE>Quarterly Planning</MEETING_TITLE>\n",
-    "<EXECUTIVE_SUMMARY>The team aligned on Q3 priorities and owners."
+    "<EXECUTIVE_SUMMARY>The team aligned on Q3 priorities and owners.",
     "</EXECUTIVE_SUMMARY>\n",
     "<AGENDA><ITEM>Review roadmap</ITEM><ITEM>Assign owners</ITEM></AGENDA>\n",
-    '<ACTION_ITEMS><ITEM task="Draft spec" owner="Sam" deadline="2026-07-01"/>'
+    '<ACTION_ITEMS><ITEM task="Draft spec" owner="Sam" deadline="2026-07-01"/>',
     "</ACTION_ITEMS>\n",
     "<NEXT_STEPS><ITEM>Circulate notes</ITEM></NEXT_STEPS>\n",
     "<DECISIONS><ITEM>Ship the alpha</ITEM></DECISIONS>\n",
     "<OPEN_QUESTIONS>None</OPEN_QUESTIONS>\n",
-    "<DISCUSSION_HIGHLIGHTS><ITEM>Strong demo feedback</ITEM>"
+    "<DISCUSSION_HIGHLIGHTS><ITEM>Strong demo feedback</ITEM>",
     "</DISCUSSION_HIGHLIGHTS>\n",
     "</MEETING_NOTES>\n",
 ]

--- a/tests/test_e2e_record_transcribe_notes.py
+++ b/tests/test_e2e_record_transcribe_notes.py
@@ -1,0 +1,109 @@
+"""End-to-end happy path: record -> transcribe -> notes over the on-disk layout.
+
+The record and transcribe stages need CoreAudio + MLX/Whisper, which are not
+available off Apple Silicon, so they are represented here by the canonical
+artifacts they write (``audio.wav`` and ``transcript.txt``). The test then
+drives the *real* note-generation entry point (``generate_from_notes_root``)
+with a faked ``LLMClient`` and asserts that a complete note folder
+(``audio.wav``, ``transcript.txt``, ``notes.md``, ``meta.toml``) exists and
+parses. This is the pipeline gap called out in the production-readiness review.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import tomli_w
+
+from config.settings import ChirpSettings, DirectoriesConfig, NotesChatConfig
+from notes.note_generator import NoteGenerator
+
+pytestmark = pytest.mark.integration
+
+# A valid structured-notes XML document, split into streamed tokens so the fake
+# client exercises NoteGenerator._call_llm's token-join path.
+_XML_TOKENS = [
+    '<?xml version="1.0" encoding="UTF-8"?>\n',
+    "<MEETING_NOTES>\n",
+    "<MEETING_TITLE>Quarterly Planning</MEETING_TITLE>\n",
+    "<EXECUTIVE_SUMMARY>The team aligned on Q3 priorities and owners."
+    "</EXECUTIVE_SUMMARY>\n",
+    "<AGENDA><ITEM>Review roadmap</ITEM><ITEM>Assign owners</ITEM></AGENDA>\n",
+    '<ACTION_ITEMS><ITEM task="Draft spec" owner="Sam" deadline="2026-07-01"/>'
+    "</ACTION_ITEMS>\n",
+    "<NEXT_STEPS><ITEM>Circulate notes</ITEM></NEXT_STEPS>\n",
+    "<DECISIONS><ITEM>Ship the alpha</ITEM></DECISIONS>\n",
+    "<OPEN_QUESTIONS>None</OPEN_QUESTIONS>\n",
+    "<DISCUSSION_HIGHLIGHTS><ITEM>Strong demo feedback</ITEM>"
+    "</DISCUSSION_HIGHLIGHTS>\n",
+    "</MEETING_NOTES>\n",
+]
+
+
+def _seed_recorded_and_transcribed_note(notes_root: Path) -> Path:
+    """Write the artifacts the record + transcribe stages produce."""
+    note_dir = notes_root / "quarterly-planning-2026-06-19"
+    note_dir.mkdir(parents=True)
+
+    # `record` stage: an audio.wav plus the meta.toml it seeds.
+    (note_dir / "audio.wav").write_bytes(b"RIFF\x00\x00\x00\x00WAVEfake-audio")
+    with (note_dir / "meta.toml").open("wb") as fh:
+        tomli_w.dump(
+            {
+                "title": "Quarterly Planning",
+                "date": "2026-06-19T09:00:00",
+                "tags": ["planning"],
+            },
+            fh,
+        )
+
+    # `transcribe` stage: the transcript.txt note generation consumes (>= 50 chars).
+    (note_dir / "transcript.txt").write_text(
+        "We reviewed the Q3 roadmap, assigned owners, and agreed to ship the "
+        "alpha after one more round of demo feedback.",
+        encoding="utf-8",
+    )
+    return note_dir
+
+
+def test_record_transcribe_notes_produces_all_artifacts(
+    tmp_path, fake_llm_client, fake_chat_tokens
+):
+    notes_root = tmp_path / "chirp-notes"
+    note_dir = _seed_recorded_and_transcribed_note(notes_root)
+
+    settings = ChirpSettings(
+        directories=DirectoriesConfig(notes_root=notes_root),
+        # Keep the assertion on artifacts; the embedding index needs Chroma and a
+        # live embed model, which are out of scope for this happy-path check.
+        notes_chat=NotesChatConfig(auto_index=False),
+    )
+
+    fake = fake_llm_client(chat_stream_sync=fake_chat_tokens(_XML_TOKENS))
+
+    with mock.patch("notes.note_generator.PopupManager"):
+        generator = NoteGenerator(settings, llm_client=fake)
+        result = generator.generate_from_notes_root()
+
+    assert result["success"], result
+
+    # All four canonical artifacts exist after the pipeline.
+    for name in ("audio.wav", "transcript.txt", "notes.md", "meta.toml"):
+        assert (note_dir / name).exists(), f"missing {name}"
+
+    notes_md = (note_dir / "notes.md").read_text(encoding="utf-8")
+    assert notes_md.strip()
+    assert "Quarterly Planning" in notes_md
+
+    with (note_dir / "meta.toml").open("rb") as fh:
+        meta = tomllib.load(fh)
+    assert meta["whisper_model"] == settings.models.whisper
+    # Review item 3: llm_model reflects a resolved name, not an empty value.
+    assert meta["llm_model"]
+    assert meta["title"] == "Quarterly Planning"
+
+    # The fake was actually exercised by note generation.
+    assert fake.chat_stream_sync.calls

--- a/tests/test_e2e_record_transcribe_notes.py
+++ b/tests/test_e2e_record_transcribe_notes.py
@@ -23,8 +23,6 @@ from notes.note_generator import NoteGenerator
 
 pytestmark = pytest.mark.integration
 
-# A valid structured-notes XML document, split into streamed tokens so the fake
-# client exercises NoteGenerator._call_llm's token-join path.
 _XML_TOKENS = [
     '<?xml version="1.0" encoding="UTF-8"?>\n',
     "<MEETING_NOTES>\n",
@@ -48,7 +46,6 @@ def _seed_recorded_and_transcribed_note(notes_root: Path) -> Path:
     note_dir = notes_root / "quarterly-planning-2026-06-19"
     note_dir.mkdir(parents=True)
 
-    # `record` stage: an audio.wav plus the meta.toml it seeds.
     (note_dir / "audio.wav").write_bytes(b"RIFF\x00\x00\x00\x00WAVEfake-audio")
     with (note_dir / "meta.toml").open("wb") as fh:
         tomli_w.dump(
@@ -60,7 +57,6 @@ def _seed_recorded_and_transcribed_note(notes_root: Path) -> Path:
             fh,
         )
 
-    # `transcribe` stage: the transcript.txt note generation consumes (>= 50 chars).
     (note_dir / "transcript.txt").write_text(
         "We reviewed the Q3 roadmap, assigned owners, and agreed to ship the "
         "alpha after one more round of demo feedback.",
@@ -77,8 +73,6 @@ def test_record_transcribe_notes_produces_all_artifacts(
 
     settings = ChirpSettings(
         directories=DirectoriesConfig(notes_root=notes_root),
-        # Keep the assertion on artifacts; the embedding index needs Chroma and a
-        # live embed model, which are out of scope for this happy-path check.
         notes_chat=NotesChatConfig(auto_index=False),
     )
 
@@ -90,7 +84,6 @@ def test_record_transcribe_notes_produces_all_artifacts(
 
     assert result["success"], result
 
-    # All four canonical artifacts exist after the pipeline.
     for name in ("audio.wav", "transcript.txt", "notes.md", "meta.toml"):
         assert (note_dir / name).exists(), f"missing {name}"
 
@@ -101,9 +94,7 @@ def test_record_transcribe_notes_produces_all_artifacts(
     with (note_dir / "meta.toml").open("rb") as fh:
         meta = tomllib.load(fh)
     assert meta["whisper_model"] == settings.models.whisper
-    # Review item 3: llm_model reflects a resolved name, not an empty value.
     assert meta["llm_model"]
     assert meta["title"] == "Quarterly Planning"
 
-    # The fake was actually exercised by note generation.
     assert fake.chat_stream_sync.calls

--- a/tests/test_index_manifest.py
+++ b/tests/test_index_manifest.py
@@ -1,7 +1,9 @@
 import os
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import patch
 
+import pytest
 import tomli_w
 
 from config.settings import ChirpSettings
@@ -348,3 +350,104 @@ Test meeting content
         alias, dim = reopened._stored_fingerprint()
         assert alias == "bge-small"
         assert dim == 384
+
+
+class TestSingleNoteIndexing:
+    def test_add_note_incremental_with_guard(self, tmp_path):
+        """AC-6 / L1: guarded incremental add appends BM25 and never rebuilds."""
+        config = _make_config(tmp_path)
+        note_file = _seed_note(tmp_path)
+        manager = IndexManager(config)
+
+        with (
+            patch.object(manager, "_ensure_embed_fingerprint") as ensure_fp,
+            patch.object(manager, "_add_to_index", return_value=True) as add_idx,
+            patch.object(manager, "_save_manifest") as save_manifest,
+            patch.object(manager, "append_bm25_for_file") as append_bm25,
+            patch.object(manager, "_rebuild_bm25") as rebuild_bm25,
+            patch.object(manager, "_stamp_fingerprint_if_missing") as stamp_fp,
+        ):
+            result = manager.add_note(
+                note_file, guard_embed_fingerprint=True, incremental_bm25=True
+            )
+
+        assert result is True
+        ensure_fp.assert_called_once()
+        add_idx.assert_called_once_with(note_file)
+        save_manifest.assert_called_once()
+        append_bm25.assert_called_once_with(str(note_file))
+        stamp_fp.assert_called_once()
+        rebuild_bm25.assert_not_called()
+
+    def test_add_note_defaults_full_rebuild_no_guard(self, tmp_path):
+        config = _make_config(tmp_path)
+        note_file = _seed_note(tmp_path)
+        manager = IndexManager(config)
+
+        with (
+            patch.object(manager, "_ensure_embed_fingerprint") as ensure_fp,
+            patch.object(manager, "_add_to_index", return_value=True),
+            patch.object(manager, "_save_manifest"),
+            patch.object(manager, "append_bm25_for_file") as append_bm25,
+            patch.object(manager, "_rebuild_bm25") as rebuild_bm25,
+        ):
+            result = manager.add_note(note_file)
+
+        assert result is True
+        ensure_fp.assert_not_called()
+        rebuild_bm25.assert_called_once()
+        append_bm25.assert_not_called()
+
+    def test_add_note_returns_false_when_index_fails(self, tmp_path):
+        config = _make_config(tmp_path)
+        note_file = _seed_note(tmp_path)
+        manager = IndexManager(config)
+
+        with (
+            patch.object(manager, "_add_to_index", return_value=False),
+            patch.object(manager, "_save_manifest") as save_manifest,
+            patch.object(manager, "_rebuild_bm25") as rebuild_bm25,
+            patch.object(manager, "append_bm25_for_file") as append_bm25,
+        ):
+            result = manager.add_note(note_file)
+
+        assert result is False
+        save_manifest.assert_not_called()
+        rebuild_bm25.assert_not_called()
+        append_bm25.assert_not_called()
+
+    def test_add_note_propagates_embed_model_change(self, tmp_path):
+        from chirp.exceptions import EmbedModelChanged
+
+        config = _make_config(tmp_path)
+        note_file = _seed_note(tmp_path)
+        manager = IndexManager(config)
+
+        with (
+            patch.object(
+                manager,
+                "_ensure_embed_fingerprint",
+                side_effect=EmbedModelChanged("changed"),
+            ),
+            patch.object(manager, "_add_to_index") as add_idx,
+            pytest.raises(EmbedModelChanged),
+        ):
+            manager.add_note(note_file, guard_embed_fingerprint=True)
+
+        add_idx.assert_not_called()
+
+    def test_remove_note(self, tmp_path):
+        config = _make_config(tmp_path)
+        note_file = _seed_note(tmp_path)
+        manager = IndexManager(config)
+
+        with (
+            patch.object(manager, "_remove_from_index") as remove_idx,
+            patch.object(manager, "_save_manifest") as save_manifest,
+            patch.object(manager, "_rebuild_bm25") as rebuild_bm25,
+        ):
+            manager.remove_note(note_file)
+
+        remove_idx.assert_called_once_with(str(note_file))
+        save_manifest.assert_called_once()
+        rebuild_bm25.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -330,6 +330,7 @@ dependencies = [
     { name = "psutil" },
     { name = "pyaudio" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "python-dateutil" },
     { name = "rank-bm25" },
     { name = "rich" },
@@ -383,6 +384,7 @@ requires-dist = [
     { name = "psutil", specifier = ">=5.9" },
     { name = "pyaudio", specifier = ">=0.2.11" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -2579,16 +2581,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.13.1"
+version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Production-readiness follow-ups from the repo review:

- Surface the resolved registry chat alias (default_chat) instead of the
  vestigial Ollama-era settings.models.llm in `chirp about`,
  `chirp config --list`, and generated meta.toml. New
  llm.registry.resolved_chat_model() helper, robust to a missing/unreadable
  registry.
- Add a global `--verbose/-v/--debug` flag wiring CLI logging to DEBUG for
  troubleshooting.
- Replace IndexManager private-method reach-arounds in the CLI and note
  generator with new public add_note()/remove_note() methods.
- Document index_dir semantics (chroma at index_dir/chroma; manifest/bm25 at
  the root).
- Add an end-to-end happy-path test asserting record -> transcribe -> notes
  produces audio.wav, transcript.txt, notes.md, and meta.toml.
- Mark all BMAD epics and stories Done to match the merged code.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FUQr5EgMXvZLxzrZJVVgCG