### PR TITLE
Address code review feedback for lexical-first retrieval

### DIFF
--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -1362,6 +1362,11 @@ def config(
         "--embedding-model",
         help="Set embedding model (e.g. nomic-embed-text)",
     ),
+    semantic: bool | None = typer.Option(
+        None,
+        "--semantic/--no-semantic",
+        help="Enable or disable opt-in semantic (vector) retrieval for ask",
+    ),
 ):
     """Manage Chirp configuration"""
     settings = get_settings()
@@ -1375,6 +1380,9 @@ Notes Root: {settings.directories.notes_root}
 Whisper: {settings.models.whisper}
 LLM: {resolved_chat_model(settings.models.llm)}
 Embedding: {settings.notes_chat.emb_model}
+
+[cyan]Search:[/cyan]
+Semantic retrieval: {"on" if settings.notes_chat.semantic_enabled else "off"}
 
 [cyan]Audio:[/cyan]
 Sample Rate: {settings.audio.sample_rate}
@@ -1404,6 +1412,10 @@ Interval: {settings.monitoring.warning_interval} minutes""",
 
     if embedding_model:
         settings.notes_chat.emb_model = embedding_model
+        changes_made = True
+
+    if semantic is not None:
+        settings.notes_chat.semantic_enabled = semantic
         changes_made = True
 
     if changes_made:

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -23,8 +23,15 @@ LEXICAL_ONLY = (1.0, 0.0)
 LITERAL_WEIGHTS = (1.0, 0.3)
 CONCEPTUAL_WEIGHTS = (1.0, 1.0)
 
-_MULTI_DIGIT_RE = re.compile(r"\d.*\d")
 _ACRONYM_RE = re.compile(r"\b[A-Z]{2,}\b")
+
+
+def _looks_like_id(token: str) -> bool:
+    """True for mixed digit+non-digit tokens (jira-123, v2.3.1, 2026-06-28).
+
+    Excludes bare numbers (room 101) so ordinary counts don't route as literal.
+    """
+    return any(ch.isdigit() for ch in token) and not token.isdigit()
 
 
 def _as_naive(value: datetime) -> datetime:
@@ -290,12 +297,10 @@ def _signature(chunk_id: str, data: dict[str, Any]) -> str:
 def _route_query(question: str) -> tuple[float, float]:
     """Pick per-source RRF weights ``(bm25, chroma)`` from the query's shape.
 
-    Pure and deterministic — no I/O. Literal signals (quoted spans, multi-digit
+    Pure and deterministic — no I/O. Literal signals (quoted spans, id-shaped
     tokens, ALL-CAPS acronyms, very short queries) favour BM25 because lexical
     retrieval wins on exact spans the small embedding model can't disambiguate.
-    Anything else is treated as conceptual, where paraphrase matching helps. The
-    function runs the same regardless of whether semantic search is enabled; it
-    only changes outcomes once the vector half actually contributes.
+    Anything else is treated as conceptual, where paraphrase matching helps.
     """
     if '"' in question:
         return LITERAL_WEIGHTS
@@ -305,7 +310,7 @@ def _route_query(question: str) -> tuple[float, float]:
         return LITERAL_WEIGHTS
 
     for token in tokens:
-        if _MULTI_DIGIT_RE.search(token):
+        if _looks_like_id(token):
             return LITERAL_WEIGHTS
 
     if _ACRONYM_RE.search(question):

--- a/notes_chat/search_keyword.py
+++ b/notes_chat/search_keyword.py
@@ -255,13 +255,23 @@ def _compile_pattern(options: SearchOptions) -> re.Pattern[str]:
         except re.error as exc:
             raise ValueError(f"invalid regex: {exc.msg}") from exc
 
-    # Match the same tokens BM25 scores in `chirp ask` so both modes agree on a
-    # match; fall back to a substring match when the query has no usable tokens.
-    tokens = _tokenize_document(options.query)
+    return _token_pattern(options.query) or re.compile(
+        re.escape(options.query), re.IGNORECASE
+    )
+
+
+def _token_pattern(text: str) -> re.Pattern[str] | None:
+    """Regex matching whole BM25 tokens of ``text``, or None if it has none.
+
+    Tokens are flanked by ``(?<!\\w)``/``(?!\\w)`` rather than ``\\b`` so the
+    match is exact token equality with `chirp ask`'s BM25 for every script
+    (``\\b`` assumes ASCII word edges and mishandles CJK / underscore runs).
+    """
+    tokens = list(dict.fromkeys(_tokenize_document(text)))
     if not tokens:
-        return re.compile(re.escape(options.query), re.IGNORECASE)
-    alternation = "|".join(re.escape(token) for token in dict.fromkeys(tokens))
-    return re.compile(rf"\b(?:{alternation})\b", re.IGNORECASE)
+        return None
+    alternation = "|".join(re.escape(token) for token in tokens)
+    return re.compile(rf"(?<!\w)(?:{alternation})(?!\w)", re.IGNORECASE)
 
 
 def _apply_since(
@@ -313,7 +323,10 @@ def _window_excerpt(line: str, match_start: int, match_end: int) -> str:
 
 
 def _markup_excerpt(text: str, query: str, regex: bool) -> str:
-    pattern = re.compile(query if regex else re.escape(query), re.IGNORECASE)
+    if regex:
+        pattern = re.compile(query, re.IGNORECASE)
+    else:
+        pattern = _token_pattern(query) or re.compile(re.escape(query), re.IGNORECASE)
     out: list[str] = []
     cursor = 0
     for match in pattern.finditer(text):

--- a/tests/notes_chat/test_search_keyword.py
+++ b/tests/notes_chat/test_search_keyword.py
@@ -207,6 +207,87 @@ def test_literal_query_uses_whole_word_matching(tmp_path):
     assert run_search(settings, SearchOptions(query="tiers"))["matches"]
 
 
+def test_cjk_query_matches_bm25_tokens_not_substrings(tmp_path):
+    """Token matching is Unicode-safe and tracks BM25 across scripts.
+
+    `_tokenize_document` splits on whitespace/punctuation, so "日本語" is a token
+    only when whitespace-separated. A literal search must match exactly that —
+    not a substring inside a longer CJK run, which `\\b` would also reject but
+    only by accident of ASCII assumptions.
+    """
+    from notes_chat.bm25 import _tokenize_document
+    from notes_chat.search_keyword import SearchOptions, run_search
+
+    assert _tokenize_document("読む 日本語 です") == ["読む", "日本語", "です"]
+    assert _tokenize_document("読む日本語です") == ["読む日本語です"]
+
+    settings = _build_settings(tmp_path)
+    now = datetime.now()
+    _seed_note(
+        settings,
+        slug="cjk-spaced-recent",
+        created_at=now,
+        title="cjk spaced",
+        transcript="読む 日本語 です\n",
+        notes_md="meeting\n",
+    )
+    _seed_note(
+        settings,
+        slug="cjk-joined-recent",
+        created_at=now,
+        title="cjk joined",
+        transcript="読む日本語です\n",
+        notes_md="meeting\n",
+    )
+
+    titles = {
+        m["title"]
+        for m in run_search(settings, SearchOptions(query="日本語"))["matches"]
+    }
+    assert titles == {"cjk spaced"}
+
+
+def test_underscore_token_matches_whole_token_only(tmp_path):
+    """`user_name` is one BM25 token (underscore is a word char), so a search for
+    `name` must not match it — exactly as `chirp ask` would score it."""
+    from notes_chat.bm25 import _tokenize_document
+    from notes_chat.search_keyword import SearchOptions, run_search
+
+    assert _tokenize_document("user_name") == ["user_name"]
+
+    settings = _build_settings(tmp_path)
+    _seed_note(
+        settings,
+        slug="snake-case-recent",
+        created_at=datetime.now(),
+        title="snake case",
+        transcript="the user_name field is required\n",
+        notes_md="meeting\n",
+    )
+
+    assert run_search(settings, SearchOptions(query="name"))["matches"] == []
+    assert run_search(settings, SearchOptions(query="user_name"))["matches"]
+
+
+def test_multi_word_literal_query_matches_any_token(tmp_path):
+    """A multi-word literal query matches notes containing ANY of its tokens
+    (BM25's OR semantics), not only the adjacent phrase."""
+    from notes_chat.search_keyword import SearchOptions, run_search
+
+    settings = _build_settings(tmp_path)
+    _seed_note(
+        settings,
+        slug="pricing-only-recent",
+        created_at=datetime.now(),
+        title="pricing only",
+        transcript="the pricing review is tomorrow\n",
+        notes_md="meeting\n",
+    )
+
+    result = run_search(settings, SearchOptions(query="pricing roadmap"))
+    assert {m["title"] for m in result["matches"]} == {"pricing only"}
+
+
 def _invoke_search(args: list[str], settings):
     import importlib
 

--- a/tests/test_retrieval_coverage.py
+++ b/tests/test_retrieval_coverage.py
@@ -30,11 +30,11 @@ from notes_chat.retrieval import (
 # ---------------------------------------------------------------------------
 
 
-def _make_config(tmp_path: Path, semantic_enabled: bool = True):
+def _make_config(tmp_path: Path, semantic_enabled: bool = False):
     """Build a minimal settings-like namespace for testing.
 
-    ``semantic_enabled`` defaults to ``True`` so the chroma-path tests in this
-    module exercise hybrid retrieval; gating tests pass ``False`` explicitly.
+    ``semantic_enabled`` defaults to ``False`` to match the production default;
+    chroma-path tests pass ``True`` explicitly.
     """
     index_dir = tmp_path / "index"
     index_dir.mkdir(parents=True, exist_ok=True)
@@ -117,7 +117,7 @@ class TestRetrieveContext:
         assert "No documents found" in result["error"]
 
     def test_returns_error_when_context_empty_after_filtering(self, tmp_path):
-        config = _make_config(tmp_path)
+        config = _make_config(tmp_path, semantic_enabled=True)
         chunk = ("id1", 0.9, {"content": "", "metadata": {}})
         with (
             patch("notes_chat.retrieval.IndexManager") as MockIM,
@@ -134,7 +134,7 @@ class TestRetrieveContext:
         assert "No relevant content" in result["error"]
 
     def test_returns_success_with_context(self, tmp_path):
-        config = _make_config(tmp_path)
+        config = _make_config(tmp_path, semantic_enabled=True)
         chunk = (
             "id1",
             0.9,
@@ -160,7 +160,7 @@ class TestRetrieveContext:
         assert "chunks_retrieved" in result
 
     def test_uses_when_filter_for_time_range(self, tmp_path):
-        config = _make_config(tmp_path)
+        config = _make_config(tmp_path, semantic_enabled=True)
         fake_range = SimpleNamespace(start=MagicMock(), end_exclusive=MagicMock())
         chunk = (
             "id1",
@@ -256,6 +256,15 @@ class TestRouteQuery:
 
     def test_jira_style_id_is_literal(self):
         assert _route_query("status of PROJ-1234 ticket") == LITERAL_WEIGHTS
+
+    def test_version_token_is_literal(self):
+        assert _route_query("when did we ship v2.3.1 to staging") == LITERAL_WEIGHTS
+
+    def test_bare_number_is_conceptual(self):
+        assert (
+            _route_query("what is the layout of room 101 in the building")
+            == CONCEPTUAL_WEIGHTS
+        )
 
     def test_acronym_is_literal(self):
         assert _route_query("what did we decide about the API gateway") == (

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,6 +25,9 @@ class TestChirpSettings:
         assert settings.audio.sample_rate == 16000
         assert settings.audio.channels == 1
 
+    def test_semantic_retrieval_defaults_off(self):
+        assert ChirpSettings().notes_chat.semantic_enabled is False
+
     def test_directories_config_paths(self):
         settings = ChirpSettings()
 


### PR DESCRIPTION
- chirp config: add --semantic/--no-semantic toggle and a Search line in
  --list so the opt-in flag is reachable without hand-editing the TOML.
- _route_query: route only id-shaped tokens (digit + non-digit) as literal,
  so ordinary numbers ("room 101") stay conceptual instead of misfiring.
- chirp search: match BM25 tokens with Unicode-safe (?<!\w)/(?!\w) bounds
  instead of \b, and highlight matched tokens (not the raw query), so the
  two search modes agree on a match across CJK / underscore / multi-word.
- Tests: assert semantic defaults off, fixture matches the prod default,
  router id-shape behavior, and CJK/underscore/multi-word search equality.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PberA5GqYHn9Ce62PJPdJQ