### PR TITLE
Gate semantic retrieval behind opt-in flag with query router

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -178,6 +178,7 @@ class LLMSettings(BaseModel):
 
 
 class NotesChatConfig(BaseModel):
+    semantic_enabled: bool = False
     emb_model: str = "nomic-embed-text"
     chunk_size: int = 1000
     overlap: int = 200

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -19,21 +19,16 @@ logger = logging.getLogger(__name__)
 # either source.
 RRF_K = 60
 
-# Per-source RRF weights as (bm25_weight, chroma_weight). The query router picks
-# between these when semantic search is enabled; LEXICAL_ONLY is forced when it is
-# off so the vector half contributes nothing even if it were searched.
+# Query-router weights, ordered (bm25_weight, chroma_weight). On literal queries
+# the vector half is downweighted rather than dropped so a paraphrase can still
+# break a lexical tie.
 LEXICAL_ONLY = (1.0, 0.0)
-# Literal queries (IDs, dates, quotes, acronyms, very short) where BM25 wins on
-# exact spans — semantic still contributes, but downweighted.
 LITERAL_WEIGHTS = (1.0, 0.3)
-# Conceptual/natural-language queries where paraphrase matching earns its keep —
-# both sources contribute fully.
 CONCEPTUAL_WEIGHTS = (1.0, 1.0)
 
-# A token carrying two or more digits (jira-123, v2.3.1, 2026-06-28) is almost
-# always a literal identifier the embedding model can't disambiguate.
+# A token with two or more digits (jira-123, v2.3.1, 2026-06-28) reads as a
+# literal identifier the embedding model can't disambiguate.
 _MULTI_DIGIT_RE = re.compile(r"\d.*\d")
-# ALL-CAPS acronyms of two or more characters (API, RRF, BM25).
 _ACRONYM_RE = re.compile(r"\b[A-Z]{2,}\b")
 
 
@@ -120,9 +115,8 @@ def retrieve_context(
             index_manager=index_manager,
         )
 
-        # BM25 is the only hard-required retriever. The vector half runs only
-        # when semantic search is opted in; otherwise nothing touches Chroma or
-        # the embedding model at query time.
+        # Gating the vector path here is the opt-in guarantee: with semantic off,
+        # nothing touches Chroma or the embedding model at query time.
         chroma_results: list[tuple[str, float, dict[str, Any]]] = []
         weights = LEXICAL_ONLY
         if config.notes_chat.semantic_enabled:

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,23 @@ logger = logging.getLogger(__name__)
 # (and .docs/hybrid-retrieval.md); it damps low-rank items without starving
 # either source.
 RRF_K = 60
+
+# Per-source RRF weights as (bm25_weight, chroma_weight). The query router picks
+# between these when semantic search is enabled; LEXICAL_ONLY is forced when it is
+# off so the vector half contributes nothing even if it were searched.
+LEXICAL_ONLY = (1.0, 0.0)
+# Literal queries (IDs, dates, quotes, acronyms, very short) where BM25 wins on
+# exact spans — semantic still contributes, but downweighted.
+LITERAL_WEIGHTS = (1.0, 0.3)
+# Conceptual/natural-language queries where paraphrase matching earns its keep —
+# both sources contribute fully.
+CONCEPTUAL_WEIGHTS = (1.0, 1.0)
+
+# A token carrying two or more digits (jira-123, v2.3.1, 2026-06-28) is almost
+# always a literal identifier the embedding model can't disambiguate.
+_MULTI_DIGIT_RE = re.compile(r"\d.*\d")
+# ALL-CAPS acronyms of two or more characters (API, RRF, BM25).
+_ACRONYM_RE = re.compile(r"\b[A-Z]{2,}\b")
 
 
 def _as_naive(value: datetime) -> datetime:
@@ -95,15 +113,23 @@ def retrieve_context(
         else:
             time_range = parse_time_range(question)
 
-        chroma_results = _search_chroma(
-            index_manager, question, config.notes_chat.k, time_range
-        )
         bm25_results = _search_bm25(
             index_manager.bm25_file,
             question,
             config.notes_chat.k,
             index_manager=index_manager,
         )
+
+        # BM25 is the only hard-required retriever. The vector half runs only
+        # when semantic search is opted in; otherwise nothing touches Chroma or
+        # the embedding model at query time.
+        chroma_results: list[tuple[str, float, dict[str, Any]]] = []
+        weights = LEXICAL_ONLY
+        if config.notes_chat.semantic_enabled:
+            weights = _route_query(question)
+            chroma_results = _search_chroma(
+                index_manager, question, config.notes_chat.k, time_range
+            )
 
         if not chroma_results and not bm25_results:
             suggestion = _generate_suggestion(config, time_range)
@@ -113,7 +139,7 @@ def retrieve_context(
                 "suggestion": suggestion,
             }
 
-        merged_chunks = _merge_and_dedupe(chroma_results, bm25_results)
+        merged_chunks = _merge_and_dedupe(chroma_results, bm25_results, weights)
 
         context, sources, retrieved_ids = _build_context(
             merged_chunks, config.notes_chat.ctx_char_budget, config
@@ -274,29 +300,64 @@ def _signature(chunk_id: str, data: dict[str, Any]) -> str:
     return chunk_id
 
 
+def _route_query(question: str) -> tuple[float, float]:
+    """Pick per-source RRF weights ``(bm25, chroma)`` from the query's shape.
+
+    Pure and deterministic — no I/O. Literal signals (quoted spans, multi-digit
+    tokens, ALL-CAPS acronyms, very short queries) favour BM25 because lexical
+    retrieval wins on exact spans the small embedding model can't disambiguate.
+    Anything else is treated as conceptual, where paraphrase matching helps. The
+    function runs the same regardless of whether semantic search is enabled; it
+    only changes outcomes once the vector half actually contributes.
+    """
+    if '"' in question:
+        return LITERAL_WEIGHTS
+
+    tokens = question.split()
+    if len(tokens) <= 2:
+        return LITERAL_WEIGHTS
+
+    for token in tokens:
+        if _MULTI_DIGIT_RE.search(token):
+            return LITERAL_WEIGHTS
+
+    if _ACRONYM_RE.search(question):
+        return LITERAL_WEIGHTS
+
+    return CONCEPTUAL_WEIGHTS
+
+
 def _merge_and_dedupe(
     chroma_results: list[tuple[str, float, dict[str, Any]]],
     bm25_results: list[tuple[str, float, dict[str, Any]]],
+    weights: tuple[float, float] = (1.0, 1.0),
 ) -> list[tuple[str, float, dict[str, Any]]]:
     """Fuse Chroma and BM25 results with Reciprocal Rank Fusion.
 
     Each input list is already rank-ordered. A chunk's fused score is
-    ``Σ 1/(RRF_K + rank_i)`` across the lists it appears in (rank is 0-based),
-    so its contribution is its *rank* in each source, not the source-specific
-    raw magnitude — this keeps an unbounded BM25 score from starving semantic
-    hits. Results are deduped by ``(path, content_hash)``, keeping the
-    best-ranked representative, and ordered by fused score. The fused score
-    replaces the raw score for ordering only.
+    ``Σ weight_i · 1/(RRF_K + rank_i)`` across the lists it appears in (rank is
+    0-based), so its contribution is its *rank* in each source scaled by that
+    source's weight, not the source-specific raw magnitude — this keeps an
+    unbounded BM25 score from starving semantic hits. ``weights`` is
+    ``(bm25_weight, chroma_weight)`` from the query router; the default
+    ``(1.0, 1.0)`` reproduces unweighted fusion exactly. Results are deduped by
+    ``(path, content_hash)``, keeping the best-ranked representative, and ordered
+    by fused score. The fused score replaces the raw score for ordering only.
     """
+    bm25_weight, chroma_weight = weights
+    source_weights = {"chroma": chroma_weight, "bm25": bm25_weight}
     fused: dict[str, float] = {}
     best: dict[str, tuple[str, dict[str, Any]]] = {}
     best_rank: dict[str, int] = {}
 
     for source, results in (("chroma", chroma_results), ("bm25", bm25_results)):
+        weight_source = source_weights[source]
         for rank, (chunk_id, _raw_score, data) in enumerate(results):
             data["source"] = data.get("source", source)
             signature = _signature(chunk_id, data)
-            fused[signature] = fused.get(signature, 0.0) + 1.0 / (RRF_K + rank)
+            fused[signature] = fused.get(signature, 0.0) + weight_source * (
+                1.0 / (RRF_K + rank)
+            )
             if signature not in best_rank or rank < best_rank[signature]:
                 best_rank[signature] = rank
                 best[signature] = (chunk_id, data)

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -19,15 +19,10 @@ logger = logging.getLogger(__name__)
 # either source.
 RRF_K = 60
 
-# Query-router weights, ordered (bm25_weight, chroma_weight). On literal queries
-# the vector half is downweighted rather than dropped so a paraphrase can still
-# break a lexical tie.
 LEXICAL_ONLY = (1.0, 0.0)
 LITERAL_WEIGHTS = (1.0, 0.3)
 CONCEPTUAL_WEIGHTS = (1.0, 1.0)
 
-# A token with two or more digits (jira-123, v2.3.1, 2026-06-28) reads as a
-# literal identifier the embedding model can't disambiguate.
 _MULTI_DIGIT_RE = re.compile(r"\d.*\d")
 _ACRONYM_RE = re.compile(r"\b[A-Z]{2,}\b")
 
@@ -115,8 +110,6 @@ def retrieve_context(
             index_manager=index_manager,
         )
 
-        # Gating the vector path here is the opt-in guarantee: with semantic off,
-        # nothing touches Chroma or the embedding model at query time.
         chroma_results: list[tuple[str, float, dict[str, Any]]] = []
         weights = LEXICAL_ONLY
         if config.notes_chat.semantic_enabled:

--- a/notes_chat/search_keyword.py
+++ b/notes_chat/search_keyword.py
@@ -255,9 +255,8 @@ def _compile_pattern(options: SearchOptions) -> re.Pattern[str]:
         except re.error as exc:
             raise ValueError(f"invalid regex: {exc.msg}") from exc
 
-    # Match the same terms BM25 scores in `chirp ask` so the two search modes
-    # agree on what counts as a match (e.g. "jira-123" matches the "jira" and
-    # "123" tokens). Fall back to a substring match when there are no tokens.
+    # Match the same tokens BM25 scores in `chirp ask` so both modes agree on a
+    # match; fall back to a substring match when the query has no usable tokens.
     tokens = _tokenize_document(options.query)
     if not tokens:
         return re.compile(re.escape(options.query), re.IGNORECASE)

--- a/notes_chat/search_keyword.py
+++ b/notes_chat/search_keyword.py
@@ -12,6 +12,7 @@ from typing import Any
 from rich.console import Console
 from rich.table import Table
 
+from notes_chat.bm25 import _tokenize_document
 from utils.file_utils import NoteRecord, list_notes
 
 EXCERPT_WIDTH = 120
@@ -253,7 +254,18 @@ def _compile_pattern(options: SearchOptions) -> re.Pattern[str]:
             return re.compile(options.query, re.IGNORECASE)
         except re.error as exc:
             raise ValueError(f"invalid regex: {exc.msg}") from exc
-    return re.compile(re.escape(options.query), re.IGNORECASE)
+
+    # Literal mode matches on the same terms BM25 scores in `chirp ask`: tokenize
+    # the query with the shared tokenizer and match each token as a whole word.
+    # This keeps the two search modes agreeing on what counts as a match (e.g.
+    # "jira-123" matches the "jira" and "123" tokens, not just the literal
+    # hyphenated span). Fall back to an escaped-substring match when the query
+    # has no usable tokens (e.g. a single punctuation character).
+    tokens = _tokenize_document(options.query)
+    if not tokens:
+        return re.compile(re.escape(options.query), re.IGNORECASE)
+    alternation = "|".join(re.escape(token) for token in dict.fromkeys(tokens))
+    return re.compile(rf"\b(?:{alternation})\b", re.IGNORECASE)
 
 
 def _apply_since(

--- a/notes_chat/search_keyword.py
+++ b/notes_chat/search_keyword.py
@@ -255,12 +255,9 @@ def _compile_pattern(options: SearchOptions) -> re.Pattern[str]:
         except re.error as exc:
             raise ValueError(f"invalid regex: {exc.msg}") from exc
 
-    # Literal mode matches on the same terms BM25 scores in `chirp ask`: tokenize
-    # the query with the shared tokenizer and match each token as a whole word.
-    # This keeps the two search modes agreeing on what counts as a match (e.g.
-    # "jira-123" matches the "jira" and "123" tokens, not just the literal
-    # hyphenated span). Fall back to an escaped-substring match when the query
-    # has no usable tokens (e.g. a single punctuation character).
+    # Match the same terms BM25 scores in `chirp ask` so the two search modes
+    # agree on what counts as a match (e.g. "jira-123" matches the "jira" and
+    # "123" tokens). Fall back to a substring match when there are no tokens.
     tokens = _tokenize_document(options.query)
     if not tokens:
         return re.compile(re.escape(options.query), re.IGNORECASE)

--- a/tests/notes_chat/test_search_keyword.py
+++ b/tests/notes_chat/test_search_keyword.py
@@ -157,6 +157,56 @@ def test_levenshtein_close_keywords_filters_query_tokens():
     assert _is_close("xylophone", "pricing") is False
 
 
+def test_literal_query_matches_same_tokens_as_bm25(tmp_path):
+    """`chirp search` matches the tokens BM25 would score for a hyphenated ID.
+
+    "JIRA-1234" tokenizes to ["jira", "1234"], so the literal search finds a note
+    that contains the ID even though it never appears as one un-split substring.
+    """
+    from notes_chat.bm25 import _tokenize_document
+    from notes_chat.search_keyword import SearchOptions, run_search
+
+    settings = _build_settings(tmp_path)
+    now = datetime.now()
+    _seed_note(
+        settings,
+        slug="jira-note-recent",
+        created_at=now,
+        title="jira note",
+        transcript="JIRA-1234 must ship before the cutoff\n",
+        notes_md="owner follows up on the ticket\n",
+    )
+
+    assert _tokenize_document("JIRA-1234") == ["jira", "1234"]
+    result = run_search(settings, SearchOptions(query="JIRA-1234"))
+    assert result["matches"]
+    assert result["matches"][0]["hits"] >= 1
+
+
+def test_literal_query_uses_whole_word_matching(tmp_path):
+    """A literal search agrees with BM25's token equality, not substrings.
+
+    BM25 scores the token "tier" distinctly from "tiers", so searching "tier"
+    must not match a note whose only near-form is "tiers" — matching what
+    `chirp ask` would retrieve.
+    """
+    from notes_chat.search_keyword import SearchOptions, run_search
+
+    settings = _build_settings(tmp_path)
+    now = datetime.now()
+    _seed_note(
+        settings,
+        slug="tiers-note-recent",
+        created_at=now,
+        title="tiers note",
+        transcript="we compared the pricing tiers carefully\n",
+        notes_md="no standalone keyword here\n",
+    )
+
+    assert run_search(settings, SearchOptions(query="tier"))["matches"] == []
+    assert run_search(settings, SearchOptions(query="tiers"))["matches"]
+
+
 def _invoke_search(args: list[str], settings):
     import importlib
 

--- a/tests/test_retrieval_coverage.py
+++ b/tests/test_retrieval_coverage.py
@@ -10,10 +10,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from notes_chat.retrieval import (
+    CONCEPTUAL_WEIGHTS,
+    LITERAL_WEIGHTS,
     _build_context,
     _create_chunk_header,
     _format_mm_ss,
     _generate_suggestion,
+    _route_query,
     _search_bm25,
     _search_chroma,
     _slug_from_chunk,
@@ -27,8 +30,12 @@ from notes_chat.retrieval import (
 # ---------------------------------------------------------------------------
 
 
-def _make_config(tmp_path: Path):
-    """Build a minimal settings-like namespace for testing."""
+def _make_config(tmp_path: Path, semantic_enabled: bool = True):
+    """Build a minimal settings-like namespace for testing.
+
+    ``semantic_enabled`` defaults to ``True`` so the chroma-path tests in this
+    module exercise hybrid retrieval; gating tests pass ``False`` explicitly.
+    """
     index_dir = tmp_path / "index"
     index_dir.mkdir(parents=True, exist_ok=True)
     notes_root = tmp_path / "notes"
@@ -37,6 +44,7 @@ def _make_config(tmp_path: Path):
     return SimpleNamespace(
         directories=SimpleNamespace(notes_root=notes_root),
         notes_chat=SimpleNamespace(
+            semantic_enabled=semantic_enabled,
             index_dir=index_dir,
             k=5,
             ctx_char_budget=10000,
@@ -186,6 +194,82 @@ class TestRetrieveContext:
 
         assert result["success"] is False
         assert "boom" in result["error"]
+
+
+class TestSemanticGate:
+    def test_lexical_only_skips_chroma_when_semantic_disabled(self, tmp_path):
+        config = _make_config(tmp_path, semantic_enabled=False)
+        bm25_chunk = (
+            "id1",
+            1.0,
+            {
+                "content": "lexical content about meetings",
+                "metadata": {"path": "/notes/slug/notes.md", "date": "2025-01-01"},
+            },
+        )
+        with (
+            patch("notes_chat.retrieval.IndexManager") as MockIM,
+            patch("notes_chat.retrieval._search_chroma") as mock_chroma,
+            patch("notes_chat.retrieval._get_query_embedding") as mock_embed,
+            patch("notes_chat.retrieval._search_bm25", return_value=[bm25_chunk]),
+            patch("notes_chat.retrieval.parse_time_range", return_value=None),
+            patch("notes_chat.retrieval._build_note_index", return_value={}),
+        ):
+            manager = _make_index_manager(config, manifest_exists=True)
+            MockIM.return_value = manager
+            result = retrieve_context(config, "what happened in the meeting")
+
+        assert result["success"] is True
+        mock_chroma.assert_not_called()
+        mock_embed.assert_not_called()
+
+    def test_searches_chroma_when_semantic_enabled(self, tmp_path):
+        config = _make_config(tmp_path, semantic_enabled=True)
+        chunk = (
+            "id1",
+            0.9,
+            {
+                "content": "semantic content",
+                "metadata": {"path": "/notes/slug/notes.md", "date": "2025-01-01"},
+            },
+        )
+        with (
+            patch("notes_chat.retrieval.IndexManager") as MockIM,
+            patch(
+                "notes_chat.retrieval._search_chroma", return_value=[chunk]
+            ) as mock_chroma,
+            patch("notes_chat.retrieval._search_bm25", return_value=[]),
+            patch("notes_chat.retrieval.parse_time_range", return_value=None),
+            patch("notes_chat.retrieval._build_note_index", return_value={}),
+        ):
+            manager = _make_index_manager(config, manifest_exists=True)
+            MockIM.return_value = manager
+            result = retrieve_context(config, "summarise the planning discussion")
+
+        assert result["success"] is True
+        mock_chroma.assert_called_once()
+
+
+class TestRouteQuery:
+    def test_quoted_phrase_is_literal(self):
+        assert _route_query('find "action items" please now') == LITERAL_WEIGHTS
+
+    def test_jira_style_id_is_literal(self):
+        assert _route_query("status of PROJ-1234 ticket") == LITERAL_WEIGHTS
+
+    def test_acronym_is_literal(self):
+        assert _route_query("what did we decide about the API gateway") == (
+            LITERAL_WEIGHTS
+        )
+
+    def test_short_query_is_literal(self):
+        assert _route_query("budget numbers") == LITERAL_WEIGHTS
+
+    def test_natural_language_question_is_conceptual(self):
+        assert (
+            _route_query("what were the main concerns raised during planning")
+            == CONCEPTUAL_WEIGHTS
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_retrieval_merge.py
+++ b/tests/test_retrieval_merge.py
@@ -345,6 +345,72 @@ class TestRetrievalMerge:
         assert chunk_id in ids
         assert "JIRA-1234" in context
 
+    def test_weighted_rrf_default_matches_unweighted(self):
+        """`weights=(1.0, 1.0)` reproduces the pre-change unweighted fusion."""
+        chroma_results = [
+            (
+                "c1",
+                0.9,
+                {"content": "a", "metadata": {"path": "f1", "content_hash": "x1"}},
+            ),
+            (
+                "c2",
+                0.8,
+                {"content": "b", "metadata": {"path": "f2", "content_hash": "x2"}},
+            ),
+        ]
+        bm25_results = [
+            ("b1", 2.5, {"source": "bm25"}),
+            ("b2", 1.8, {"source": "bm25"}),
+        ]
+
+        # _merge_and_dedupe mutates the data dicts (sets "source"), so feed each
+        # call independent copies.
+        def _copy(rows):
+            return [(cid, score, dict(data)) for cid, score, data in rows]
+
+        default = _merge_and_dedupe(_copy(chroma_results), _copy(bm25_results))
+        explicit = _merge_and_dedupe(
+            _copy(chroma_results), _copy(bm25_results), weights=(1.0, 1.0)
+        )
+
+        assert [cid for cid, _, _ in default] == [cid for cid, _, _ in explicit]
+        assert [s for _, s, _ in default] == [s for _, s, _ in explicit]
+
+    def test_lexical_only_weights_drop_chroma_contribution(self):
+        """With chroma weight 0.0, chroma hits score 0 and sort below BM25 hits."""
+        chroma_results = [
+            (
+                "c1",
+                0.95,
+                {"content": "a", "metadata": {"path": "f1", "content_hash": "x1"}},
+            ),
+        ]
+        bm25_results = [("b1", 1.0, {"source": "bm25"})]
+
+        merged = _merge_and_dedupe(chroma_results, bm25_results, weights=(1.0, 0.0))
+
+        by_id = {cid: score for cid, score, _ in merged}
+        assert by_id["c1"] == 0.0
+        assert by_id["b1"] == pytest.approx(1.0 / 60.0)
+        assert merged[0][0] == "b1"
+
+    def test_literal_weights_downweight_chroma(self):
+        """A 0.3 chroma weight scales that source's RRF contribution."""
+        chroma_results = [
+            (
+                "c1",
+                0.9,
+                {"content": "a", "metadata": {"path": "f1", "content_hash": "x1"}},
+            ),
+        ]
+        bm25_results = [("b1", 1.0, {"source": "bm25"})]
+
+        merged = _merge_and_dedupe(chroma_results, bm25_results, weights=(1.0, 0.3))
+        by_id = {cid: score for cid, score, _ in merged}
+        assert by_id["c1"] == pytest.approx(0.3 * (1.0 / 60.0))
+        assert by_id["b1"] == pytest.approx(1.0 / 60.0)
+
     def test_chunk_header_creation(self):
         """Headers carry date + filename; sources fall back to slug when no config."""
         chunks = [


### PR DESCRIPTION
Make lexical (BM25) the default and only hard-required retriever, with
semantic (Chroma) search an additive, opt-in layer (Phase 1).

- Add NotesChatConfig.semantic_enabled (default False).
- retrieve_context always runs BM25; Chroma runs only when the flag is on,
  so a default install never touches embeddings at query time.
- Add deterministic _route_query that returns per-source RRF weights,
  favoring lexical on quoted spans, multi-digit IDs, acronyms, and very
  short queries; conceptual queries get balanced weights.
- Thread weights through _merge_and_dedupe; default (1.0, 1.0) reproduces
  the prior unweighted fusion exactly.
- Unify chirp search literal matching with the BM25 tokenizer so both
  search modes agree on what counts as a match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PberA5GqYHn9Ce62PJPdJQ