### PR TITLE
ci: fix sync-version-to-main (install portaudio for pyaudio)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -67,6 +67,11 @@ jobs:
       - name: 🚀 Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
+      - name: 🔧 Install system dependencies (portaudio for pyaudio)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y portaudio19-dev python3-dev
+
       - name: 🏷️ Update pyproject.toml to released version
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
The `sync-version-to-main` job in `publish.yaml` failed on the v0.0.2-alpha release: it runs `uv run`/`uv lock` on ubuntu, which builds `pyaudio` from source and needs `portaudio.h` (`gcc ... portaudio` error). The macOS/Linux build job already installs `portaudio19-dev python3-dev`; this adds the same step to the sync job.

The release/publish itself succeeded — this only affected the post-release version-sync PR automation.