### PR TITLE
Phase 2: decouple BM25 indexing & retrieval from Chroma

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -369,12 +369,14 @@ class ChirpSettings(BaseModel):
 
     def ensure_directories_exist(self):
         chirp_home = default_chirp_home()
-        for directory in [
+        directories = [
             self.directories.notes_root,
             chirp_home,
             self.notes_chat.index_dir,
-            self.notes_chat.index_dir / "chroma",
-        ]:
+        ]
+        if self.notes_chat.semantic_enabled:
+            directories.append(self.notes_chat.index_dir / "chroma")
+        for directory in directories:
             directory.mkdir(parents=True, exist_ok=True)
 
 

--- a/notes_chat/bm25.py
+++ b/notes_chat/bm25.py
@@ -131,9 +131,9 @@ class BM25Index:
     def hydrate(self, chunk_id: str) -> tuple[str, dict[str, Any]] | None:
         """Return the raw ``(content, metadata)`` stored for ``chunk_id``.
 
-        Phase 2 stores each chunk's content + metadata in ``bm25.json`` itself, so
-        a lexical hit can build context with no Chroma round-trip. Returns ``None``
-        for ids without stored content (old-schema index awaiting a rebuild).
+        Content + metadata live in ``bm25.json`` itself, so a lexical hit can
+        build context with no Chroma round-trip. Returns ``None`` for ids without
+        stored content (old-schema index awaiting a rebuild).
         """
         if self._hydration is None:
             self._hydration = {

--- a/notes_chat/bm25.py
+++ b/notes_chat/bm25.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 from pathlib import Path
+from typing import Any
 
 from rank_bm25 import BM25Okapi
 
@@ -11,7 +12,15 @@ logger = logging.getLogger(__name__)
 # (mtime, size). `chirp ask` builds a BM25Index per query; without this each
 # query re-tokenizes and rebuilds BM25Okapi — O(corpus) on a ~5k-note corpus.
 _MODEL_CACHE: dict[
-    str, tuple[tuple[float, int], "BM25Okapi", list[str], list[list[str]]]
+    str,
+    tuple[
+        tuple[float, int],
+        "BM25Okapi",
+        list[str],
+        list[list[str]],
+        list[str],
+        list[dict[str, Any]],
+    ],
 ] = {}
 
 
@@ -28,8 +37,11 @@ class BM25Index:
         self.bm25_file = bm25_file
         self.bm25 = None
         self.doc_ids: list[str] = []
+        self.documents: list[str] = []
+        self.metadatas: list[dict[str, Any]] = []
         self._tokenized_corpus: list[list[str]] = []
         self._vocabulary: dict[str, int] | None = None
+        self._hydration: dict[str, tuple[str, dict[str, Any]]] | None = None
         self.load()
 
     def load(self):
@@ -41,7 +53,14 @@ class BM25Index:
         cache_key = str(self.bm25_file)
         cached = _MODEL_CACHE.get(cache_key)
         if cached is not None and fingerprint is not None and cached[0] == fingerprint:
-            _, self.bm25, self.doc_ids, self._tokenized_corpus = cached
+            (
+                _,
+                self.bm25,
+                self.doc_ids,
+                self._tokenized_corpus,
+                self.documents,
+                self.metadatas,
+            ) = cached
             return
 
         try:
@@ -49,6 +68,8 @@ class BM25Index:
                 data = json.load(f)
 
             self.doc_ids = data.get("doc_ids", [])
+            self.documents = data.get("documents", []) or []
+            self.metadatas = data.get("metadatas", []) or []
 
             if data.get("corpus"):
                 corpus = [doc.split() for doc in data["corpus"]]
@@ -60,6 +81,8 @@ class BM25Index:
                         self.bm25,
                         self.doc_ids,
                         corpus,
+                        self.documents,
+                        self.metadatas,
                     )
         except (
             OSError,
@@ -105,6 +128,22 @@ class BM25Index:
         results.sort(key=lambda x: x[1], reverse=True)
         return results[:k]
 
+    def hydrate(self, chunk_id: str) -> tuple[str, dict[str, Any]] | None:
+        """Return the raw ``(content, metadata)`` stored for ``chunk_id``.
+
+        Phase 2 stores each chunk's content + metadata in ``bm25.json`` itself, so
+        a lexical hit can build context with no Chroma round-trip. Returns ``None``
+        for ids without stored content (old-schema index awaiting a rebuild).
+        """
+        if self._hydration is None:
+            self._hydration = {
+                doc_id: (document, metadata)
+                for doc_id, document, metadata in zip(
+                    self.doc_ids, self.documents, self.metadatas, strict=False
+                )
+            }
+        return self._hydration.get(chunk_id)
+
     def _tokenize(self, text: str) -> list[str]:
         """Tokenize text for BM25."""
         text = text.lower()
@@ -112,25 +151,29 @@ class BM25Index:
         return [token for token in text.split() if len(token) > 1]
 
 
-def rebuild_bm25_index(chroma_collection, bm25_file: Path):
-    """Rebuild BM25 index from Chroma collection."""
-    try:
-        results = chroma_collection.get()
+def rebuild_bm25_index(
+    doc_ids: list[str],
+    documents: list[str],
+    metadatas: list[dict[str, Any]],
+    bm25_file: Path,
+) -> None:
+    """Rewrite ``bm25.json`` as a self-sufficient lexical store.
 
-        if not results["ids"]:
+    Stores the tokenized ``corpus`` for scoring plus the raw chunk ``documents``
+    and ``metadatas``, so retrieval can build context from this file alone — no
+    Chroma round-trip even when semantic search is enabled.
+    """
+    try:
+        if not doc_ids:
             return
 
-        doc_ids = results["ids"]
-        documents = results["documents"]
-
-        tokenized_corpus = []
-        for doc in documents:
-            tokens = _tokenize_document(doc)
-            tokenized_corpus.append(tokens)
+        tokenized_corpus = [_tokenize_document(doc) for doc in documents]
 
         bm25_data = {
             "doc_ids": doc_ids,
             "corpus": [" ".join(tokens) for tokens in tokenized_corpus],
+            "documents": documents,
+            "metadatas": metadatas,
         }
 
         bm25_file.parent.mkdir(parents=True, exist_ok=True)
@@ -141,7 +184,7 @@ def rebuild_bm25_index(chroma_collection, bm25_file: Path):
         # mtime resolution, so the fingerprint alone wouldn't invalidate it.
         _MODEL_CACHE.pop(str(bm25_file), None)
 
-    except Exception as e:  # noqa: BLE001 - chromadb or IO; many failure modes
+    except OSError as e:
         logger.warning("Failed to rebuild BM25 index: %s", e)
 
 
@@ -149,15 +192,17 @@ def append_bm25_index(
     bm25_file: Path,
     doc_ids: list[str],
     documents: list[str],
+    metadatas: list[dict[str, Any]],
     stale_id_prefix: str | None = None,
 ) -> None:
     """Merge a single note's chunks into ``bm25.json`` without a full re-tokenize.
 
     Auto-indexing one saved note used to trigger a whole-corpus rebuild
-    (``rebuild_bm25_index`` pulls the entire Chroma collection and re-tokenizes
-    it). A burst of N saves then cost N full rebuilds. Appending just the
-    changed chunks — replacing any existing entries for the same ids so a
-    re-save updates in place — keeps a save O(note) instead of O(corpus).
+    (``rebuild_bm25_index`` re-tokenizes every chunk). A burst of N saves then
+    cost N full rebuilds. Appending just the changed chunks — replacing any
+    existing entries for the same ids so a re-save updates in place — keeps a
+    save O(note) instead of O(corpus). The raw ``documents`` and ``metadatas``
+    are merged alongside the tokenized corpus so the store stays self-sufficient.
 
     ``stale_id_prefix`` (the note's ``{slug}_`` id prefix) drops any existing
     entry that belongs to this note but is no longer present — i.e. ghost ids
@@ -166,24 +211,46 @@ def append_bm25_index(
     """
     existing_ids: list[str] = []
     existing_corpus: list[str] = []
+    existing_documents: list[str] = []
+    existing_metadatas: list[dict[str, Any]] = []
     if bm25_file.exists():
         try:
             with bm25_file.open() as f:
                 data = json.load(f)
             existing_ids = data.get("doc_ids", []) or []
             existing_corpus = data.get("corpus", []) or []
+            existing_documents = data.get("documents", []) or []
+            existing_metadatas = data.get("metadatas", []) or []
         except (OSError, json.JSONDecodeError, ValueError, TypeError):
             existing_ids = []
             existing_corpus = []
+            existing_documents = []
+            existing_metadatas = []
+
+    # Pad so the parallel-array merge below can't truncate to the shortest list
+    # and silently drop ids — an old-schema file carries no documents/metadatas.
+    n = len(existing_ids)
+    if len(existing_documents) != n:
+        existing_documents = [""] * n
+    if len(existing_metadatas) != n:
+        existing_metadatas = [{} for _ in range(n)]
 
     incoming = {
-        doc_id: " ".join(_tokenize_document(doc))
-        for doc_id, doc in zip(doc_ids, documents, strict=False)
+        doc_id: (" ".join(_tokenize_document(doc)), doc, meta)
+        for doc_id, doc, meta in zip(doc_ids, documents, metadatas, strict=False)
     }
 
     merged_ids: list[str] = []
     merged_corpus: list[str] = []
-    for doc_id, corpus_entry in zip(existing_ids, existing_corpus, strict=False):
+    merged_documents: list[str] = []
+    merged_metadatas: list[dict[str, Any]] = []
+    for doc_id, corpus_entry, document, metadata in zip(
+        existing_ids,
+        existing_corpus,
+        existing_documents,
+        existing_metadatas,
+        strict=False,
+    ):
         if doc_id in incoming:
             continue
         # Drop ghost ids: a chunk that vanished when this note was re-chunked.
@@ -191,13 +258,26 @@ def append_bm25_index(
             continue
         merged_ids.append(doc_id)
         merged_corpus.append(corpus_entry)
-    for doc_id, corpus_entry in incoming.items():
+        merged_documents.append(document)
+        merged_metadatas.append(metadata)
+    for doc_id, (corpus_entry, document, metadata) in incoming.items():
         merged_ids.append(doc_id)
         merged_corpus.append(corpus_entry)
+        merged_documents.append(document)
+        merged_metadatas.append(metadata)
 
     bm25_file.parent.mkdir(parents=True, exist_ok=True)
     with bm25_file.open("w") as f:
-        json.dump({"doc_ids": merged_ids, "corpus": merged_corpus}, f, indent=2)
+        json.dump(
+            {
+                "doc_ids": merged_ids,
+                "corpus": merged_corpus,
+                "documents": merged_documents,
+                "metadatas": merged_metadatas,
+            },
+            f,
+            indent=2,
+        )
 
     _MODEL_CACHE.pop(str(bm25_file), None)
 

--- a/notes_chat/index.py
+++ b/notes_chat/index.py
@@ -704,8 +704,8 @@ class IndexManager:
 
         Used by the auto-index-on-save path so a single save doesn't trigger a
         full-corpus re-tokenize (a burst of N saves would otherwise cost N full
-        rebuilds — see AC-6). Chunks come from the file itself, so this works
-        with the vector half disabled.
+        rebuilds). Chunks come from the file itself, so this works with the
+        vector half disabled.
         """
         try:
             from notes_chat.bm25 import append_bm25_index

--- a/notes_chat/index.py
+++ b/notes_chat/index.py
@@ -442,6 +442,9 @@ class IndexManager:
 
     def _save_manifest(self, manifest: dict[str, Any]):
         """Save the index manifest."""
+        # A lexical-only add_note never opens Chroma (which used to create
+        # index_dir as a side effect), so ensure the directory exists here.
+        self.manifest_file.parent.mkdir(parents=True, exist_ok=True)
         with self.manifest_file.open("w") as f:
             json.dump(manifest, f, indent=2)
 

--- a/notes_chat/index.py
+++ b/notes_chat/index.py
@@ -36,17 +36,39 @@ class IndexManager:
         self.notes_root = config.directories.notes_root
         self._llm_client = llm_client
 
-        self.chroma_client = chromadb.PersistentClient(
-            path=str(self.settings.index_dir / "chroma"),
-            settings=ChromaSettings(allow_reset=True),
-        )
-        self.collection = self.chroma_client.get_or_create_collection(
-            name=COLLECTION_NAME, metadata={"hnsw:space": "cosine"}
-        )
+        self._chroma_client: chromadb.ClientAPI | None = None
+        self._collection: chromadb.Collection | None = None
         self._temp_collection = None
 
         self.manifest_file = self.settings.index_dir / "manifest.json"
         self.bm25_file = self.settings.index_dir / "bm25.json"
+
+    @property
+    def chroma_client(self) -> chromadb.ClientAPI:
+        """Lazily open the Chroma client (and so the ``chroma/`` dir) on first use.
+
+        A lexical-only install (``semantic_enabled=False``) never touches the
+        vector half, so this stays unopened and no ``chroma/`` directory is
+        created. Only the gated semantic paths reach it.
+        """
+        if self._chroma_client is None:
+            self._chroma_client = chromadb.PersistentClient(
+                path=str(self.settings.index_dir / "chroma"),
+                settings=ChromaSettings(allow_reset=True),
+            )
+        return self._chroma_client
+
+    @property
+    def collection(self) -> chromadb.Collection:
+        if self._collection is None:
+            self._collection = self.chroma_client.get_or_create_collection(
+                name=COLLECTION_NAME, metadata={"hnsw:space": "cosine"}
+            )
+        return self._collection
+
+    @collection.setter
+    def collection(self, value: chromadb.Collection) -> None:
+        self._collection = value
 
     def build_index(
         self,
@@ -59,7 +81,8 @@ class IndexManager:
 
         try:
             self.config.ensure_directories_exist()
-            self._ensure_embed_fingerprint()
+            if self.settings.semantic_enabled:
+                self._ensure_embed_fingerprint()
 
             manifest = self._load_manifest()
             current_files = self._scan_notes_files()
@@ -90,7 +113,8 @@ class IndexManager:
             failed_files: list[str] = []
 
             for file_path in removed_files:
-                self._remove_from_index(file_path)
+                if self.settings.semantic_enabled:
+                    self._remove_from_index(file_path)
                 manifest.pop(file_path, None)
                 processed_count += 1
                 if progress_callback:
@@ -110,7 +134,8 @@ class IndexManager:
 
             self._save_manifest(manifest)
             self._rebuild_bm25()
-            self._stamp_fingerprint_if_missing()
+            if self.settings.semantic_enabled:
+                self._stamp_fingerprint_if_missing()
             self._report_failures(failed_files)
 
             return {
@@ -142,7 +167,7 @@ class IndexManager:
         note's chunks instead of rebuilding the whole BM25 index, keeping a
         burst of saves O(note) per save.
         """
-        if guard_embed_fingerprint:
+        if guard_embed_fingerprint and self.settings.semantic_enabled:
             self._ensure_embed_fingerprint()
         if not self._add_to_index(notes_path):
             return False
@@ -156,7 +181,8 @@ class IndexManager:
 
         if incremental_bm25:
             self.append_bm25_for_file(file_path)
-            self._stamp_fingerprint_if_missing()
+            if self.settings.semantic_enabled:
+                self._stamp_fingerprint_if_missing()
         else:
             self._rebuild_bm25()
         return True
@@ -164,7 +190,8 @@ class IndexManager:
     def remove_note(self, notes_path: str | Path) -> None:
         """Drop a single note from the vector index, manifest, and BM25."""
         file_path = str(notes_path)
-        self._remove_from_index(file_path)
+        if self.settings.semantic_enabled:
+            self._remove_from_index(file_path)
         manifest = self._load_manifest()
         manifest.pop(file_path, None)
         self._save_manifest(manifest)
@@ -185,28 +212,24 @@ class IndexManager:
             self.config.ensure_directories_exist()
 
             current_files = self._scan_notes_files()
-            temp_collection = self._reset_temp_collection()
 
-            new_manifest: dict[str, Any] = {}
-            failed_files: list[str] = []
-            processed_count = 0
+            if self.settings.semantic_enabled:
+                temp_collection = self._reset_temp_collection()
+                active_collection = self.collection
+                self.collection = temp_collection
+                try:
+                    new_manifest, failed_files, processed_count = self._index_files(
+                        current_files, progress_callback
+                    )
+                finally:
+                    self.collection = active_collection
+                self._promote_temp_collection()
+                self._write_fingerprint_metadata(self.collection)
+            else:
+                new_manifest, failed_files, processed_count = self._index_files(
+                    current_files, progress_callback
+                )
 
-            active_collection = self.collection
-            self.collection = temp_collection
-            try:
-                for file_path in current_files:
-                    if self._add_to_index(Path(file_path)):
-                        new_manifest[file_path] = current_files[file_path]
-                        processed_count += 1
-                        if progress_callback:
-                            progress_callback()
-                    else:
-                        failed_files.append(file_path)
-            finally:
-                self.collection = active_collection
-
-            self._promote_temp_collection()
-            self._write_fingerprint_metadata(self.collection)
             self._save_manifest(new_manifest)
             self._rebuild_bm25()
             self._report_failures(failed_files)
@@ -222,8 +245,28 @@ class IndexManager:
 
         except Exception as e:  # noqa: BLE001 - force rebuild orchestrates many subsystems
             logger.debug("Index force-rebuild failed: %s", e, exc_info=True)
-            self._discard_temp_collection()
+            if self.settings.semantic_enabled:
+                self._discard_temp_collection()
             return {"success": False, "error": str(e)}
+
+    def _index_files(
+        self,
+        current_files: dict[str, dict[str, Any]],
+        progress_callback: Callable | None,
+    ) -> tuple[dict[str, Any], list[str], int]:
+        """Add each note file to the index, returning (manifest, failed, count)."""
+        new_manifest: dict[str, Any] = {}
+        failed_files: list[str] = []
+        processed_count = 0
+        for file_path in current_files:
+            if self._add_to_index(Path(file_path)):
+                new_manifest[file_path] = current_files[file_path]
+                processed_count += 1
+                if progress_callback:
+                    progress_callback()
+            else:
+                failed_files.append(file_path)
+        return new_manifest, failed_files, processed_count
 
     def _report_failures(self, failed_files: list[str]) -> None:
         if not failed_files:
@@ -402,19 +445,34 @@ class IndexManager:
         with self.manifest_file.open("w") as f:
             json.dump(manifest, f, indent=2)
 
+    def _chunks_for_file(self, file_path: Path) -> list[Chunk]:
+        """Read a note file and split it into chunks (no embedding / Chroma touch).
+
+        Shared by the embed path and the file-sourced BM25 build so both derive
+        identical chunk ids from the same content.
+        """
+        content = file_path.read_text(encoding="utf-8")
+        meta = self._extract_metadata(file_path, content)
+        if not meta:
+            return []
+        return self._chunk_content(file_path, content, meta)
+
     def _add_to_index(self, file_path: Path) -> bool:
-        """Add a notes file to the index."""
+        """Add a notes file to the index.
+
+        With ``semantic_enabled=False`` the lexical store is the only index, so
+        this just validates the file chunks and returns success without loading
+        the embed model or touching Chroma; ``_rebuild_bm25`` / the BM25 append
+        path persist the lexical entries.
+        """
         try:
-            content = file_path.read_text(encoding="utf-8")
-            meta = self._extract_metadata(file_path, content)
-
-            if not meta:
-                return False
-
-            chunks = self._chunk_content(file_path, content, meta)
+            chunks = self._chunks_for_file(file_path)
 
             if not chunks:
                 return False
+
+            if not self.settings.semantic_enabled:
+                return True
 
             self._remove_from_index(str(file_path))
 
@@ -615,12 +673,26 @@ class IndexManager:
         }
 
     def _rebuild_bm25(self):
-        """Rebuild BM25 index from Chroma data."""
+        """Rebuild the BM25 lexical store from the note files on disk.
+
+        Sourced from the files (not Chroma) so the lexical index is fully
+        self-sufficient — it exists and answers queries even when the vector
+        half is disabled and no ``chroma/`` directory has been created.
+        """
         try:
             from notes_chat.bm25 import rebuild_bm25_index
 
-            rebuild_bm25_index(self.collection, self.bm25_file)
-        except Exception as e:  # noqa: BLE001 - chromadb or IO; many failure modes
+            doc_ids: list[str] = []
+            documents: list[str] = []
+            metadatas: list[dict[str, Any]] = []
+            for file_path in self._scan_notes_files():
+                for chunk in self._chunks_for_file(Path(file_path)):
+                    doc_ids.append(chunk.id)
+                    documents.append(chunk.content)
+                    metadatas.append(self._chunk_to_metadata(chunk))
+
+            rebuild_bm25_index(doc_ids, documents, metadatas, self.bm25_file)
+        except Exception as e:  # noqa: BLE001 - IO / parse; many failure modes
             logger.debug("Failed to rebuild BM25 index: %s", e)
             console.print(f"[yellow]Failed to rebuild BM25 index: {e}[/yellow]")
 
@@ -629,14 +701,16 @@ class IndexManager:
 
         Used by the auto-index-on-save path so a single save doesn't trigger a
         full-corpus re-tokenize (a burst of N saves would otherwise cost N full
-        rebuilds — see AC-6).
+        rebuilds — see AC-6). Chunks come from the file itself, so this works
+        with the vector half disabled.
         """
         try:
             from notes_chat.bm25 import append_bm25_index
 
-            records = self.collection.get(where={"path": file_path})
-            doc_ids = records.get("ids") or []
-            documents = records.get("documents") or []
+            chunks = self._chunks_for_file(Path(file_path))
+            doc_ids = [chunk.id for chunk in chunks]
+            documents = [chunk.content for chunk in chunks]
+            metadatas = [self._chunk_to_metadata(chunk) for chunk in chunks]
             if doc_ids:
                 # Purge {slug}_NNN ghost ids for this note that vanished when it
                 # was re-chunked into fewer chunks.
@@ -645,9 +719,10 @@ class IndexManager:
                     self.bm25_file,
                     doc_ids,
                     documents,
+                    metadatas,
                     stale_id_prefix=slug_prefix,
                 )
-        except Exception as e:  # noqa: BLE001 - chromadb or IO; many failure modes
+        except Exception as e:  # noqa: BLE001 - IO / parse; many failure modes
             logger.debug("Failed to append BM25 index for %s: %s", file_path, e)
 
 

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -220,15 +220,19 @@ def _search_bm25(
     k: int,
     index_manager: IndexManager | None = None,
 ) -> list[tuple[str, float, dict[str, Any]]]:
-    """Search BM25 index, hydrating each hit with its Chroma metadata + content.
+    """Search BM25, hydrating each hit with its content + metadata from the store.
 
-    A bare ``{"source": "bm25"}`` payload carries no ``metadata`` and no
-    ``content``, which breaks two things: (1) ``_merge_and_dedupe`` would key the
-    hit by bare chunk_id instead of ``path::content_hash``, so a chunk found by
-    BOTH retrievers fails to dedupe and its RRF contributions are never summed;
-    (2) ``_build_context`` drops contentless chunks, so the lexical half of
-    "hybrid" could never surface a BM25-only hit. Hydrating from Chroma
-    (``collection.get(ids=...)``) gives both sources the same shape.
+    The lexical store (``bm25.json``) carries each chunk's content and metadata,
+    so hits hydrate from it directly — no Chroma round-trip, which is what lets
+    lexical-only retrieval answer with the vector half disabled. A bare
+    ``{"source": "bm25"}`` payload carries no ``metadata`` and no ``content``,
+    which breaks two things: (1) ``_merge_and_dedupe`` would key the hit by bare
+    chunk_id instead of ``path::content_hash``, so a chunk found by BOTH
+    retrievers fails to dedupe and its RRF contributions are never summed;
+    (2) ``_build_context`` drops contentless chunks, so the lexical half could
+    never surface a BM25-only hit. Hydrating from the store gives both sources
+    the same shape. ``index_manager`` is accepted for call-site compatibility but
+    no longer consulted — the BM25 store is self-sufficient.
     """
     try:
         bm25_index = BM25Index(bm25_file)
@@ -236,52 +240,22 @@ def _search_bm25(
         if not bm25_results:
             return []
 
-        if index_manager is None:
-            return [
-                (chunk_id, score, {"source": "bm25"})
-                for chunk_id, score in bm25_results
-            ]
-
-        hydrated = _hydrate_chunks(index_manager, [cid for cid, _ in bm25_results])
         results: list[tuple[str, float, dict[str, Any]]] = []
         for chunk_id, score in bm25_results:
-            data = hydrated.get(chunk_id)
-            if data is None:
-                # Stale BM25 id with no Chroma record: keep it so a lexical-only
-                # match isn't dropped, but without content it can't enter context.
-                data = {"source": "bm25"}
+            hydrated = bm25_index.hydrate(chunk_id)
+            if hydrated is None:
+                # Keep a contentless old-schema/stale hit so the match isn't
+                # dropped, though without content it can't enter context.
+                data: dict[str, Any] = {"source": "bm25"}
+            else:
+                content, metadata = hydrated
+                data = {"content": content, "metadata": metadata, "source": "bm25"}
             results.append((chunk_id, score, data))
         return results
 
     except Exception as e:  # noqa: BLE001 - BM25 can raise many types on corrupt index
         logger.debug("BM25 search failed: %s", e, exc_info=True)
         return []
-
-
-def _hydrate_chunks(
-    index_manager: IndexManager, chunk_ids: list[str]
-) -> dict[str, dict[str, Any]]:
-    """Map chunk_id → ``{"content", "metadata", "source": "bm25"}`` from Chroma."""
-    try:
-        records = index_manager.collection.get(ids=chunk_ids)
-    except Exception as e:  # noqa: BLE001 - chromadb raises various internal exceptions
-        logger.debug("BM25 hydrate failed: %s", e, exc_info=True)
-        return {}
-
-    ids = records.get("ids") or []
-    documents = records.get("documents") or []
-    metadatas = records.get("metadatas") or []
-
-    hydrated: dict[str, dict[str, Any]] = {}
-    for i, chunk_id in enumerate(ids):
-        document = documents[i] if i < len(documents) else ""
-        metadata = metadatas[i] if i < len(metadatas) else {}
-        hydrated[chunk_id] = {
-            "content": document,
-            "metadata": metadata,
-            "source": "bm25",
-        }
-    return hydrated
 
 
 def _signature(chunk_id: str, data: dict[str, Any]) -> str:

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -1,7 +1,7 @@
 import json
-from unittest.mock import Mock
 
 from notes_chat.bm25 import (
+    _MODEL_CACHE,
     BM25Index,
     _tokenize_document,
     append_bm25_index,
@@ -131,19 +131,20 @@ class TestBM25:
         assert results == []
         assert index.bm25 is None
 
-    def test_rebuild_from_chroma(self, tmp_path):
-        """Test rebuilding BM25 index from Chroma collection."""
-        mock_collection = Mock()
-        mock_collection.get.return_value = {
-            "ids": ["chunk1", "chunk2"],
-            "documents": [
-                "Meeting about project planning and timelines",
-                "Technical discussion on architecture decisions",
-            ],
-        }
+    def test_rebuild_writes_self_sufficient_store(self, tmp_path):
+        """Rebuild writes corpus + raw documents + metadata (no Chroma needed)."""
+        doc_ids = ["chunk1", "chunk2"]
+        documents = [
+            "Meeting about project planning and timelines",
+            "Technical discussion on architecture decisions",
+        ]
+        metadatas = [
+            {"path": "/n/a/notes.md", "content_hash": "h1"},
+            {"path": "/n/b/notes.md", "content_hash": "h2"},
+        ]
 
         bm25_file = tmp_path / "rebuilt_bm25.json"
-        rebuild_bm25_index(mock_collection, bm25_file)
+        rebuild_bm25_index(doc_ids, documents, metadatas, bm25_file)
 
         assert bm25_file.exists()
 
@@ -154,32 +155,106 @@ class TestBM25:
         assert len(data["corpus"]) == 2
         assert "project" in data["corpus"][0]
         assert "technical" in data["corpus"][1]
+        assert data["documents"] == documents
+        assert data["metadatas"] == metadatas
+
+    def test_rebuild_skips_write_when_empty(self, tmp_path):
+        """No doc ids => no file written (nothing to index)."""
+        bm25_file = tmp_path / "empty_bm25.json"
+        rebuild_bm25_index([], [], [], bm25_file)
+        assert not bm25_file.exists()
+
+    def test_index_exposes_documents_and_metadata(self, tmp_path):
+        """BM25Index round-trips documents/metadatas for in-store hydration."""
+        bm25_file = tmp_path / "bm25.json"
+        doc_ids = ["doc1", "doc2"]
+        documents = ["alpha budget planning", "beta roadmap review"]
+        metadatas = [
+            {"path": "/n/alpha/notes.md", "content_hash": "ha"},
+            {"path": "/n/beta/notes.md", "content_hash": "hb"},
+        ]
+        rebuild_bm25_index(doc_ids, documents, metadatas, bm25_file)
+
+        index = BM25Index(bm25_file)
+        assert index.documents == documents
+        assert index.metadatas == metadatas
+        assert index.hydrate("doc1") == (documents[0], metadatas[0])
+        assert index.hydrate("missing") is None
+
+    def test_old_schema_hydrate_returns_none(self, tmp_path):
+        """An old 2-key bm25.json still searches but hydrates nothing (rebuild cue).
+
+        Existing installs carry ``{doc_ids, corpus}`` only; until the next full
+        rebuild repopulates documents/metadatas, hydration must degrade to None
+        rather than crash so a lexical hit is still surfaced (without content).
+        """
+        bm25_file = tmp_path / "bm25.json"
+        bm25_file.write_text(
+            json.dumps({"doc_ids": ["doc1"], "corpus": ["alpha budget planning"]})
+        )
+        _MODEL_CACHE.pop(str(bm25_file), None)
+
+        index = BM25Index(bm25_file)
+        assert index.search("budget", k=5)
+        assert index.documents == []
+        assert index.hydrate("doc1") is None
 
 
 class TestBM25Append:
+    def _meta(self, *slugs):
+        return [{"path": f"/n/{s}/notes.md", "content_hash": s} for s in slugs]
+
     def test_append_adds_chunks(self, tmp_path):
         bm25_file = tmp_path / "bm25.json"
         append_bm25_index(
             bm25_file,
             ["alpha_000", "alpha_001"],
             ["first chunk text", "second chunk text"],
+            self._meta("a0", "a1"),
             stale_id_prefix="alpha_",
         )
         with bm25_file.open() as f:
             data = json.load(f)
         assert set(data["doc_ids"]) == {"alpha_000", "alpha_001"}
+        assert data["documents"] == ["first chunk text", "second chunk text"]
+        assert data["metadatas"] == self._meta("a0", "a1")
 
     def test_append_preserves_other_notes(self, tmp_path):
+        bm25_file = tmp_path / "bm25.json"
+        rebuild_bm25_index(
+            ["beta_000"], ["beta content here"], self._meta("b0"), bm25_file
+        )
+        append_bm25_index(
+            bm25_file,
+            ["alpha_000"],
+            ["alpha content"],
+            self._meta("a0"),
+            stale_id_prefix="alpha_",
+        )
+        with bm25_file.open() as f:
+            data = json.load(f)
+        assert set(data["doc_ids"]) == {"beta_000", "alpha_000"}
+        index = BM25Index(bm25_file)
+        assert index.hydrate("beta_000") == ("beta content here", self._meta("b0")[0])
+
+    def test_append_preserves_old_schema_entries(self, tmp_path):
+        """Appending to a 2-key file keeps the existing ids (padded content)."""
         bm25_file = tmp_path / "bm25.json"
         bm25_file.write_text(
             json.dumps({"doc_ids": ["beta_000"], "corpus": ["beta content here"]})
         )
         append_bm25_index(
-            bm25_file, ["alpha_000"], ["alpha content"], stale_id_prefix="alpha_"
+            bm25_file,
+            ["alpha_000"],
+            ["alpha content"],
+            self._meta("a0"),
+            stale_id_prefix="alpha_",
         )
         with bm25_file.open() as f:
             data = json.load(f)
         assert set(data["doc_ids"]) == {"beta_000", "alpha_000"}
+        assert len(data["documents"]) == 2
+        assert len(data["metadatas"]) == 2
 
     def test_append_purges_ghost_ids_on_shrink(self, tmp_path):
         """L3: a note shrinking from 3 chunks to 2 must not leave a ghost id."""
@@ -188,12 +263,14 @@ class TestBM25Append:
             bm25_file,
             ["alpha_000", "alpha_001", "alpha_002"],
             ["chunk a", "chunk b", "chunk c"],
+            self._meta("a0", "a1", "a2"),
             stale_id_prefix="alpha_",
         )
         append_bm25_index(
             bm25_file,
             ["alpha_000", "alpha_001"],
             ["chunk a edited", "chunk b edited"],
+            self._meta("a0", "a1"),
             stale_id_prefix="alpha_",
         )
         with bm25_file.open() as f:
@@ -208,8 +285,11 @@ class TestBM25Append:
             bm25_file,
             ["alpha_000", "alpha_001", "alpha_002"],
             ["chunk a", "chunk b", "chunk c"],
+            self._meta("a0", "a1", "a2"),
         )
-        append_bm25_index(bm25_file, ["alpha_000"], ["chunk a edited"])
+        append_bm25_index(
+            bm25_file, ["alpha_000"], ["chunk a edited"], self._meta("a0")
+        )
         with bm25_file.open() as f:
             data = json.load(f)
         # Ghosts linger by design without a prefix; a full rebuild purges them.

--- a/tests/test_index_manifest.py
+++ b/tests/test_index_manifest.py
@@ -424,6 +424,55 @@ class TestLexicalOnlyIndexing:
         assert manager.collection.get()["ids"]
         assert manager.bm25_file.exists()
 
+    def test_incremental_add_note_skips_fingerprint_when_lexical_only(self, tmp_path):
+        """Off-mirror of the guarded incremental add: no embed-fingerprint work.
+
+        This is the production-default (semantic off) auto-index-on-save path;
+        with the flag on it would call ensure/stamp (see the guarded on-case).
+        """
+        config = _make_config(tmp_path, semantic_enabled=False)
+        note_file = _seed_note(tmp_path)
+        manager = IndexManager(config)
+
+        with (
+            patch.object(manager, "_ensure_embed_fingerprint") as ensure_fp,
+            patch.object(manager, "_add_to_index", return_value=True) as add_idx,
+            patch.object(manager, "_save_manifest") as save_manifest,
+            patch.object(manager, "append_bm25_for_file") as append_bm25,
+            patch.object(manager, "_rebuild_bm25") as rebuild_bm25,
+            patch.object(manager, "_stamp_fingerprint_if_missing") as stamp_fp,
+        ):
+            result = manager.add_note(
+                note_file, guard_embed_fingerprint=True, incremental_bm25=True
+            )
+
+        assert result is True
+        ensure_fp.assert_not_called()
+        stamp_fp.assert_not_called()
+        add_idx.assert_called_once_with(note_file)
+        save_manifest.assert_called_once()
+        append_bm25.assert_called_once_with(str(note_file))
+        rebuild_bm25.assert_not_called()
+
+    def test_incremental_add_note_lexical_only_end_to_end(self, tmp_path):
+        """The real auto-index path off: no embed call, no chroma/, BM25 has content."""
+        from notes_chat.bm25 import BM25Index
+
+        config = _make_config(tmp_path, semantic_enabled=False)
+        note_file = _seed_note(tmp_path)
+
+        manager = IndexManager(config, llm_client=_ExplodingEmbedClient())
+        assert manager.add_note(
+            note_file, guard_embed_fingerprint=True, incremental_bm25=True
+        )
+
+        assert not (config.notes_chat.index_dir / "chroma").exists()
+        index = BM25Index(manager.bm25_file)
+        hits = index.search("chunking", k=5)
+        assert hits
+        content, _meta = index.hydrate(hits[0][0])
+        assert "chunking" in content.lower()
+
 
 class TestSingleNoteIndexing:
     def test_add_note_incremental_with_guard(self, tmp_path):

--- a/tests/test_index_manifest.py
+++ b/tests/test_index_manifest.py
@@ -30,10 +30,17 @@ class _FakeEmbedClient:
         return [[0.1] * self.dim for _ in inputs]
 
 
-def _make_config(tmp_path):
+def _make_config(tmp_path, semantic_enabled: bool = True):
+    """Build settings rooted at ``tmp_path``.
+
+    ``semantic_enabled`` defaults to ``True`` so the embed/Chroma regression
+    tests below exercise the vector path; the lexical-only suite passes ``False``
+    to assert no embed model loads and no ``chroma/`` directory is created.
+    """
     config = ChirpSettings()
     config.directories.notes_root = tmp_path
     config.notes_chat.index_dir = tmp_path / ".notes_index"
+    config.notes_chat.semantic_enabled = semantic_enabled
     return config
 
 
@@ -350,6 +357,72 @@ Test meeting content
         alias, dim = reopened._stored_fingerprint()
         assert alias == "bge-small"
         assert dim == 384
+
+
+class _ExplodingEmbedClient:
+    """Sentinel embed client: any embed call fails the lexical-only contract."""
+
+    def embed_sync(self, inputs, model="default"):
+        raise AssertionError("embed model must not load when semantic is disabled")
+
+
+class TestLexicalOnlyIndexing:
+    def test_build_creates_no_chroma_dir_and_never_embeds(self, tmp_path):
+        """Semantic off: no embed model loads and no chroma/ directory appears."""
+        config = _make_config(tmp_path, semantic_enabled=False)
+        _seed_note(tmp_path)
+
+        manager = IndexManager(config, llm_client=_ExplodingEmbedClient())
+        result = manager.build_index()
+
+        assert result["success"]
+        assert result["files_processed"] == 1
+        assert not (config.notes_chat.index_dir / "chroma").exists()
+        assert manager.bm25_file.exists()
+        assert manager.manifest_file.exists()
+
+    def test_bm25_store_carries_content_when_lexical_only(self, tmp_path):
+        """A BM25 hit hydrates content + metadata straight from bm25.json."""
+        from notes_chat.bm25 import BM25Index
+
+        config = _make_config(tmp_path, semantic_enabled=False)
+        _seed_note(tmp_path)
+
+        manager = IndexManager(config, llm_client=_ExplodingEmbedClient())
+        assert manager.build_index()["success"]
+
+        index = BM25Index(manager.bm25_file)
+        hits = index.search("chunking", k=5)
+        assert hits
+        content, metadata = index.hydrate(hits[0][0])
+        assert "chunking" in content.lower()
+        assert metadata["path"].endswith("notes.md")
+        assert not (config.notes_chat.index_dir / "chroma").exists()
+
+    def test_force_rebuild_lexical_only_skips_chroma(self, tmp_path):
+        """--force with semantic off rebuilds BM25 without creating chroma/."""
+        config = _make_config(tmp_path, semantic_enabled=False)
+        _seed_note(tmp_path)
+
+        manager = IndexManager(config, llm_client=_ExplodingEmbedClient())
+        result = manager.build_index(force=True)
+
+        assert result["success"]
+        assert result["files_processed"] == 1
+        assert not (config.notes_chat.index_dir / "chroma").exists()
+        assert manager.bm25_file.exists()
+
+    def test_semantic_on_still_populates_chroma_and_bm25(self, tmp_path):
+        """Regression: with semantic on, both Chroma and BM25 are populated."""
+        config = _make_config(tmp_path, semantic_enabled=True)
+        _seed_note(tmp_path)
+
+        manager = IndexManager(config, llm_client=_FakeEmbedClient())
+        assert manager.build_index()["success"]
+
+        assert (config.notes_chat.index_dir / "chroma").exists()
+        assert manager.collection.get()["ids"]
+        assert manager.bm25_file.exists()
 
 
 class TestSingleNoteIndexing:

--- a/tests/test_retrieval_merge.py
+++ b/tests/test_retrieval_merge.py
@@ -226,9 +226,9 @@ class TestRetrievalMerge:
         Drives the REAL `_search_bm25` hydration: a bare bm25 result carries no
         metadata, so without hydration the same physical chunk would key by bare
         chunk_id (bm25) vs `path::content_hash` (chroma) and NOT dedupe — getting
-        1/60 twice instead of a summed 2/60 and wasting a top-k slot. Phase 2
-        hydrates from the self-sufficient BM25 store (no Chroma), so both sources
-        carry `path::content_hash` and collapse.
+        1/60 twice instead of a summed 2/60 and wasting a top-k slot. Hydrating
+        from the self-sufficient BM25 store (no Chroma) gives both sources
+        `path::content_hash`, so they collapse.
         """
         import json
 

--- a/tests/test_retrieval_merge.py
+++ b/tests/test_retrieval_merge.py
@@ -223,26 +223,19 @@ class TestRetrievalMerge:
     def test_dedupe_across_sources_keeps_best_rank(self):
         """A chunk found by BOTH retrievers collapses and sums its RRF terms.
 
-        Drives the REAL `_search_bm25` hydration: bm25 raw results carry no
+        Drives the REAL `_search_bm25` hydration: a bare bm25 result carries no
         metadata, so without hydration the same physical chunk would key by bare
         chunk_id (bm25) vs `path::content_hash` (chroma) and NOT dedupe — getting
-        1/60 twice instead of a summed 2/60 and wasting a top-k slot. With
-        hydration both sources carry `path::content_hash` and collapse.
+        1/60 twice instead of a summed 2/60 and wasting a top-k slot. Phase 2
+        hydrates from the self-sufficient BM25 store (no Chroma), so both sources
+        carry `path::content_hash` and collapse.
         """
         import json
-        from unittest.mock import MagicMock
 
         from notes_chat.retrieval import _search_bm25
 
         chunk_id = "team-sync-2025-01-15_000"
         shared_meta = {"path": "/n/team-sync-2025-01-15/notes.md", "content_hash": "h1"}
-
-        manager = MagicMock()
-        manager.collection.get.return_value = {
-            "ids": [chunk_id],
-            "documents": ["budget timeline discussion"],
-            "metadatas": [shared_meta],
-        }
 
         import tempfile
         from pathlib import Path
@@ -251,13 +244,18 @@ class TestRetrievalMerge:
             bm25_file = Path(tmp) / "bm25.json"
             bm25_file.write_text(
                 json.dumps(
-                    {"doc_ids": [chunk_id], "corpus": ["budget timeline discussion"]}
+                    {
+                        "doc_ids": [chunk_id],
+                        "corpus": ["budget timeline discussion"],
+                        "documents": ["budget timeline discussion"],
+                        "metadatas": [shared_meta],
+                    }
                 )
             )
             from notes_chat import bm25 as bm25_module
 
             bm25_module._MODEL_CACHE.pop(str(bm25_file), None)
-            bm25_results = _search_bm25(bm25_file, "budget", k=5, index_manager=manager)
+            bm25_results = _search_bm25(bm25_file, "budget", k=5)
 
         assert len(bm25_results) == 1
         assert bm25_results[0][2]["metadata"] == shared_meta
@@ -300,14 +298,14 @@ class TestRetrievalMerge:
     def test_bm25_only_hit_surfaces_content_after_hydration(self):
         """M3: a lexical-only hit (not in chroma results) reaches the context.
 
-        Before hydration a BM25-only hit had no `content`, so `_build_context`
-        dropped it — the lexical half of "hybrid" could never surface unique
-        content. After hydration the hit carries its document and survives.
+        Without in-store hydration a BM25-only hit had no `content`, so
+        `_build_context` dropped it — the lexical half could never surface
+        unique content. Hydrating from the BM25 store (no Chroma) lets the hit
+        carry its document and survive even with the vector half disabled.
         """
         import json
         import tempfile
         from pathlib import Path
-        from unittest.mock import MagicMock
 
         from notes_chat.retrieval import _search_bm25
 
@@ -317,12 +315,6 @@ class TestRetrievalMerge:
             "content_hash": "hx",
             "date": "2025-02-01",
         }
-        manager = MagicMock()
-        manager.collection.get.return_value = {
-            "ids": [chunk_id],
-            "documents": ["JIRA-1234 must ship before the release cutoff."],
-            "metadatas": [meta],
-        }
 
         with tempfile.TemporaryDirectory() as tmp:
             bm25_file = Path(tmp) / "bm25.json"
@@ -331,15 +323,15 @@ class TestRetrievalMerge:
                     {
                         "doc_ids": [chunk_id],
                         "corpus": ["jira 1234 must ship before the release cutoff"],
+                        "documents": ["JIRA-1234 must ship before the release cutoff."],
+                        "metadatas": [meta],
                     }
                 )
             )
             from notes_chat import bm25 as bm25_module
 
             bm25_module._MODEL_CACHE.pop(str(bm25_file), None)
-            bm25_results = _search_bm25(
-                bm25_file, "jira 1234", k=5, index_manager=manager
-            )
+            bm25_results = _search_bm25(bm25_file, "jira 1234", k=5)
 
         context, _sources, ids = _build_context(bm25_results, char_budget=10000)
         assert chunk_id in ids

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -42,6 +42,7 @@ class TestChirpSettings:
         settings = ChirpSettings()
         settings.directories.notes_root = tmp_path / "notes"
         settings.notes_chat.index_dir = tmp_path / "home"
+        settings.notes_chat.semantic_enabled = True
 
         with patch(
             "config.settings.default_chirp_home", return_value=tmp_path / "home"
@@ -51,6 +52,21 @@ class TestChirpSettings:
         assert (tmp_path / "notes").is_dir()
         assert (tmp_path / "home").is_dir()
         assert (tmp_path / "home" / "chroma").is_dir()
+
+    def test_ensure_directories_exist_skips_chroma_when_lexical_only(self, tmp_path):
+        """A lexical-only install must not create an empty chroma/ directory."""
+        settings = ChirpSettings()
+        settings.directories.notes_root = tmp_path / "notes"
+        settings.notes_chat.index_dir = tmp_path / "home"
+        settings.notes_chat.semantic_enabled = False
+
+        with patch(
+            "config.settings.default_chirp_home", return_value=tmp_path / "home"
+        ):
+            settings.ensure_directories_exist()
+
+        assert (tmp_path / "home").is_dir()
+        assert not (tmp_path / "home" / "chroma").exists()
 
     def test_config_path_lives_under_chirp_home(self):
         assert ChirpSettings.get_config_path() == Path.home() / ".chirp" / "config.toml"


### PR DESCRIPTION
Make the BM25 lexical store self-sufficient so lexical-only retrieval
(semantic_enabled=False) fully answers `chirp ask` with no embedding model,
no Chroma read, and no chroma/ directory ever created.

- bm25.json now stores per-doc content + metadata alongside the tokenized
  corpus; BM25Index exposes documents/metadatas and a hydrate() lookup.
  rebuild_bm25_index/append_bm25_index take plain (doc_ids, documents,
  metadatas) lists instead of a Chroma collection; old 2-key files are
  tolerated and repopulated on the next rebuild.
- index.py sources the BM25 build from the note files (not Chroma), gates
  every vector touch point behind semantic_enabled, and opens the Chroma
  client lazily so a lexical-only install never creates chroma/.
- retrieval hydrates BM25 hits from the BM25 store, removing the lexical
  half's Chroma dependency; _search_chroma (semantic-on only) is unchanged.
- ensure_directories_exist only creates chroma/ when semantic is enabled.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015V3R3RXQHETQ88trJS2rPN