### PR TITLE
Lexical-first retrieval — Phases 3–5 (registry hiding, enable flow, docs)

### DIFF
--- a/.docs/DEVELOPMENT.md
+++ b/.docs/DEVELOPMENT.md
@@ -8,7 +8,7 @@ This document is for contributors working on Chirp. End users should start with 
 - macOS for local audio-capture development
 - Homebrew
 - Git
-- A registered MLX chat + embed model for note-generation and retrieval flows (`chirp models add …`); the bundled chirpd daemon serves them on-device
+- A registered MLX chat model for note-generation and retrieval flows (`chirp models add …`); the bundled chirpd daemon serves it on-device. An embed model is optional — retrieval is lexical-first (BM25), and the embed model is only registered when you opt into semantic search with `chirp config --semantic`
 
 ## Setup
 

--- a/.docs/architecture.md
+++ b/.docs/architecture.md
@@ -1,49 +1,54 @@
 # Chirp Architecture (at a glance)
 
-This guide shows how Chirp moves from audio to answers using a simple, hybrid RAG pipeline. For implementation details, see `notes_chat/`, `notes/`, `transcriber/`, and `config/`.
+This guide shows how Chirp moves from audio to answers using a lexical-first RAG pipeline that becomes hybrid when semantic search is enabled. For implementation details, see `notes_chat/`, `notes/`, `transcriber/`, and `config/`.
+
+> The dashed Embed/Chroma steps below run **only when `notes_chat.semantic_enabled`
+> is `True`** (opt in with `chirp config --semantic`). By default retrieval is
+> BM25-only: ingestion builds the BM25 corpus from note files and skips Chroma,
+> and the query path skips the embed + vector steps.
 
 ## Ingestion (index build)
 
 ```mermaid
 flowchart LR
   Notes[notes-out/*.md] --> Chunk[Chunk]
-  Chunk --> Embed[Embed]
-  Embed --> Chroma[(Chroma)]
   Chunk --> BM25[BM25 Corpus]
+  Chunk -.semantic_enabled.-> Embed[Embed]
+  Embed -.-> Chroma[(Chroma)]
 ```
 
 ## Retrieval (ask)
 
 ```mermaid
 flowchart LR
-  Question[Question] --> QEmb[Embed]
-  QEmb --> Chroma[(Chroma)]
-  Question --> BM25Q[BM25 Search]
-  Chroma --> VecHits[Vector Hits]
+  Question[Question] --> BM25Q[BM25 Search]
+  Question -.semantic_enabled.-> QEmb[Embed]
+  QEmb -.-> Chroma[(Chroma)]
+  Chroma -.-> VecHits[Vector Hits]
   BM25Q --> LexHits[Lexical Hits]
-  VecHits --> Merge[Merge + Dedupe]
+  VecHits -.-> Merge[Merge + Dedupe]
   LexHits --> Merge
   Merge --> Context[Context Budget]
   Context --> LLM[LLM]
   LLM --> Answer[Answer + Sources]
 ```
 
-- Chunking: section-aware with overlap. See: [Chunking Strategy](./chunking.md)
-- Embeddings: chirpd/MLX embeddings; same model for chunks and queries. See: [Embedding Backend](./embeddings.md)
+- Chunking: section-aware with overlap; feeds BM25 always and embeddings when enabled. See: [Chunking Strategy](./chunking.md)
+- Embeddings (opt-in): chirpd/MLX embeddings; same model for chunks and queries. See: [Embedding Backend](./embeddings.md)
 - Dedupe key: `(path, content_hash)` so overlapping or repeated text doesn’t show twice
-- Why hybrid? See: [Hybrid Retrieval](./hybrid-retrieval.md)
+- Lexical-first, hybrid when enabled. See: [Retrieval](./hybrid-retrieval.md)
 
 ## Components (what exists)
 
 - CLI (`chirp`): entry point to record, process notes, index, and chat
 - Recorder + Transcriber: produce transcription and notes
 - Note Generator: writes `notes-out/*.md`
-- Indexer: chunks, embeds, and stores in Chroma; rebuilds BM25
-- Retriever: hybrid search (vector + BM25), merges and builds context
+- Indexer: chunks notes and builds the BM25 store; also embeds into Chroma when `semantic_enabled`
+- Retriever: BM25 by default, fused with vector hits when `semantic_enabled`; merges and builds context
 - LLM: answers using the built context
 - Storage:
-  - Chroma (persistent at `.notes_index/chroma`)
-  - BM25 corpus (at `.notes_index/bm25.json`)
+  - BM25 store (at `index_dir/bm25.json`) — always present
+  - Chroma (persistent at `index_dir/chroma`) — only when `semantic_enabled`
 
 ## Operations (quick refs)
 

--- a/.docs/chunking.md
+++ b/.docs/chunking.md
@@ -6,10 +6,12 @@ This document defines the chunking strategy used for indexing notes into the RAG
 - Config knobs: `notes_chat.chunk_size`, `notes_chat.overlap` in `config/config.yaml` / `config/settings.py`
 - Defaults: `chunk_size: 1000` characters, `overlap: 200` characters
 
+Chunks feed the BM25 lexical index always, and the embedding/Chroma index only when semantic search is enabled (`notes_chat.semantic_enabled`; see [Retrieval](./hybrid-retrieval.md)). Chunking itself is identical in both modes.
+
 ## Goals
 
 - Preserve semantic boundaries by splitting around second-level headings first (`##` in Markdown)
-- Keep chunks under a target character budget for efficient embedding and retrieval
+- Keep chunks under a target character budget for efficient lexical indexing and (when enabled) embedding
 - Add overlap to reduce information loss at boundaries
 
 ## Inputs & Outputs

--- a/.docs/embeddings.md
+++ b/.docs/embeddings.md
@@ -1,5 +1,12 @@
 # Embedding Backend
 
+> **Applies only when semantic search is enabled.** Embeddings are opt-in
+> (`notes_chat.semantic_enabled`, default `False`). With the default lexical-first
+> setup, retrieval is BM25-only and nothing in this document runs — no embed
+> model is registered, no Chroma store is created, and the query path never calls
+> `embed_sync`. Turn it on with `chirp config --semantic` (which registers the
+> embed model and rebuilds the index). See [Retrieval](./hybrid-retrieval.md).
+
 This document explains how embeddings are generated and used in Chirp’s RAG pipeline.
 
 - Code references: `notes_chat/index.py`, `notes_chat/retrieval.py`, `config/settings.py`, `llm/client.py`

--- a/.docs/embeddings.md
+++ b/.docs/embeddings.md
@@ -11,7 +11,7 @@ This document explains how embeddings are generated and used in Chirp’s RAG pi
 
 - Code references: `notes_chat/index.py`, `notes_chat/retrieval.py`, `config/settings.py`, `llm/client.py`
 - Backend: the bundled **chirpd** daemon, running an embedding model on-device via **MLX** (`llm.client.LLMClient.embed_sync`)
-- Embedding model: whatever is registered as the `default_embed` alias in the model registry (`chirp models add <hf-repo> --role embed`, e.g. `mlx-community/bge-small-en-v1.5`)
+- Embedding model: whatever is registered as the `default_embed` alias in the model registry (`chirp models add <hf-repo> --role embed`, e.g. `mlx-community/bge-small-en-v1.5-bf16`). `chirp config --semantic` registers this for you.
 
 ## Overview
 
@@ -67,8 +67,8 @@ Key method signatures:
 
 - Embedding calls are stateless and do not stream; `embed_sync` returns one
   vector per input.
-- A small general-purpose English model such as `bge-small-en-v1.5` is suitable
-  for note-sized chunks.
+- A small general-purpose English model such as `bge-small-en-v1.5-bf16` is
+  suitable for note-sized chunks.
 - Swap the embedding model by registering a different one and setting it as the
   default embed alias (`chirp models add <repo> --role embed` →
   `chirp models default <alias>`).

--- a/.docs/hybrid-retrieval.md
+++ b/.docs/hybrid-retrieval.md
@@ -1,32 +1,34 @@
-# Hybrid Retrieval: Embeddings + BM25
+# Retrieval: Lexical-first, hybrid when enabled
 
-This note explains why Chirp uses hybrid retrieval (semantic embeddings + BM25 lexical search), how it works, and when you might tune or change it.
+This note explains how Chirp retrieves context: BM25 lexical search by default, with semantic embeddings added on top when you opt in. It covers how the two combine, how queries are routed, and when to tune or change it.
 
 ## TL;DR
 
-- Keep both: embeddings catch semantic matches; BM25 catches exact terms (IDs, names, phrases).
+- **Lexical-first.** BM25 is the default and only required retriever; it catches exact terms (IDs, names, phrases) and needs no embedding model.
+- **Semantic is opt-in** (`notes_chat.semantic_enabled`, default `False`; flip it with `chirp config --semantic`). When on, embeddings also catch paraphrase/conceptual matches and are fused with BM25.
 - Merge the results, dedupe by `(path, content_hash)`, then build a context under a fixed character budget.
 
 ## How it works
 
 See the retrieval diagram in the Architecture doc: [Architecture → Retrieval (ask)](./architecture.md#retrieval-ask).
 
-- Embeddings: query and chunks are embedded with the same model; Chroma returns top-k by cosine similarity.
-- BM25: ranks chunks by lexical overlap; strong for exact tokens, IDs, acronyms, and phrases.
-- Merge + Dedupe: combine lists and deduplicate using `(path, content_hash)`.
+- BM25 (always): ranks chunks by lexical overlap; strong for exact tokens, IDs, acronyms, and phrases. With `semantic_enabled=False` this is the entire retrieval path — no Chroma query, no query embedding.
+- Embeddings (when `semantic_enabled=True`): query and chunks are embedded with the same model; Chroma returns top-k by cosine similarity.
+- Query routing (`_route_query` in `notes_chat/retrieval.py`): when semantic is on, the query's shape picks per-source fusion weights `(bm25, chroma)`. Literal signals — quoted spans, id-shaped tokens (`jira-123`), ALL-CAPS acronyms, or very short queries — favour BM25 (`LITERAL_WEIGHTS = (1.0, 0.3)`); anything else is treated as conceptual (`CONCEPTUAL_WEIGHTS = (1.0, 1.0)`). With semantic off the weights are fixed `LEXICAL_ONLY = (1.0, 0.0)`.
+- Merge + Dedupe: combine lists and deduplicate using `(path, content_hash)`, fusing ranks with weighted Reciprocal Rank Fusion (`RRF_K = 60`).
 - Context: allocate text across top chunks within `ctx_char_budget`, then prompt the LLM and attach sources.
 
-## Why hybrid?
+## Why lexical-first?
 
-- Short or specific queries: BM25 shines on IDs (e.g., `jira-123`), names, codes, dates, and quoted phrases.
-- Paraphrased or fuzzy queries: embeddings retrieve semantically related content even if words differ.
-- Local and fast: both run locally (chirpd/MLX + Chroma + BM25 corpus) with low overhead.
+- No setup cost: BM25 needs no embedding model, so search works the moment you have notes — nothing to download, no daemon embed calls.
+- Short or specific queries: BM25 shines on IDs (e.g., `jira-123`), names, codes, dates, and quoted phrases, which is where many note searches land.
+- Opt into semantic when paraphrase matters: enabling embeddings (`chirp config --semantic`) retrieves semantically related content even when the words differ, fused with BM25 rather than replacing it.
 
-## When to change it
+## When to enable or change it
 
-- Stronger embeddings + re-ranker: if you add a cross-encoder/LLM re-ranking step, embeddings-only can be competitive.
-- Domain-specific tokens: increase BM25 weight if queries often include IDs or exact terms.
-- Minimal needs: if queries are always natural language, embeddings-only may be sufficient.
+- Enable semantic search: run `chirp config --semantic` if queries are often natural-language paraphrases rather than exact terms. It registers the embed model, verifies the daemon can load it, and rebuilds the index.
+- Stay lexical-only: if queries are usually exact terms/IDs, the default needs no embedding model at all; `chirp config --no-semantic --purge` returns to it and reclaims the vector store.
+- Domain-specific tokens: increase BM25 weight (see `_route_query`) if queries often include IDs or exact terms.
 
 ## Tuning tips
 

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ setup: install ## Initial setup for new installations
 	uv run pre-commit install
 	@echo "Chirp setup complete!"
 	@echo "Next steps:"
-	@echo "  1. Register a chat model: uv run chirp models add mlx-community/gemma-4-4b-it-4bit"
+	@echo "  1. Register a chat model: uv run chirp models add mlx-community/Qwen2.5-7B-Instruct-4bit"
 	@echo "  2. Run 'make verify-deps' to verify setup"
 
 # Build commands

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ If you prefer to set things up manually on macOS:
 2. Register a chat model (downloaded to the local HF cache, served on-device by chirpd):
 
    ```bash
-   # Chat — balanced quality and speed (~2 GB)
-   chirp models add mlx-community/gemma-4-4b-it-4bit
+   # Chat — strong quality (~4.3 GB)
+   chirp models add mlx-community/Qwen2.5-7B-Instruct-4bit
    # ...or a smaller-footprint variant for tighter RAM:
    chirp models add mlx-community/gemma-4-e2b-it-8bit
    ```

--- a/README.md
+++ b/README.md
@@ -130,6 +130,24 @@ chirp search "action item" --since 30d
 chirp search "owner: .*" --regex --json
 ```
 
+## How search works
+
+`chirp ask` and `chirp search` run on a **lexical (BM25) index by default** — fast, exact-term matching over your transcripts and notes, with no embedding model to download. This is the out-of-the-box behavior; nothing else is required.
+
+**Semantic search is opt-in.** Enable it to also match on meaning (paraphrases, related concepts) using on-device embeddings:
+
+```bash
+# Enable: registers a small embed model, verifies chirpd can load it, then
+# rebuilds the index. `chirp ask` then blends lexical and semantic hits.
+chirp config --semantic
+
+# Disable: return to lexical-only. Add --purge to also delete the vector store.
+chirp config --no-semantic
+chirp config --no-semantic --purge
+```
+
+While semantic search is off, embed models stay hidden from `chirp models list` (pass `--all` to see them) and can't be added until you enable it.
+
 ## Setup details
 
 `chirp init` is the recommended setup path. It checks for Apple Silicon, verifies Homebrew and `ffmpeg`, confirms the bundled chirpd daemon is reachable, reports whether a default chat model is registered, and checks the screen-recording permission — then helps install anything missing and offers to start chirpd at login. The bundled `Chirp.app` helper records system audio and microphone directly via ScreenCaptureKit; no virtual audio driver is required.
@@ -142,16 +160,19 @@ If you prefer to set things up manually on macOS:
    brew install ffmpeg
    ```
 
-2. Register a chat model and an embedding model (downloaded to the local HF cache, served on-device by chirpd):
+2. Register a chat model (downloaded to the local HF cache, served on-device by chirpd):
 
    ```bash
    # Chat — balanced quality and speed (~2 GB)
    chirp models add mlx-community/gemma-4-4b-it-4bit
    # ...or a smaller-footprint variant for tighter RAM:
    chirp models add mlx-community/gemma-4-e2b-it-8bit
+   ```
 
-   # Embeddings (for search / retrieval)
-   chirp models add mlx-community/bge-small-en-v1.5 --role embed
+   Search works out of the box on the lexical (BM25) index — no embedding model needed. To also match on meaning, opt into semantic search; this registers the embed model and rebuilds the index for you (see [How search works](#how-search-works)):
+
+   ```bash
+   chirp config --semantic
    ```
 
 3. Re-check your environment:

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -1,5 +1,9 @@
 # Deferred Work
 
+## Deferred from: lexical-first retrieval phases 3–5 (2026-06-28)
+
+- **No chirpd daemon-side embed guard.** With semantic search off, nothing asks chirpd to embed (Phase 2 removed every embed call), so the opt-in is enforced entirely client-side: retrieval skips the vector path, and `chirp config --semantic` is the only thing that registers/loads an embed model. A defense-in-depth guard that rejects `embed`/`model.load(role="embed")` ops on the daemon when no embed model is configured is intentionally not added — there is no caller to guard against today. Revisit if a future client path can request embeddings while semantic is off. [chirpd/dispatcher.py, chirpd/backend.py]
+
 ## Deferred from: code review of 1.1-storage-rewrite (2026-04-20)
 
 - Live session writes `transcript.live.txt` instead of canonical `transcript.txt`. Intentional — live transcript is a watch-along preview; canonical transcript comes from `chirp transcribe`. Revisit if users expect live-only recordings to flow into notes/index. [recorder/live_session.py]

--- a/chirp/about.py
+++ b/chirp/about.py
@@ -30,7 +30,7 @@ from chirp.branding import (
     REPO,
     TAGLINE,
 )
-from llm.registry import resolved_chat_model
+from llm.registry import resolved_chat_model, resolved_embed_model
 
 SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
 
@@ -143,6 +143,18 @@ def _model_label(value: str | None) -> str:
     return "<not set>"
 
 
+def _index_backend_label(settings) -> str:
+    """Describe what powers the search index for the about panel.
+
+    Lexical-first: with semantic retrieval off (the default) the index is
+    BM25-only, so naming an embed model would mislead. When it's on, show the
+    resolved embed alias the vector half actually uses.
+    """
+    if not settings.notes_chat.semantic_enabled:
+        return "lexical (BM25)"
+    return resolved_embed_model(settings.notes_chat.recommended_embed_model)
+
+
 def run_about(
     console: Console,
     settings,
@@ -160,7 +172,7 @@ def run_about(
     notes_root = settings.directories.notes_root
     notes_count = _count_notes(notes_root)
     chat_model = resolved_chat_model(settings.models.llm)
-    embed_model = settings.notes_chat.emb_model
+    embed_model = _index_backend_label(settings)
     version = _installed_version()
 
     lines: list[Text] = [_prompt_line(), Text("")]
@@ -230,7 +242,7 @@ def render_about_plain(console: Console, settings) -> None:
     notes_root = settings.directories.notes_root
     notes_count = _count_notes(notes_root)
     chat_model = resolved_chat_model(settings.models.llm)
-    embed_model = settings.notes_chat.emb_model
+    embed_model = _index_backend_label(settings)
     version = _installed_version()
 
     for line in _info_lines(version, notes_count, chat_model, embed_model, notes_root):

--- a/chirp/about.py
+++ b/chirp/about.py
@@ -161,7 +161,7 @@ def run_about(
     speed: float = 1.0,
     sleeper: Callable[[float], None] | None = None,
 ) -> None:
-    """Run the full 3-phase about animation.
+    """Run the about animation.
 
     Parameters mirror the design's live preview. ``sleeper`` defaults to
     ``time.sleep`` so tests can pass a no-op.
@@ -178,7 +178,6 @@ def run_about(
     lines: list[Text] = [_prompt_line(), Text("")]
 
     with Live(Group(*lines), console=console, refresh_per_second=20) as live:
-        # Phase 1 — paint the entire bird in one go
         logo_start = len(lines)
         lines.extend(_logo_line(idx, beak_open=False) for idx in range(len(LOGO_ROWS)))
         live.update(Group(*lines))
@@ -188,7 +187,6 @@ def run_about(
 
         sleep(0.3 * scale)
 
-        # Phase 2 — spinner + status lines while chirp "wakes up"
         status_start = len(lines)
         for spinner_msg, done_template, dwell in PHASE_ONE:
             done_msg = done_template.format(
@@ -212,7 +210,6 @@ def run_about(
 
         sleep(0.3 * scale)
 
-        # Phase 3 — clear the status lines and reveal info while the beak chirps
         del lines[status_start:]
         live.update(Group(*lines))
 

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -1400,13 +1400,6 @@ Interval: {settings.monitoring.warning_interval} minutes""",
         stdout_console.print(panel)
         return
 
-    if semantic is not None:
-        _toggle_semantic(settings, enable=semantic, purge=purge)
-        return
-
-    if purge:
-        console.print("[yellow]--purge has no effect without --no-semantic.[/yellow]")
-
     changes_made = False
 
     if notes_root:
@@ -1426,9 +1419,18 @@ Interval: {settings.monitoring.warning_interval} minutes""",
         settings.ensure_directories_exist()
         console.print("[green]configuration updated[/green]")
 
+    if semantic is not None:
+        _toggle_semantic(settings, enable=semantic, purge=purge)
+        return
+
+    if purge:
+        console.print("[yellow]--purge has no effect without --no-semantic.[/yellow]")
+
 
 def _toggle_semantic(settings: ChirpSettings, *, enable: bool, purge: bool) -> None:
     if enable:
+        if purge:
+            console.print("[yellow]--purge has no effect with --semantic.[/yellow]")
         _enable_semantic(settings)
     else:
         _disable_semantic(settings, purge=purge)

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -26,7 +26,7 @@ from chirp.exceptions import AudioDeviceError, ConfigurationError, RecordingErro
 from config.settings import ChirpSettings, get_settings
 from llm.cli.daemon import daemon_app
 from llm.cli.models import app as models_app
-from llm.registry import resolved_chat_model
+from llm.registry import resolved_chat_model, resolved_embed_model
 from utils.file_utils import NoteRecord, list_notes
 
 logger = logging.getLogger(__name__)
@@ -1357,15 +1357,19 @@ def config(
     llm_model: str | None = typer.Option(
         None, "--llm-model", help="Set LLM model (e.g. llama3.1:8b)"
     ),
-    embedding_model: str | None = typer.Option(
-        None,
-        "--embedding-model",
-        help="Set embedding model (e.g. nomic-embed-text)",
-    ),
     semantic: bool | None = typer.Option(
         None,
         "--semantic/--no-semantic",
-        help="Enable or disable opt-in semantic (vector) retrieval for ask",
+        help=(
+            "Enable opt-in semantic (vector) retrieval for ask. Enabling "
+            "registers an embed model and rebuilds the index; --no-semantic "
+            "returns to lexical-only (add --purge to delete the vector store)."
+        ),
+    ),
+    purge: bool = typer.Option(
+        False,
+        "--purge",
+        help="With --no-semantic, delete the vector store at index_dir/chroma.",
     ),
 ):
     """Manage Chirp configuration"""
@@ -1379,7 +1383,7 @@ Notes Root: {settings.directories.notes_root}
 [cyan]Models:[/cyan]
 Whisper: {settings.models.whisper}
 LLM: {resolved_chat_model(settings.models.llm)}
-Embedding: {settings.notes_chat.emb_model}
+Embedding: {resolved_embed_model(settings.notes_chat.recommended_embed_model)}
 
 [cyan]Search:[/cyan]
 Semantic retrieval: {"on" if settings.notes_chat.semantic_enabled else "off"}
@@ -1396,6 +1400,13 @@ Interval: {settings.monitoring.warning_interval} minutes""",
         stdout_console.print(panel)
         return
 
+    if semantic is not None:
+        _toggle_semantic(settings, enable=semantic, purge=purge)
+        return
+
+    if purge:
+        console.print("[yellow]--purge has no effect without --no-semantic.[/yellow]")
+
     changes_made = False
 
     if notes_root:
@@ -1410,18 +1421,91 @@ Interval: {settings.monitoring.warning_interval} minutes""",
         settings.models.llm = llm_model
         changes_made = True
 
-    if embedding_model:
-        settings.notes_chat.emb_model = embedding_model
-        changes_made = True
-
-    if semantic is not None:
-        settings.notes_chat.semantic_enabled = semantic
-        changes_made = True
-
     if changes_made:
         settings.save_to_file(ChirpSettings.get_config_path())
         settings.ensure_directories_exist()
         console.print("[green]configuration updated[/green]")
+
+
+def _toggle_semantic(settings: ChirpSettings, *, enable: bool, purge: bool) -> None:
+    if enable:
+        _enable_semantic(settings)
+    else:
+        _disable_semantic(settings, purge=purge)
+
+
+def _enable_semantic(settings: ChirpSettings) -> None:
+    """Wire up the vector half: register the embed model, verify it loads, flip
+    the flag, then backfill Chroma.
+
+    Atomicity (lexical-first stays the safe fallback): the flag is flipped only
+    after the embed model is registered AND verified loadable on chirpd. Any
+    earlier failure exits without touching the flag, so a half-enabled state can
+    never make `chirp ask` fail at query time.
+    """
+    from chirp.init_flow import RECOMMENDED_EMBED_REPO
+    from llm.cli.models import register_model
+    from llm.client import LLMClient
+    from llm.exceptions import LLMError
+    from notes_chat.index import build_index
+
+    if settings.notes_chat.semantic_enabled:
+        console.print("[green]semantic search is already on.[/green]")
+        return
+
+    console.print(
+        f"[blue]enabling semantic search — registering embed model "
+        f"{RECOMMENDED_EMBED_REPO}…[/blue]"
+    )
+    alias = register_model(RECOMMENDED_EMBED_REPO, role="embed", warm=False)
+
+    console.print(f"[blue]verifying chirpd can load {alias}…[/blue]")
+    try:
+        LLMClient().model_load_sync(alias, "embed")
+    except LLMError as exc:
+        console.print(
+            f"[red]could not load embed model {alias} on chirpd ({exc}). "
+            "semantic search stays off — you remain on lexical (BM25) search. "
+            "Run `chirp daemon logs` to diagnose, then retry.[/red]"
+        )
+        raise typer.Exit(exit_codes.MODEL_LOAD_FAILED) from exc
+
+    settings.notes_chat.semantic_enabled = True
+    settings.save_to_file(ChirpSettings.get_config_path())
+    settings.ensure_directories_exist()
+    console.print("[green]semantic search enabled.[/green] rebuilding the index…")
+    result = build_index(settings, force=True)
+    if not result.get("success"):
+        console.print(
+            f"[yellow]index rebuild reported a problem: {result.get('error')}. "
+            "`chirp ask` will retry the build on demand.[/yellow]"
+        )
+        return
+    console.print("[green]done — `chirp ask` now uses hybrid retrieval.[/green]")
+
+
+def _disable_semantic(settings: ChirpSettings, *, purge: bool) -> None:
+    settings.notes_chat.semantic_enabled = False
+    settings.save_to_file(ChirpSettings.get_config_path())
+    console.print(
+        "[green]semantic search disabled.[/green] now using lexical (BM25) search."
+    )
+    if purge:
+        _purge_chroma(settings.notes_chat.index_dir / "chroma")
+
+
+def _purge_chroma(chroma_dir: Path) -> None:
+    import shutil
+
+    if not chroma_dir.exists():
+        console.print(f"[dim]no vector store at {chroma_dir}; nothing to purge.[/dim]")
+        return
+    try:
+        shutil.rmtree(chroma_dir)
+    except OSError as exc:
+        console.print(f"[yellow]could not purge {chroma_dir}: {exc}[/yellow]")
+        return
+    console.print(f"[green]purged vector store at {chroma_dir}.[/green]")
 
 
 @app.command(hidden=True)

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -1293,8 +1293,8 @@ def init(
 
     # Gate before get_settings(): loading settings creates a default
     # config.toml when missing, and a non-arm64 machine must exit without
-    # touching the filesystem (story 7.1 AC-1). run_init re-checks the gate
-    # for callers that bypass the CLI.
+    # touching the filesystem. run_init re-checks the gate for callers that
+    # bypass the CLI.
     code = require_apple_silicon(console)
     if code is not None:
         raise typer.Exit(code)

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -47,7 +47,7 @@ EXIT_NOT_APPLE_SILICON = exit_codes.NOT_APPLE_SILICON
 
 # Single source of truth for the recommended first model — story 7.2's
 # migration plan and the README sweep (7.5) reference these constants.
-RECOMMENDED_CHAT_REPO = "mlx-community/gemma-4-4b-it-4bit"
+RECOMMENDED_CHAT_REPO = "mlx-community/Qwen2.5-7B-Instruct-4bit"
 SMALLER_CHAT_REPO = "mlx-community/gemma-4-e2b-it-8bit"
 # Recommended embed model registered by `chirp config --semantic`. Must be a
 # repo that exists on HF: the bf16 build is the published mlx-community embed
@@ -261,7 +261,7 @@ def verify(settings: ChirpSettings, console: Console) -> list[DependencyStatus]:
     if not chat_row.installed:
         console.print(
             f"  next step: [bold]chirp models add {RECOMMENDED_CHAT_REPO}[/bold]"
-            " [dim](~2 GB, balanced quality and speed)[/dim]"
+            " [dim](~4.3 GB, strong quality)[/dim]"
         )
         console.print(
             f"  [dim]smaller alternative: chirp models add {SMALLER_CHAT_REPO}[/dim]"
@@ -700,7 +700,7 @@ def _print_migration_plan(console: Console, detection: dict[str, bool]) -> None:
     console.print(" To finish the migration:")
     console.print("   1. Pick an MLX model [dim](GGUF models do not work)[/dim]:")
     console.print(f"        [bold]chirp models add {RECOMMENDED_CHAT_REPO}[/bold]")
-    console.print("      [dim](~2 GB, balanced quality and speed)[/dim]")
+    console.print("      [dim](~4.3 GB, strong quality)[/dim]")
     console.print()
     console.print("      Tight on RAM? Use the smaller-footprint variant:")
     console.print(f"        [bold]chirp models add {SMALLER_CHAT_REPO}[/bold]")

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -427,8 +427,14 @@ def _run_switch_model(settings: ChirpSettings, console: Console) -> int:
 
 
 def _finalize_paths(settings: ChirpSettings, console: Console) -> None:
-    """Phase 3 — ensure config/chroma/notes paths exist, print the summary."""
+    """Phase 3 — ensure config/notes (and chroma only when semantic) paths exist.
+
+    Lexical-first: the Chroma vector store is created only when semantic search
+    is enabled, mirroring ``ChirpSettings.ensure_directories_exist``. A fresh,
+    lexical-only install therefore never gets an empty ``chroma/`` directory.
+    """
     config_path = ChirpSettings.get_config_path()
+    semantic_enabled = settings.notes_chat.semantic_enabled
     chroma_dir = settings.notes_chat.index_dir / "chroma"
     notes_root = settings.directories.notes_root
 
@@ -439,14 +445,15 @@ def _finalize_paths(settings: ChirpSettings, console: Console) -> None:
     if not config_existed:
         _merge_config(config_path, console=console)
 
-    chroma_dir.mkdir(parents=True, exist_ok=True)
+    if semantic_enabled:
+        chroma_dir.mkdir(parents=True, exist_ok=True)
     notes_root.mkdir(parents=True, exist_ok=True)
 
     _print_path_summary(
         console,
         config_path=config_path,
         config_changed=not config_existed,
-        chroma_dir=chroma_dir,
+        chroma_dir=chroma_dir if semantic_enabled else None,
         chroma_was_new=not chroma_existed,
         notes_root=notes_root,
         notes_was_new=not notes_existed,
@@ -590,7 +597,7 @@ def _print_path_summary(
     *,
     config_path: Path,
     config_changed: bool,
-    chroma_dir: Path,
+    chroma_dir: Path | None,
     chroma_was_new: bool,
     notes_root: Path,
     notes_was_new: bool,
@@ -603,13 +610,14 @@ def _print_path_summary(
             created_or_changed=config_changed,
         )
     )
-    console.print(
-        _path_line(
-            "initialized chromadb at",
-            chroma_dir,
-            created_or_changed=chroma_was_new,
+    if chroma_dir is not None:
+        console.print(
+            _path_line(
+                "initialized chromadb at",
+                chroma_dir,
+                created_or_changed=chroma_was_new,
+            )
         )
-    )
     console.print(
         _path_line(
             "notes dir:",

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -49,6 +49,9 @@ EXIT_NOT_APPLE_SILICON = exit_codes.NOT_APPLE_SILICON
 # migration plan and the README sweep (7.5) reference these constants.
 RECOMMENDED_CHAT_REPO = "mlx-community/gemma-4-4b-it-4bit"
 SMALLER_CHAT_REPO = "mlx-community/gemma-4-e2b-it-8bit"
+# Recommended embed model registered by `chirp config --semantic`. Its inferred
+# alias (bge-small-en-v1.5) matches NotesChatConfig.recommended_embed_model.
+RECOMMENDED_EMBED_REPO = "mlx-community/bge-small-en-v1.5"
 
 _MODELS_ADD_HINT = f"not configured — run 'chirp models add {RECOMMENDED_CHAT_REPO}'"
 

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -49,9 +49,11 @@ EXIT_NOT_APPLE_SILICON = exit_codes.NOT_APPLE_SILICON
 # migration plan and the README sweep (7.5) reference these constants.
 RECOMMENDED_CHAT_REPO = "mlx-community/gemma-4-4b-it-4bit"
 SMALLER_CHAT_REPO = "mlx-community/gemma-4-e2b-it-8bit"
-# Recommended embed model registered by `chirp config --semantic`. Its inferred
-# alias (bge-small-en-v1.5) matches NotesChatConfig.recommended_embed_model.
-RECOMMENDED_EMBED_REPO = "mlx-community/bge-small-en-v1.5"
+# Recommended embed model registered by `chirp config --semantic`. Must be a
+# repo that exists on HF: the bf16 build is the published mlx-community embed
+# (the bare `bge-small-en-v1.5` repo 404s). Its inferred alias
+# (bge-small-en-v1.5-bf16) matches NotesChatConfig.recommended_embed_model.
+RECOMMENDED_EMBED_REPO = "mlx-community/bge-small-en-v1.5-bf16"
 
 _MODELS_ADD_HINT = f"not configured — run 'chirp models add {RECOMMENDED_CHAT_REPO}'"
 

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -1,24 +1,24 @@
-"""`chirp init` — smart first-run setup: an architecture gate plus three phases.
+"""`chirp init` — smart first-run setup: an architecture gate plus a few steps.
 
 Gate: require Apple Silicon. Everything downstream (the bundled
 chirpd daemon, MLX inference) is arm64-only, so a non-arm64 machine fails
 fast with exit code 7 before any other work.
 
-Phase 1: verify homebrew, ffmpeg, daemon readiness (via `llm.client`'s
+Verify: check homebrew, ffmpeg, daemon readiness (via `llm.client`'s
 health handshake, which lazy-spawns chirpd), the registered default chat
 model (via `llm.registry`), and the screen-recording permission. Print a
 check table and ask whether to install what's missing.
 
-Phase 2: install missing dependencies via Homebrew (macOS only) and rebuild
+Install: install missing dependencies via Homebrew (macOS only) and rebuild
 the capture_audio helper when needed. The daemon is part of the pip package
 and is never "installed" here; model registration is the user's own
 `chirp models add` step.
 
-Phase 3: finalize — create the config/chroma/notes directories and print
-the "your nest is ready" panel.
+Finalize: create the config/chroma/notes directories and print the "your nest
+is ready" panel.
 
-Re-running is idempotent: each phase is skipped cleanly when nothing is
-missing. ``--recheck`` stops after phase 1; ``--switch-model`` flips the
+Re-running is idempotent: each step is skipped cleanly when nothing is
+missing. ``--recheck`` stops after verify; ``--switch-model`` flips the
 registry's default chat alias.
 """
 
@@ -45,8 +45,8 @@ from config.settings import ChirpSettings, _stringify_paths
 
 EXIT_NOT_APPLE_SILICON = exit_codes.NOT_APPLE_SILICON
 
-# Single source of truth for the recommended first model — story 7.2's
-# migration plan and the README sweep (7.5) reference these constants.
+# Single source of truth for the recommended first models; the README and
+# Makefile mirror these strings.
 RECOMMENDED_CHAT_REPO = "mlx-community/Qwen2.5-7B-Instruct-4bit"
 SMALLER_CHAT_REPO = "mlx-community/gemma-4-e2b-it-8bit"
 # Recommended embed model registered by `chirp config --semantic`. Must be a
@@ -81,7 +81,7 @@ def _run(args: list[str], timeout: float = 10.0) -> tuple[int, str]:
 
 
 def require_apple_silicon(console: Console) -> int | None:
-    """Phase 0 gate — returns EXIT_NOT_APPLE_SILICON on non-arm64, else None."""
+    """Architecture gate — returns EXIT_NOT_APPLE_SILICON on non-arm64, else None."""
     machine = platform.machine()
     if machine == "arm64":
         return None
@@ -130,8 +130,8 @@ def _daemon_ready() -> DependencyStatus:
     """Probe daemon readiness through `llm.client`'s health handshake.
 
     The client owns lazy-spawn and the version handshake — no daemon-process
-    logic lives here (architecture §Cross-Component Dependencies). Imports are
-    lazy so a broken `llm` module can't make init un-importable.
+    logic lives here. Imports are lazy so a broken `llm` module can't make init
+    un-importable.
     """
     from llm.client import LLMClient
     from llm.exceptions import LLMDaemonSpawnFailed, LLMTransportError
@@ -230,7 +230,7 @@ def _screen_recording_permission() -> DependencyStatus:
 
 
 def verify(settings: ChirpSettings, console: Console) -> list[DependencyStatus]:
-    """Run phase 1 — returns the ordered status list and prints the table."""
+    """Run the verify step — returns the ordered status list and prints the table."""
     console.print()
     console.print(" [bold]Welcome to Chirp.[/bold] Let's set up your nest.")
     console.print()
@@ -300,7 +300,7 @@ def _confirm(console: Console, prompt: str, default: bool = True) -> bool:
 
 
 def install_missing(console: Console, statuses: list[DependencyStatus]) -> bool:
-    """Phase 2 — install what's missing via Homebrew.
+    """Install what's missing via Homebrew.
 
     Returns True when every actionable task succeeded. Returns False on
     non-macOS hosts, when Homebrew itself is missing, when a brew/build task
@@ -429,7 +429,7 @@ def _run_switch_model(settings: ChirpSettings, console: Console) -> int:
 
 
 def _finalize_paths(settings: ChirpSettings, console: Console) -> None:
-    """Phase 3 — ensure config/notes (and chroma only when semantic) paths exist.
+    """Ensure config/notes (and chroma only when semantic) paths exist.
 
     Lexical-first: the Chroma vector store is created only when semantic search
     is enabled, mirroring ``ChirpSettings.ensure_directories_exist``. A fresh,
@@ -674,10 +674,9 @@ _DETECTION_LABELS = {
 def _print_migration_plan(console: Console, detection: dict[str, bool]) -> None:
     """Print the loud, informational-only Ollama migration plan.
 
-    PRD §Project Scoping → Out of Scope forbids auto-uninstalling Ollama —
-    cleanup commands are shown for the user to run, never executed. OQ6 is
-    resolved to a loud multi-line plan (Devon's journey): offline-friendly
-    and explicit beats a one-line pointer at an external URL.
+    chirp must never auto-uninstall Ollama — cleanup commands are shown for the
+    user to run, never executed. A loud multi-line plan is deliberate:
+    offline-friendly and explicit beats a one-line pointer at an external URL.
     """
     rule = " [dim]──────────────────────────────────────────────────────────[/dim]"
     console.print()
@@ -732,7 +731,7 @@ def run_init(
     recheck: bool = False,
     switch_model: bool = False,
 ) -> int:
-    """Top-level entry — orchestrates the phases. Returns exit code."""
+    """Top-level entry — orchestrates the steps. Returns exit code."""
     code = require_apple_silicon(console)
     if code is not None:
         return code

--- a/config/settings.py
+++ b/config/settings.py
@@ -179,7 +179,7 @@ class LLMSettings(BaseModel):
 
 class NotesChatConfig(BaseModel):
     semantic_enabled: bool = False
-    emb_model: str = "nomic-embed-text"
+    recommended_embed_model: str = "bge-small-en-v1.5"
     chunk_size: int = 1000
     overlap: int = 200
     k: int = 10

--- a/config/settings.py
+++ b/config/settings.py
@@ -179,7 +179,7 @@ class LLMSettings(BaseModel):
 
 class NotesChatConfig(BaseModel):
     semantic_enabled: bool = False
-    recommended_embed_model: str = "bge-small-en-v1.5"
+    recommended_embed_model: str = "bge-small-en-v1.5-bf16"
     chunk_size: int = 1000
     overlap: int = 200
     k: int = 10

--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -30,6 +30,7 @@ from rich.table import Table
 
 from chirp import glyphs
 from chirpd.paths import MODELS_TOML_PATH
+from config.settings import get_settings
 from llm import hf
 from llm.cli._console import console, stdout_console
 from llm.cli._progress import RichProgressCallback
@@ -106,8 +107,42 @@ def add_command(
     ),
 ) -> None:
     """Download a model from HuggingFace, register it, and warm it on the daemon."""
+    register_model(
+        hf_repo,
+        role=role,
+        alias=alias,
+        warm=not no_warm,
+        require_semantic_for_embed=True,
+    )
+
+
+def register_model(
+    hf_repo: str,
+    *,
+    role: Literal["chat", "embed"] | None = None,
+    alias: str | None = None,
+    warm: bool = True,
+    require_semantic_for_embed: bool = False,
+) -> str:
+    """Validate, download, register, and optionally warm a model; return its alias.
+
+    Shared by ``chirp models add`` and the ``chirp config --semantic`` enable
+    flow so both register through one path (epic §3 decision 8 ordering:
+    validate → resolve role → resolve alias → download → read → mutate → write
+    → warm). ``require_semantic_for_embed`` gates the user-facing ``models add``
+    path: an embed model can't be added while semantic search is off. The enable
+    flow leaves it ``False`` because it is mid-flight turning semantic on and
+    registers the embed model *before* flipping the flag.
+    """
     metadata = _validate_repo(hf_repo)
     resolved_role = _resolve_role(hf_repo, metadata, role)
+    if require_semantic_for_embed and resolved_role == "embed" and not _semantic_on():
+        _exit(
+            "Error: semantic search is off, so embed models can't be added. Run "
+            "`chirp config --semantic` to enable it (registers an embed model), "
+            "then add more embed models.",
+            2,
+        )
     resolved_alias = _resolve_alias(hf_repo, alias)
     _download(hf_repo, resolved_alias)
 
@@ -121,8 +156,21 @@ def add_command(
 
     _warn_on_role_change(resolved_alias, previous_entry, resolved_role)
 
-    if not no_warm:
+    if warm:
         _warm(resolved_alias, resolved_role)
+    return resolved_alias
+
+
+def _semantic_on() -> bool:
+    """Whether opt-in semantic retrieval is enabled in config.
+
+    A failure to read config is treated as off — the lexical-first default —
+    so a broken config never silently exposes embed-model addability.
+    """
+    try:
+        return get_settings().notes_chat.semantic_enabled
+    except Exception:  # noqa: BLE001 - config read must not break models commands
+        return False
 
 
 @dataclass(frozen=True)
@@ -143,13 +191,23 @@ def list_command(
         "--json",
         help="Emit a JSON document on stdout instead of a table.",
     ),
+    show_all: bool = typer.Option(
+        False,
+        "--all",
+        help="Include embed models even when semantic search is off.",
+    ),
 ) -> None:
-    """List registered models with role, default, and daemon-loaded state."""
+    """List registered models with role, default, and daemon-loaded state.
+
+    With semantic search off (the default), embed models are hidden because
+    they serve no purpose until it is enabled; pass --all to see them.
+    """
     registry = _read_registry()
     daemon_reachable, loaded_aliases = _query_loaded_state()
-    rows = _compose_rows(registry, loaded_aliases)
+    include_embed = show_all or _semantic_on()
+    rows = _compose_rows(registry, loaded_aliases, include_embed=include_embed)
     if json_output:
-        _render_list_json(registry, rows, daemon_reachable)
+        _render_list_json(registry, rows, daemon_reachable, include_embed=include_embed)
     else:
         _render_list_table(rows, daemon_reachable)
 
@@ -176,11 +234,18 @@ def _query_loaded_state() -> tuple[bool, set[str]]:
     return True, loaded_aliases
 
 
-def _compose_rows(registry: Registry, loaded_aliases: set[str]) -> list[ListRow]:
+def _compose_rows(
+    registry: Registry,
+    loaded_aliases: set[str],
+    *,
+    include_embed: bool = True,
+) -> list[ListRow]:
     """Build the sorted render rows from the registry and loaded-alias set.
 
     Sorted by ``(role, alias)`` ascending — ``chat`` sorts before ``embed`` —
-    so the table order is stable across runs.
+    so the table order is stable across runs. When ``include_embed`` is False
+    (semantic search off, no ``--all``), embed rows are dropped so both the
+    table and JSON renderers stay consistent.
     """
     defaults = {
         alias
@@ -196,6 +261,7 @@ def _compose_rows(registry: Registry, loaded_aliases: set[str]) -> list[ListRow]
             hf_repo=entry.hf_repo,
         )
         for alias, entry in registry.models.items()
+        if include_embed or entry.role != "embed"
     ]
     rows.sort(key=lambda row: (row.role, row.alias))
     return rows
@@ -230,12 +296,16 @@ def _render_list_table(rows: list[ListRow], daemon_reachable: bool) -> None:
 
 
 def _render_list_json(
-    registry: Registry, rows: list[ListRow], daemon_reachable: bool
+    registry: Registry,
+    rows: list[ListRow],
+    daemon_reachable: bool,
+    *,
+    include_embed: bool = True,
 ) -> None:
     payload: dict[str, Any] = {
         "schema_version": registry.schema_version,
         "default_chat": registry.default_chat,
-        "default_embed": registry.default_embed,
+        "default_embed": registry.default_embed if include_embed else None,
         "models": [
             {
                 "alias": row.alias,

--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -92,7 +92,7 @@ def _complete_alias(incomplete: str) -> list[str]:
 @app.command("add")
 def add_command(
     hf_repo: str = typer.Argument(
-        ..., help="HuggingFace repo id, e.g. mlx-community/gemma-4-4b-it-4bit."
+        ..., help="HuggingFace repo id, e.g. mlx-community/Qwen2.5-7B-Instruct-4bit."
     ),
     alias: str | None = typer.Option(
         None, "--alias", help="Override the alias inferred from the repo name."

--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -6,12 +6,12 @@ top-level CLI (``chirp/cli.py``). They share the same plumbing: HuggingFace
 validation/download/cache lookup (:mod:`llm.hf`), atomic registry writes
 (:mod:`llm.registry`), and daemon warm (:class:`llm.client.LLMClient`).
 
-``add``'s execution order is fixed (epic §3 decision 8): validate → resolve
-role → resolve alias → download → read registry → mutate → write → warm. Any
-failure before the registry write aborts without touching ``models.toml``. A
-failed warm leaves the registry write intact — the model is registered the
-moment its weights land, and the user retries the warm with ``chirp models
-pull``. The 4.5 commands share that read → mutate-or-display → optional-write
+``add``'s execution order is fixed: validate → resolve role → resolve alias →
+download → read registry → mutate → write → warm. Any failure before the
+registry write aborts without touching ``models.toml``. A failed warm leaves
+the registry write intact — the model is registered the moment its weights
+land, and the user retries the warm with ``chirp models pull``. The
+read/display commands share that read → mutate-or-display → optional-write
 shape and route every failure through the same error-mapping helpers.
 """
 
@@ -127,12 +127,11 @@ def register_model(
     """Validate, download, register, and optionally warm a model; return its alias.
 
     Shared by ``chirp models add`` and the ``chirp config --semantic`` enable
-    flow so both register through one path (epic §3 decision 8 ordering:
-    validate → resolve role → resolve alias → download → read → mutate → write
-    → warm). ``require_semantic_for_embed`` gates the user-facing ``models add``
-    path: an embed model can't be added while semantic search is off. The enable
-    flow leaves it ``False`` because it is mid-flight turning semantic on and
-    registers the embed model *before* flipping the flag.
+    flow so both register through one path. ``require_semantic_for_embed`` gates
+    the user-facing ``models add`` path: an embed model can't be added while
+    semantic search is off. The enable flow leaves it ``False`` because it is
+    mid-flight turning semantic on and registers the embed model *before*
+    flipping the flag.
     """
     metadata = _validate_repo(hf_repo)
     resolved_role = _resolve_role(hf_repo, metadata, role)
@@ -517,7 +516,7 @@ def _purge_cache(hf_repo: str) -> str | None:
     Returns the resolved path on success, or ``None`` when the directory is
     missing or unreadable (a warning is printed and the caller continues — the
     registry mutation already succeeded). A resolved path outside the hub cache
-    root is treated as a hard failure (exit 1) per AC-11.
+    root is treated as a hard failure (exit 1).
     """
     cache_dir = hf.cache_dir_for_repo(hf_repo).resolve()
     hub_root = hf.hf_hub_cache_root().resolve()

--- a/llm/registry.py
+++ b/llm/registry.py
@@ -113,6 +113,24 @@ def resolved_chat_model(fallback: str | None = None, path: Path | None = None) -
     return fallback or "unset"
 
 
+def resolved_embed_model(fallback: str | None = None, path: Path | None = None) -> str:
+    """Best-effort display name for the active embed model.
+
+    Mirrors :func:`resolved_chat_model`: returns the registry's configured
+    default embed alias when present, else ``fallback`` (the recommended embed
+    model), else ``"none"``. Never raises — display sites (``chirp about``,
+    ``chirp config --list``) must tolerate a missing or unreadable registry.
+    """
+    try:
+        registry = read_registry(path)
+    except LLMError:
+        return fallback or "none"
+    alias = registry.default_embed
+    if alias and alias in registry.models:
+        return alias
+    return fallback or "none"
+
+
 def resolve_alias(
     registry: Registry,
     identifier: str,

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -463,8 +463,8 @@ Return ONLY the XML document, no additional text before or after."""
 
     def _call_llm(self, prompt: str) -> str:
         # Single user message so the chat template wraps SYSTEM_PROMPT + prompt
-        # verbatim — preserving the prompt shape the 6.1 regression baseline was
-        # captured against (story 6.6 compares against it).
+        # verbatim — preserving the prompt shape the regression baseline was
+        # captured against.
         messages = [{"role": "user", "content": prompt}]
         options = {"max_tokens": self.settings.models.num_predict}
         # Reuse one client across records in a batch — LLMClient() resolves the

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -22,6 +22,11 @@ logger = logging.getLogger(__name__)
 # transcript was silently truncated mid-generation, so window it and warn.
 MAX_TRANSCRIPT_CHARS = 24000
 
+# Below this, a transcript has nothing to summarize (a silent/near-empty clip);
+# generating notes would only yield junk that later poisons `ask`. Callers treat
+# this as a benign skip, not a failure.
+MIN_TRANSCRIPT_CHARS = 50
+
 MAX_PARSE_ATTEMPTS = 2
 
 SYSTEM_PROMPT = """You are Chirp, the user's meeting note co-pilot.
@@ -175,6 +180,19 @@ class NoteGenerator:
         if successful:
             return {**successful[-1], "results": results}
 
+        # Distinguish a benign skip (nothing to summarize) from a real failure so
+        # callers can surface it as a skip rather than a hard error. Only when
+        # *every* record was skipped — a single genuine failure makes the batch a
+        # failure.
+        skipped = [r for r in results if r.get("skipped")]
+        if results and len(skipped) == len(results):
+            return {
+                "success": False,
+                "skipped": True,
+                "error": skipped[-1]["error"],
+                "results": results,
+            }
+
         return {
             "success": False,
             "error": "Failed to generate notes for any record",
@@ -221,11 +239,15 @@ class NoteGenerator:
             }
 
         transcript_text = record.transcript.read_text(encoding="utf-8").strip()
-        if len(transcript_text) < 50:
+        if len(transcript_text) < MIN_TRANSCRIPT_CHARS:
             return {
                 "success": False,
+                "skipped": True,
                 "slug": record.slug,
-                "error": "Insufficient transcript content (< 50 characters)",
+                "error": (
+                    f"Insufficient transcript content "
+                    f"(< {MIN_TRANSCRIPT_CHARS} characters)"
+                ),
             }
 
         provided_title = record.title

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -1,5 +1,6 @@
 import logging
 import tomllib
+import wave
 import xml.etree.ElementTree as ET
 from datetime import UTC, datetime
 from pathlib import Path
@@ -284,7 +285,10 @@ class NoteGenerator:
             "decisions": structured_notes.get("decisions", []),
             "open_questions": structured_notes.get("open_questions", []),
             "discussion_highlights": structured_notes.get("discussion_highlights", []),
-            "metadata": {"date": record.created_at.isoformat()},
+            "metadata": {
+                "date": record.created_at.isoformat(),
+                "duration_s": self._resolve_duration_seconds(record),
+            },
         }
 
         body = self.template_engine.render_meeting_section(meeting_notes)
@@ -300,6 +304,45 @@ class NoteGenerator:
             "filename": notes_path.name,
             "path": str(notes_path),
         }
+
+    def _resolve_duration_seconds(self, record: NoteRecord) -> float:
+        """Best-effort clip length for the note's Duration field.
+
+        Prefers ``duration_s`` from meta.toml (written by the recorder and the
+        transcribe save stage), falls back to the legacy ``duration`` key, then
+        to the WAV header — so a real duration shows even for imported audio
+        whose meta predates the field. Returns 0.0 when unknown (renders as
+        "Unknown"). Previously the generator passed no duration at all, so every
+        generated note read "Duration: Unknown" despite meta carrying it.
+        """
+        meta_path = record.dir / META_FILENAME
+        if meta_path.exists():
+            try:
+                with meta_path.open("rb") as fh:
+                    meta = tomllib.load(fh)
+            except (OSError, tomllib.TOMLDecodeError):
+                meta = {}
+            for key in ("duration_s", "duration"):
+                value = meta.get(key)
+                if value is None:
+                    continue
+                try:
+                    seconds = float(value)
+                except (TypeError, ValueError):
+                    continue
+                if seconds > 0:
+                    return seconds
+        audio = record.audio
+        if audio is not None and audio.exists():
+            try:
+                with wave.open(str(audio), "rb") as handle:
+                    frames = handle.getnframes()
+                    rate = handle.getframerate()
+                if rate > 0:
+                    return frames / float(rate)
+            except (OSError, wave.Error):
+                pass
+        return 0.0
 
     def _update_meta(self, note_dir: Path) -> None:
         meta_path = note_dir / META_FILENAME

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -340,8 +340,8 @@ class NoteGenerator:
                     rate = handle.getframerate()
                 if rate > 0:
                     return frames / float(rate)
-            except (OSError, wave.Error):
-                pass
+            except (OSError, wave.Error) as exc:
+                logger.debug("Could not read duration from %s: %s", audio, exc)
         return 0.0
 
     def _update_meta(self, note_dir: Path) -> None:

--- a/notes/template_engine.py
+++ b/notes/template_engine.py
@@ -71,7 +71,7 @@ class TemplateEngine:
     def render_meeting_section(self, meeting_data: dict[str, Any]) -> str:
         metadata = meeting_data.get("metadata", {})
         meeting_time = _extract_meeting_time(metadata)
-        duration = metadata.get("duration", 0)
+        duration = metadata.get("duration_s") or metadata.get("duration") or 0
         duration_str = format_duration(duration) if duration else "Unknown"
 
         variables = {

--- a/notes_chat/retrieval.py
+++ b/notes_chat/retrieval.py
@@ -23,6 +23,14 @@ LEXICAL_ONLY = (1.0, 0.0)
 LITERAL_WEIGHTS = (1.0, 0.3)
 CONCEPTUAL_WEIGHTS = (1.0, 1.0)
 
+# Retrieval returns a fixed top-k, so a query that truly matches one note still
+# comes back padded with weak/zero-score filler. RRF fuses by rank (not score),
+# discarding the raw-score gap, so that filler would otherwise ride into the
+# context and the `sources` line. Drop hits that scored <= 0 (matched nothing)
+# or below this fraction of the top hit's score, applied to raw scores BEFORE
+# the merge. The top hit is always kept (top >= top * ratio).
+RELEVANCE_FLOOR_RATIO = 0.2
+
 _ACRONYM_RE = re.compile(r"\b[A-Z]{2,}\b")
 
 
@@ -207,7 +215,7 @@ def _search_chroma(
                     (chunk_id, score, {"content": document, "metadata": metadata})
                 )
 
-        return chroma_results
+        return _apply_relevance_floor(chroma_results)
 
     except Exception as e:  # noqa: BLE001 - chromadb raises various internal exceptions
         logger.debug("Chroma search failed: %s", e, exc_info=True)
@@ -251,7 +259,7 @@ def _search_bm25(
                 content, metadata = hydrated
                 data = {"content": content, "metadata": metadata, "source": "bm25"}
             results.append((chunk_id, score, data))
-        return results
+        return _apply_relevance_floor(results)
 
     except Exception as e:  # noqa: BLE001 - BM25 can raise many types on corrupt index
         logger.debug("BM25 search failed: %s", e, exc_info=True)
@@ -266,6 +274,30 @@ def _signature(chunk_id: str, data: dict[str, Any]) -> str:
         content_hash = metadata.get("content_hash", "")
         return f"{path}::{content_hash}"
     return chunk_id
+
+
+def _apply_relevance_floor(
+    results: list[tuple[str, float, dict[str, Any]]],
+    ratio: float = RELEVANCE_FLOOR_RATIO,
+) -> list[tuple[str, float, dict[str, Any]]]:
+    """Drop weak/zero-score filler from a single retriever's ranked hits.
+
+    Keeps only hits scoring above 0 AND at least ``ratio`` of the top hit's
+    score, so the strongest match is always retained while padding that matched
+    nothing (or barely anything) is cut before it can pollute the context and
+    the ``sources`` line.
+    """
+    if not results:
+        return results
+    top_score = max(score for _id, score, _data in results)
+    if top_score <= 0:
+        # Degenerate/tiny corpus: BM25's IDF can push even a genuine match to
+        # <= 0 (e.g. a term present in most of a handful of notes), so there's
+        # no positive top to measure filler against. Keep everything rather than
+        # drop a real, low-scored hit and answer "no documents found".
+        return results
+    threshold = top_score * ratio
+    return [hit for hit in results if hit[1] > 0 and hit[1] >= threshold]
 
 
 def _route_query(question: str) -> tuple[float, float]:

--- a/tests/llm/test_cli_models.py
+++ b/tests/llm/test_cli_models.py
@@ -737,6 +737,21 @@ def test_list_json_hides_embed_when_semantic_off(
     assert payload["default_embed"] is None
 
 
+def test_list_all_json_shows_embed_when_semantic_off(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_and_embed(registry_path)
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["list", "--all", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    aliases = {model["alias"] for model in payload["models"]}
+    assert aliases == {"gemma-4-4b-it-4bit", "bge-small-en-v1.5"}
+    assert payload["default_embed"] == "bge-small-en-v1.5"
+
+
 def test_list_daemon_unreachable_tty(
     registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
 ) -> None:

--- a/tests/llm/test_cli_models.py
+++ b/tests/llm/test_cli_models.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -40,6 +41,22 @@ EMBED_REPO = "mlx-community/bge-small-en-v1.5"
 AMBIGUOUS_REPO = "mlx-community/mystery-model"
 
 runner = CliRunner()
+
+
+def _settings_with_semantic(enabled: bool):
+    """Factory standing in for ``get_settings`` with semantic toggled."""
+    return lambda: SimpleNamespace(notes_chat=SimpleNamespace(semantic_enabled=enabled))
+
+
+@pytest.fixture(autouse=True)
+def _semantic_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every models-CLI test to the lexical-first state (semantic off).
+
+    The embed-hiding (``list``) and embed-gating (``add``) paths read config via
+    ``get_settings``; pinning it here keeps those tests off the host's real
+    ``~/.chirp/config.toml``. Tests that need semantic on re-set it themselves.
+    """
+    monkeypatch.setattr(models_module, "get_settings", _settings_with_semantic(False))
 
 
 def _chat_metadata(repo: str = CHAT_REPO) -> hf.HfRepoMetadata:
@@ -165,6 +182,7 @@ def test_add_with_alias_flag_overrides_inferred(
 def test_add_with_role_flag_overrides_inferred(
     registry_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(models_module, "get_settings", _settings_with_semantic(True))
     _mock_hf(monkeypatch, validate=_ambiguous_metadata(), download=MagicMock())
     _mock_client(monkeypatch)
 
@@ -177,6 +195,37 @@ def test_add_with_role_flag_overrides_inferred(
     alias = alias_for_repo(AMBIGUOUS_REPO)
     assert registry.models[alias].role == "embed"
     assert registry.default_embed == alias
+
+
+def test_add_embed_rejected_when_semantic_off(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    download = _mock_hf(
+        monkeypatch, validate=_ambiguous_metadata(), download=MagicMock()
+    )
+    _mock_client(monkeypatch)
+
+    result = runner.invoke(
+        models_module.app, ["add", AMBIGUOUS_REPO, "--role", "embed"]
+    )
+
+    assert result.exit_code == 2
+    assert "chirp config --semantic" in result.stderr
+    assert not registry_path.exists()
+    download.assert_not_called()
+
+
+def test_add_chat_unaffected_when_semantic_off(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _mock_hf(monkeypatch, validate=_chat_metadata(), download=MagicMock())
+    _mock_client(monkeypatch)
+
+    result = runner.invoke(models_module.app, ["add", CHAT_REPO])
+
+    assert result.exit_code == 0
+    registry = read_registry(path=registry_path)
+    assert alias_for_repo(CHAT_REPO) in registry.models
 
 
 def test_add_no_warm_skips_model_load(
@@ -316,6 +365,7 @@ def test_add_idempotent_second_run(
 def test_add_role_change_warning(
     registry_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(models_module, "get_settings", _settings_with_semantic(True))
     alias = alias_for_repo(CHAT_REPO)
     _seed_registry(
         registry_path,
@@ -612,6 +662,7 @@ def test_list_one_chat_model_json(
 def test_list_chat_and_embed_tty(
     registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
 ) -> None:
+    monkeypatch.setattr(models_module, "get_settings", _settings_with_semantic(True))
     _seed_chat_and_embed(registry_path)
     _mock_list_client(
         monkeypatch, models=[{"alias": "bge-small-en-v1.5", "loaded": True}]
@@ -628,6 +679,7 @@ def test_list_chat_and_embed_tty(
 def test_list_chat_and_embed_json(
     registry_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setattr(models_module, "get_settings", _settings_with_semantic(True))
     _seed_chat_and_embed(registry_path)
     _mock_list_client(
         monkeypatch, models=[{"alias": "bge-small-en-v1.5", "loaded": True}]
@@ -642,6 +694,47 @@ def test_list_chat_and_embed_json(
     assert by_alias["bge-small-en-v1.5"]["loaded"] is True
     assert by_alias["bge-small-en-v1.5"]["role"] == "embed"
     assert payload["default_embed"] == "bge-small-en-v1.5"
+
+
+def test_list_hides_embed_when_semantic_off(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
+) -> None:
+    _seed_chat_and_embed(registry_path)
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["list"])
+
+    assert result.exit_code == 0
+    assert "gemma-4-4b-it-4bit" in result.stdout
+    assert "bge-small-en-v1.5" not in result.stdout
+
+
+def test_list_all_shows_embed_when_semantic_off(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch, wide_table: None
+) -> None:
+    _seed_chat_and_embed(registry_path)
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["list", "--all"])
+
+    assert result.exit_code == 0
+    assert "gemma-4-4b-it-4bit" in result.stdout
+    assert "bge-small-en-v1.5" in result.stdout
+
+
+def test_list_json_hides_embed_when_semantic_off(
+    registry_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_chat_and_embed(registry_path)
+    _mock_list_client(monkeypatch, models=[])
+
+    result = runner.invoke(models_module.app, ["list", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    aliases = {model["alias"] for model in payload["models"]}
+    assert aliases == {"gemma-4-4b-it-4bit"}
+    assert payload["default_embed"] is None
 
 
 def test_list_daemon_unreachable_tty(

--- a/tests/llm/test_registry.py
+++ b/tests/llm/test_registry.py
@@ -19,6 +19,7 @@ from llm.registry import (
     read_registry,
     remove_model,
     resolve_alias,
+    resolved_embed_model,
     set_default_for_role,
     upsert_model,
     write_registry,
@@ -182,6 +183,37 @@ def _embed_entry() -> RegistryEntry:
         hf_repo="mlx-community/bge-small-en-v1.5",
         role="embed",
     )
+
+
+def test_resolved_embed_model_returns_registry_default(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    write_registry(
+        Registry(
+            schema_version=1,
+            default_embed="bge-small-en-v1.5",
+            models={"bge-small-en-v1.5": _embed_entry()},
+        ),
+        path=target,
+    )
+    assert resolved_embed_model("fallback", target) == "bge-small-en-v1.5"
+
+
+def test_resolved_embed_model_falls_back_when_unset(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    write_registry(Registry(schema_version=1), path=target)
+    assert resolved_embed_model("fallback", target) == "fallback"
+
+
+def test_resolved_embed_model_falls_back_when_alias_missing(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    write_registry(
+        Registry(schema_version=1, default_embed="ghost", models={}), path=target
+    )
+    assert resolved_embed_model("fallback", target) == "fallback"
+
+
+def test_resolved_embed_model_none_when_no_fallback(tmp_path: Path) -> None:
+    assert resolved_embed_model(path=tmp_path / "absent.toml") == "none"
 
 
 def test_registry_round_trip_empty(tmp_path: Path) -> None:

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -24,7 +24,9 @@ def _fake_settings(tmp_path):
     return SimpleNamespace(
         directories=SimpleNamespace(notes_root=notes_root),
         models=SimpleNamespace(llm="llama3.1:8b"),
-        notes_chat=SimpleNamespace(emb_model="nomic-embed-text"),
+        notes_chat=SimpleNamespace(
+            semantic_enabled=False, recommended_embed_model="bge-small-en-v1.5"
+        ),
     )
 
 

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -25,7 +25,7 @@ def _fake_settings(tmp_path):
         directories=SimpleNamespace(notes_root=notes_root),
         models=SimpleNamespace(llm="llama3.1:8b"),
         notes_chat=SimpleNamespace(
-            semantic_enabled=False, recommended_embed_model="bge-small-en-v1.5"
+            semantic_enabled=False, recommended_embed_model="bge-small-en-v1.5-bf16"
         ),
     )
 

--- a/tests/test_about.py
+++ b/tests/test_about.py
@@ -53,3 +53,27 @@ def test_run_about_paints_all_logo_rows(tmp_path):
     assert "chirp" in output
     assert "Colby Timm" in output
     assert TAGLINE in output
+
+
+def test_plain_about_shows_lexical_label_when_semantic_off(tmp_path):
+    buffer = StringIO()
+    console = Console(file=buffer, width=120, force_terminal=False)
+
+    about.render_about_plain(console, _fake_settings(tmp_path))
+
+    assert "lexical (BM25)" in buffer.getvalue()
+
+
+def test_plain_about_shows_embed_alias_when_semantic_on(tmp_path, monkeypatch):
+    settings = _fake_settings(tmp_path)
+    settings.notes_chat.semantic_enabled = True
+    monkeypatch.setattr(about, "resolved_embed_model", lambda fallback: "my-embed")
+
+    buffer = StringIO()
+    console = Console(file=buffer, width=120, force_terminal=False)
+
+    about.render_about_plain(console, settings)
+
+    output = buffer.getvalue()
+    assert "my-embed" in output
+    assert "lexical (BM25)" not in output

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import pytest
 import tomli_w
 from rich.console import Console
 
@@ -12,9 +13,19 @@ from transcriber.batch_processor import (
     StageState,
     _has_transcript,
     _read_meta,
+    _StageSkipped,
     _write_meta,
 )
 from utils.file_utils import NoteRecord
+
+
+@pytest.fixture(autouse=True)
+def _isolate_resolved_chat_model(monkeypatch):
+    """Pin ``resolved_chat_model`` to its fallback so meta/label assertions don't
+    depend on the host's ``models.toml``."""
+    monkeypatch.setattr(
+        "transcriber.batch_processor.resolved_chat_model", lambda fallback: fallback
+    )
 
 
 def _seed_record_dir(tmp_path: Path, slug: str, with_transcript: bool = False) -> Path:
@@ -76,6 +87,18 @@ class TestChecklistView:
         assert "loaded audio" in output
         assert "00:42" in output
         assert "transcribe" in output
+
+    def test_skip_renders_muted_detail_not_failure(self):
+        from io import StringIO
+
+        view = ChecklistView(header="clip")
+        view.skip(Stage.GENERATE_NOTES, "recording too short to summarize")
+        assert view.statuses[Stage.GENERATE_NOTES].state is StageState.SKIPPED
+        buffer = StringIO()
+        Console(file=buffer, force_terminal=False, width=80).print(view.render())
+        output = buffer.getvalue()
+        assert "recording too short to summarize" in output
+        assert "✗" not in output
 
 
 class TestSelectQueue:
@@ -180,7 +203,7 @@ class TestRunQueueIntegration:
         proc = _processor(tmp_path)
 
         result = proc.run_queue(console=Console(force_terminal=False))
-        assert result == {"ok": 2, "failed": 0, "total": 2}
+        assert result == {"ok": 2, "skipped": 0, "failed": 0, "total": 2}
 
         for slug in ("alpha", "beta"):
             transcript = tmp_path / slug / "transcript.txt"
@@ -210,7 +233,7 @@ class TestRunQueueIntegration:
         proc = _processor(tmp_path)
 
         result = proc.run_queue(console=Console(force_terminal=False))
-        assert result == {"ok": 1, "failed": 1, "total": 2}
+        assert result == {"ok": 1, "skipped": 0, "failed": 1, "total": 2}
         # second one still got its notes file
         assert (tmp_path / "second" / "notes.md").exists()
         # first one did NOT — generation failed
@@ -233,10 +256,26 @@ class TestRunQueueIntegration:
         proc = _processor(tmp_path)
 
         result = proc.run_queue(n=2, console=Console(force_terminal=False))
-        assert result == {"ok": 2, "failed": 0, "total": 2}
+        assert result == {"ok": 2, "skipped": 0, "failed": 0, "total": 2}
         assert (tmp_path / "a" / "notes.md").exists()
         assert (tmp_path / "b" / "notes.md").exists()
         assert not (tmp_path / "c" / "notes.md").exists()
+
+    def test_run_queue_counts_skip_not_failure(self, tmp_path, monkeypatch):
+        _seed_record_dir(tmp_path, "blip")
+        self._stub_stages(monkeypatch)
+
+        def skip_generate(self, ctx):
+            raise _StageSkipped("recording too short to summarize")
+
+        monkeypatch.setattr(BatchProcessor, "_stage_generate_notes", skip_generate)
+        proc = _processor(tmp_path)
+
+        result = proc.run_queue(console=Console(force_terminal=False))
+
+        assert result == {"ok": 0, "skipped": 1, "failed": 0, "total": 1}
+        # A skipped record runs no later stages, so no notes are written.
+        assert not (tmp_path / "blip" / "notes.md").exists()
 
 
 class TestMetaIO:
@@ -350,7 +389,7 @@ class TestResumeFromFailure:
         )
 
         result = proc.run_queue(console=Console(force_terminal=False))
-        assert result == {"ok": 1, "failed": 0, "total": 1}
+        assert result == {"ok": 1, "skipped": 0, "failed": 0, "total": 1}
         assert whisper_called["count"] == 0
         # Transcript untouched
         assert (

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -1,0 +1,174 @@
+"""Tests for ``chirp config`` — the semantic enable/disable flow and listing.
+
+Every external boundary is mocked: ``register_model`` (HF download + registry),
+``LLMClient`` (chirpd verify-load), and ``build_index`` (Chroma backfill). The
+config file and chirp home are redirected under ``tmp_path`` so no test touches
+the host's real ``~/.chirp``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from chirp import cli
+from chirp.init_flow import RECOMMENDED_EMBED_REPO
+from config.settings import ChirpSettings
+from llm.exceptions import LLMModelLoadFailed
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def config_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
+    config_path = tmp_path / "config.toml"
+    notes_root = tmp_path / "notes"
+    index_dir = tmp_path / "home"
+    notes_root.mkdir()
+    index_dir.mkdir()
+
+    seed = ChirpSettings()
+    seed.directories.notes_root = notes_root
+    seed.notes_chat.index_dir = index_dir
+    seed.notes_chat.semantic_enabled = False
+    seed.save_to_file(config_path)
+
+    monkeypatch.setattr(
+        ChirpSettings, "get_config_path", classmethod(lambda cls: config_path)
+    )
+    monkeypatch.setattr(
+        cli, "get_settings", lambda: ChirpSettings.load_from_file(config_path)
+    )
+    monkeypatch.setattr("config.settings.default_chirp_home", lambda: index_dir)
+    return SimpleNamespace(
+        config_path=config_path, notes_root=notes_root, index_dir=index_dir
+    )
+
+
+def _reload(config_path: Path) -> ChirpSettings:
+    return ChirpSettings.load_from_file(config_path)
+
+
+def test_enable_registers_verifies_flips_and_rebuilds(
+    config_env: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    order: list[str] = []
+
+    def _register(repo, *, role=None, alias=None, warm=True, **_):
+        order.append("register")
+        assert repo == RECOMMENDED_EMBED_REPO
+        assert role == "embed"
+        assert warm is False
+        return "bge-small-en-v1.5"
+
+    client = MagicMock()
+    client.model_load_sync.side_effect = lambda *a, **k: order.append("verify")
+
+    def _build(config, force=False, progress_callback=None):
+        order.append("build")
+        assert force is True
+        assert _reload(config_env.config_path).notes_chat.semantic_enabled is True
+        return {"success": True}
+
+    monkeypatch.setattr("llm.cli.models.register_model", _register)
+    monkeypatch.setattr("llm.client.LLMClient", MagicMock(return_value=client))
+    monkeypatch.setattr("notes_chat.index.build_index", _build)
+
+    result = runner.invoke(cli.app, ["config", "--semantic"])
+
+    assert result.exit_code == 0
+    assert order == ["register", "verify", "build"]
+    client.model_load_sync.assert_called_once_with("bge-small-en-v1.5", "embed")
+    assert _reload(config_env.config_path).notes_chat.semantic_enabled is True
+
+
+def test_enable_aborts_and_keeps_flag_off_when_load_fails(
+    config_env: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = MagicMock()
+    client.model_load_sync.side_effect = LLMModelLoadFailed("bert not supported")
+    build = MagicMock()
+
+    monkeypatch.setattr(
+        "llm.cli.models.register_model", MagicMock(return_value="bge-small-en-v1.5")
+    )
+    monkeypatch.setattr("llm.client.LLMClient", MagicMock(return_value=client))
+    monkeypatch.setattr("notes_chat.index.build_index", build)
+
+    result = runner.invoke(cli.app, ["config", "--semantic"])
+
+    assert result.exit_code == 4
+    assert "stays off" in result.stderr
+    build.assert_not_called()
+    assert _reload(config_env.config_path).notes_chat.semantic_enabled is False
+
+
+def test_disable_with_purge_removes_chroma(config_env: SimpleNamespace) -> None:
+    chroma = config_env.index_dir / "chroma"
+    chroma.mkdir()
+    (chroma / "chroma.sqlite3").write_text("x")
+    _seed_semantic_on(config_env)
+
+    result = runner.invoke(cli.app, ["config", "--no-semantic", "--purge"])
+
+    assert result.exit_code == 0
+    assert not chroma.exists()
+    assert _reload(config_env.config_path).notes_chat.semantic_enabled is False
+
+
+def test_disable_without_purge_keeps_chroma(config_env: SimpleNamespace) -> None:
+    chroma = config_env.index_dir / "chroma"
+    chroma.mkdir()
+    (chroma / "chroma.sqlite3").write_text("x")
+    _seed_semantic_on(config_env)
+
+    result = runner.invoke(cli.app, ["config", "--no-semantic"])
+
+    assert result.exit_code == 0
+    assert chroma.exists()
+    assert _reload(config_env.config_path).notes_chat.semantic_enabled is False
+
+
+def _seed_semantic_on(config_env: SimpleNamespace) -> None:
+    settings = _reload(config_env.config_path)
+    settings.notes_chat.semantic_enabled = True
+    settings.save_to_file(config_env.config_path)
+
+
+def test_list_shows_resolved_embed_alias(
+    config_env: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str | None] = []
+
+    def _spy(fallback=None, path=None):
+        calls.append(fallback)
+        return "spy-embed"
+
+    monkeypatch.setattr(cli, "resolved_embed_model", _spy)
+
+    result = runner.invoke(cli.app, ["config", "--list"])
+
+    assert result.exit_code == 0
+    assert "spy-embed" in result.stdout
+    assert "nomic-embed-text" not in result.stdout
+    assert calls == ["bge-small-en-v1.5"]
+
+
+def test_embedding_model_option_is_gone(config_env: SimpleNamespace) -> None:
+    result = runner.invoke(cli.app, ["config", "--embedding-model", "nomic-embed-text"])
+
+    assert result.exit_code == 2
+
+
+def test_purge_without_disable_is_a_noop_warning(
+    config_env: SimpleNamespace,
+) -> None:
+    result = runner.invoke(cli.app, ["config", "--purge"])
+
+    assert result.exit_code == 0
+    assert "no effect" in result.stderr
+    assert _reload(config_env.config_path).notes_chat.semantic_enabled is False

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -63,7 +63,7 @@ def test_enable_registers_verifies_flips_and_rebuilds(
         assert repo == RECOMMENDED_EMBED_REPO
         assert role == "embed"
         assert warm is False
-        return "bge-small-en-v1.5"
+        return "bge-small-en-v1.5-bf16"
 
     client = MagicMock()
     client.model_load_sync.side_effect = lambda *a, **k: order.append("verify")
@@ -82,7 +82,7 @@ def test_enable_registers_verifies_flips_and_rebuilds(
 
     assert result.exit_code == 0
     assert order == ["register", "verify", "build"]
-    client.model_load_sync.assert_called_once_with("bge-small-en-v1.5", "embed")
+    client.model_load_sync.assert_called_once_with("bge-small-en-v1.5-bf16", "embed")
     assert _reload(config_env.config_path).notes_chat.semantic_enabled is True
 
 
@@ -94,7 +94,8 @@ def test_enable_aborts_and_keeps_flag_off_when_load_fails(
     build = MagicMock()
 
     monkeypatch.setattr(
-        "llm.cli.models.register_model", MagicMock(return_value="bge-small-en-v1.5")
+        "llm.cli.models.register_model",
+        MagicMock(return_value="bge-small-en-v1.5-bf16"),
     )
     monkeypatch.setattr("llm.client.LLMClient", MagicMock(return_value=client))
     monkeypatch.setattr("notes_chat.index.build_index", build)
@@ -144,7 +145,8 @@ def test_enable_with_purge_warns_but_proceeds(
 ) -> None:
     client = MagicMock()
     monkeypatch.setattr(
-        "llm.cli.models.register_model", MagicMock(return_value="bge-small-en-v1.5")
+        "llm.cli.models.register_model",
+        MagicMock(return_value="bge-small-en-v1.5-bf16"),
     )
     monkeypatch.setattr("llm.client.LLMClient", MagicMock(return_value=client))
     monkeypatch.setattr(
@@ -189,7 +191,8 @@ def test_scalar_setter_persists_through_enable(
 ) -> None:
     new_root = tmp_path / "relocated"
     monkeypatch.setattr(
-        "llm.cli.models.register_model", MagicMock(return_value="bge-small-en-v1.5")
+        "llm.cli.models.register_model",
+        MagicMock(return_value="bge-small-en-v1.5-bf16"),
     )
     monkeypatch.setattr("llm.client.LLMClient", MagicMock(return_value=MagicMock()))
     monkeypatch.setattr(
@@ -241,7 +244,7 @@ def test_list_shows_resolved_embed_alias(
     assert result.exit_code == 0
     assert "spy-embed" in result.stdout
     assert "nomic-embed-text" not in result.stdout
-    assert calls == ["bge-small-en-v1.5"]
+    assert calls == ["bge-small-en-v1.5-bf16"]
 
 
 def test_embedding_model_option_is_gone(config_env: SimpleNamespace) -> None:

--- a/tests/test_config_command.py
+++ b/tests/test_config_command.py
@@ -120,6 +120,92 @@ def test_disable_with_purge_removes_chroma(config_env: SimpleNamespace) -> None:
     assert _reload(config_env.config_path).notes_chat.semantic_enabled is False
 
 
+def test_enable_when_already_on_is_a_noop(
+    config_env: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _seed_semantic_on(config_env)
+    register = MagicMock()
+    build = MagicMock()
+    monkeypatch.setattr("llm.cli.models.register_model", register)
+    monkeypatch.setattr("llm.client.LLMClient", MagicMock())
+    monkeypatch.setattr("notes_chat.index.build_index", build)
+
+    result = runner.invoke(cli.app, ["config", "--semantic"])
+
+    assert result.exit_code == 0
+    assert "already on" in result.stderr
+    register.assert_not_called()
+    build.assert_not_called()
+    assert _reload(config_env.config_path).notes_chat.semantic_enabled is True
+
+
+def test_enable_with_purge_warns_but_proceeds(
+    config_env: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client = MagicMock()
+    monkeypatch.setattr(
+        "llm.cli.models.register_model", MagicMock(return_value="bge-small-en-v1.5")
+    )
+    monkeypatch.setattr("llm.client.LLMClient", MagicMock(return_value=client))
+    monkeypatch.setattr(
+        "notes_chat.index.build_index", MagicMock(return_value={"success": True})
+    )
+
+    result = runner.invoke(cli.app, ["config", "--semantic", "--purge"])
+
+    assert result.exit_code == 0
+    assert "no effect with --semantic" in result.stderr
+    assert _reload(config_env.config_path).notes_chat.semantic_enabled is True
+
+
+def test_disable_purge_when_chroma_missing(config_env: SimpleNamespace) -> None:
+    _seed_semantic_on(config_env)
+    assert not (config_env.index_dir / "chroma").exists()
+
+    result = runner.invoke(cli.app, ["config", "--no-semantic", "--purge"])
+
+    assert result.exit_code == 0
+    assert "nothing to purge" in result.stderr
+    assert _reload(config_env.config_path).notes_chat.semantic_enabled is False
+
+
+def test_scalar_setter_applies_alongside_semantic_toggle(
+    config_env: SimpleNamespace, tmp_path: Path
+) -> None:
+    new_root = tmp_path / "relocated"
+
+    result = runner.invoke(
+        cli.app, ["config", "--no-semantic", "--notes-root", str(new_root)]
+    )
+
+    assert result.exit_code == 0
+    reloaded = _reload(config_env.config_path)
+    assert reloaded.directories.notes_root == new_root
+    assert reloaded.notes_chat.semantic_enabled is False
+
+
+def test_scalar_setter_persists_through_enable(
+    config_env: SimpleNamespace, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    new_root = tmp_path / "relocated"
+    monkeypatch.setattr(
+        "llm.cli.models.register_model", MagicMock(return_value="bge-small-en-v1.5")
+    )
+    monkeypatch.setattr("llm.client.LLMClient", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        "notes_chat.index.build_index", MagicMock(return_value={"success": True})
+    )
+
+    result = runner.invoke(
+        cli.app, ["config", "--semantic", "--notes-root", str(new_root)]
+    )
+
+    assert result.exit_code == 0
+    reloaded = _reload(config_env.config_path)
+    assert reloaded.directories.notes_root == new_root
+    assert reloaded.notes_chat.semantic_enabled is True
+
+
 def test_disable_without_purge_keeps_chroma(config_env: SimpleNamespace) -> None:
     chroma = config_env.index_dir / "chroma"
     chroma.mkdir()

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -189,7 +189,7 @@ def test_verify_handles_empty_registry(tmp_path, monkeypatch):
     chat = next(s for s in statuses if s.name == "default chat model")
     assert chat.installed is False
     assert chat.required is False
-    assert "chirp models add mlx-community/gemma-4-4b-it-4bit" in chat.detail
+    assert f"chirp models add {init_flow.RECOMMENDED_CHAT_REPO}" in chat.detail
 
 
 def test_verify_handles_missing_registry_file(tmp_path, monkeypatch):
@@ -223,7 +223,7 @@ def test_run_init_prints_models_add_hint_when_registry_empty(tmp_path, monkeypat
 
     assert code == 0
     output = console.file.getvalue()
-    assert "chirp models add mlx-community/gemma-4-4b-it-4bit" in output
+    assert f"chirp models add {init_flow.RECOMMENDED_CHAT_REPO}" in output
     assert "ollama" not in output.lower()
 
 
@@ -241,7 +241,7 @@ def test_switch_model_with_empty_registry_prints_models_add_hint(tmp_path, monke
 
     assert code == 0
     output = console.file.getvalue()
-    assert "chirp models add mlx-community/gemma-4-4b-it-4bit" in output
+    assert f"chirp models add {init_flow.RECOMMENDED_CHAT_REPO}" in output
     assert "pick" not in output.lower()  # no tag picker shown
 
 
@@ -967,7 +967,7 @@ def test_plan_recommends_default_chat_repo(tmp_path, monkeypatch):
     init_flow.run_init(_fake_settings(tmp_path), console, recheck=True)
 
     output = console.file.getvalue()
-    assert "mlx-community/gemma-4-4b-it-4bit" in output
+    assert init_flow.RECOMMENDED_CHAT_REPO in output
     assert init_flow.SMALLER_CHAT_REPO in output
 
 

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -799,8 +799,38 @@ def test_finalize_paths_preserves_existing_config(tmp_path, monkeypatch):
     init_flow._finalize_paths(settings, _console())
 
     assert config_path.stat().st_mtime == original_mtime
-    assert (settings.notes_chat.index_dir / "chroma").exists()
     assert settings.directories.notes_root.exists()
+
+
+def test_finalize_paths_skips_chroma_when_lexical_only(tmp_path, monkeypatch):
+    """A fresh lexical-only install must not get an empty chroma/ directory."""
+    settings = _fake_settings(tmp_path)
+    settings.notes_chat.semantic_enabled = False
+    monkeypatch.setattr(
+        init_flow.ChirpSettings, "get_config_path", lambda: tmp_path / "config.toml"
+    )
+    monkeypatch.setattr(init_flow, "_offer_launch_agent", lambda *a, **k: None)
+
+    console = _console()
+    init_flow._finalize_paths(settings, console)
+
+    assert not (settings.notes_chat.index_dir / "chroma").exists()
+    assert "chromadb" not in console.file.getvalue()
+
+
+def test_finalize_paths_creates_chroma_when_semantic_on(tmp_path, monkeypatch):
+    settings = _fake_settings(tmp_path)
+    settings.notes_chat.semantic_enabled = True
+    monkeypatch.setattr(
+        init_flow.ChirpSettings, "get_config_path", lambda: tmp_path / "config.toml"
+    )
+    monkeypatch.setattr(init_flow, "_offer_launch_agent", lambda *a, **k: None)
+
+    console = _console()
+    init_flow._finalize_paths(settings, console)
+
+    assert (settings.notes_chat.index_dir / "chroma").exists()
+    assert "chromadb" in console.file.getvalue()
 
 
 # --- --recheck Ollama migration plan (story 7.2) ---------------------------------

--- a/tests/test_note_generator.py
+++ b/tests/test_note_generator.py
@@ -226,6 +226,31 @@ class TestNoteGenerator:
         assert result["skipped"] is True
         assert "Insufficient" in result["error"]
 
+    def test_resolve_duration_reads_duration_s_from_meta(self, mock_settings, tmp_path):
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+            record = _seed_record(tmp_path, title="X", transcript="hi")
+            meta_path = record.dir / "meta.toml"
+            with meta_path.open("rb") as fh:
+                meta = tomllib.load(fh)
+            meta["duration_s"] = 91.99
+            with meta_path.open("wb") as fh:
+                tomli_w.dump(meta, fh)
+
+            assert generator._resolve_duration_seconds(record) == pytest.approx(91.99)
+
+    def test_resolve_duration_zero_when_no_meta_or_audio(self, mock_settings, tmp_path):
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+            record = _seed_record(tmp_path, title="X", transcript="hi")  # audio=None
+            assert generator._resolve_duration_seconds(record) == 0.0
+
     def test_parse_failure_retries_once(self, mock_settings):
         """Unparsable output is retried once before giving up (AC-12)."""
         with (

--- a/tests/test_note_generator.py
+++ b/tests/test_note_generator.py
@@ -207,6 +207,23 @@ class TestNoteGenerator:
             result = generator._generate_for_record(record, force=False)
 
         assert result["success"] is False
+        assert result["skipped"] is True
+        assert "Insufficient" in result["error"]
+
+    def test_generate_for_records_marks_all_short_as_skipped(
+        self, mock_settings, tmp_path
+    ):
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+            record = _seed_record(tmp_path, title="Quick", transcript="hi")
+
+            result = generator.generate_for_records([record])
+
+        assert result["success"] is False
+        assert result["skipped"] is True
         assert "Insufficient" in result["error"]
 
     def test_parse_failure_retries_once(self, mock_settings):

--- a/tests/test_note_generator.py
+++ b/tests/test_note_generator.py
@@ -251,6 +251,51 @@ class TestNoteGenerator:
             record = _seed_record(tmp_path, title="X", transcript="hi")  # audio=None
             assert generator._resolve_duration_seconds(record) == 0.0
 
+    def _record_with_audio(self, tmp_path, audio) -> NoteRecord:
+        note_dir = audio.parent
+        (note_dir / "meta.toml").write_text('title = "W"\n', encoding="utf-8")
+        return NoteRecord(
+            slug=note_dir.name,
+            dir=note_dir,
+            audio=audio,
+            transcript=None,
+            notes=None,
+            meta=note_dir / "meta.toml",
+            created_at=datetime(2026, 4, 20),
+        )
+
+    def test_resolve_duration_falls_back_to_wav_header(self, mock_settings, tmp_path):
+        import wave
+
+        note_dir = tmp_path / "wav-note"
+        note_dir.mkdir()
+        audio = note_dir / "audio.wav"
+        with wave.open(str(audio), "wb") as fh:
+            fh.setnchannels(1)
+            fh.setsampwidth(2)
+            fh.setframerate(16000)
+            fh.writeframes(b"\x00\x00" * 8000)  # 8000 frames @ 16 kHz = 0.5s
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+            record = self._record_with_audio(tmp_path, audio)
+            assert generator._resolve_duration_seconds(record) == pytest.approx(0.5)
+
+    def test_resolve_duration_zero_on_unreadable_audio(self, mock_settings, tmp_path):
+        note_dir = tmp_path / "bad-audio"
+        note_dir.mkdir()
+        audio = note_dir / "audio.wav"
+        audio.write_bytes(b"not a wav file")  # triggers wave.Error → logged, falls to 0
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+            record = self._record_with_audio(tmp_path, audio)
+            assert generator._resolve_duration_seconds(record) == 0.0
+
     def test_parse_failure_retries_once(self, mock_settings):
         """Unparsable output is retried once before giving up (AC-12)."""
         with (

--- a/tests/test_retrieval_merge.py
+++ b/tests/test_retrieval_merge.py
@@ -1,6 +1,34 @@
 import pytest
 
-from notes_chat.retrieval import _build_context, _merge_and_dedupe
+from notes_chat.retrieval import (
+    _apply_relevance_floor,
+    _build_context,
+    _merge_and_dedupe,
+)
+
+
+def _hit(cid, score):
+    return (cid, score, {"source": "bm25"})
+
+
+class TestRelevanceFloor:
+    def test_drops_zero_and_below_ratio_keeps_top(self):
+        hits = [_hit("a", 8.0), _hit("b", 3.6), _hit("c", 1.2), _hit("d", 0.0)]
+        kept = {cid for cid, _s, _d in _apply_relevance_floor(hits, ratio=0.2)}
+        # top kept; b (>20% of 8) kept; c (1.2 < 1.6) and zero-score d dropped.
+        assert kept == {"a", "b"}
+
+    def test_top_is_always_kept(self):
+        kept = _apply_relevance_floor([_hit("only", 5.0)], ratio=0.2)
+        assert [cid for cid, _s, _d in kept] == ["only"]
+
+    def test_tiny_corpus_nonpositive_top_keeps_everything(self):
+        # BM25 IDF can drive a genuine match to <= 0 in a tiny corpus.
+        hits = [_hit("a", 0.0), _hit("b", -0.3)]
+        assert _apply_relevance_floor(hits) == hits
+
+    def test_empty_in_empty_out(self):
+        assert _apply_relevance_floor([]) == []
 
 
 class TestRetrievalMerge:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -112,7 +112,7 @@ class TestChirpSettings:
 
         assert not hasattr(reloaded.notes_chat, "emb_model")
         assert reloaded.notes_chat.k == 7
-        assert reloaded.notes_chat.recommended_embed_model == "bge-small-en-v1.5"
+        assert reloaded.notes_chat.recommended_embed_model == "bge-small-en-v1.5-bf16"
 
     def test_non_table_init_value_does_not_block_load(self, tmp_path):
         """A hand-written non-table `init` value must not crash settings load.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -86,6 +86,34 @@ class TestChirpSettings:
         reloaded = ChirpSettings.load_from_file(config_path)
         assert reloaded.directories.notes_root == tmp_path / "custom-root"
 
+    def test_recommended_embed_model_round_trips(self, tmp_path):
+        settings = ChirpSettings()
+        settings.notes_chat.recommended_embed_model = "custom-embed"
+        config_path = tmp_path / "config.toml"
+
+        settings.save_to_file(config_path)
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert reloaded.notes_chat.recommended_embed_model == "custom-embed"
+
+    def test_legacy_emb_model_key_loads_without_error(self, tmp_path):
+        """An old config carrying the renamed ``emb_model`` key must still load.
+
+        The key was renamed to ``recommended_embed_model``; pydantic ignores the
+        stale extra key rather than raising, so existing configs survive upgrade.
+        """
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            '[notes_chat]\nemb_model = "nomic-embed-text"\nk = 7\n',
+            encoding="utf-8",
+        )
+
+        reloaded = ChirpSettings.load_from_file(config_path)
+
+        assert not hasattr(reloaded.notes_chat, "emb_model")
+        assert reloaded.notes_chat.k == 7
+        assert reloaded.notes_chat.recommended_embed_model == "bge-small-en-v1.5"
+
     def test_non_table_init_value_does_not_block_load(self, tmp_path):
         """A hand-written non-table `init` value must not crash settings load.
 

--- a/tests/test_template_engine.py
+++ b/tests/test_template_engine.py
@@ -201,3 +201,20 @@ class TestRenderMeetingSection:
     def test_formats_duration_from_metadata(self, engine):
         result = engine.render_meeting_section(self._full_meeting_data())
         assert "1h 0m" in result
+
+    def test_formats_duration_from_duration_s_key(self, engine):
+        # meta.toml stores the recording length under `duration_s`.
+        data = self._full_meeting_data()
+        data["metadata"] = {
+            "date": datetime(2026, 4, 20, 10, 0, 0),
+            "duration_s": 91.99,
+        }
+        result = engine.render_meeting_section(data)
+        assert "1m 31s" in result
+        assert "Unknown" not in result.split("**Duration:**")[1].splitlines()[0]
+
+    def test_duration_s_takes_precedence_over_legacy_duration(self, engine):
+        data = self._full_meeting_data()
+        data["metadata"] = {"duration_s": 90.0, "duration": 0}
+        result = engine.render_meeting_section(data)
+        assert "1m 30s" in result

--- a/transcriber/batch_processor.py
+++ b/transcriber/batch_processor.py
@@ -17,6 +17,7 @@ from rich.table import Table
 from rich.text import Text
 
 from config.settings import ChirpSettings
+from llm.registry import resolved_chat_model
 from transcriber.whisper_transcriber import WhisperTranscriber
 from utils.file_utils import (
     META_FILENAME,
@@ -46,7 +47,20 @@ class StageState(Enum):
     PENDING = "pending"
     RUNNING = "running"
     DONE = "done"
+    SKIPPED = "skipped"
     FAILED = "failed"
+
+
+class _StageSkipped(Exception):
+    """Raised by a stage to skip the rest of a record without failing it.
+
+    Carries the user-facing reason (e.g. a too-short recording with nothing to
+    summarize) so the checklist can render a muted skip instead of a red error.
+    """
+
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
 
 
 @dataclass
@@ -70,6 +84,9 @@ class ChecklistView:
 
     def done(self, stage: Stage, detail: str | None = None) -> None:
         self.statuses[stage] = StageStatus(StageState.DONE, detail)
+
+    def skip(self, stage: Stage, detail: str | None = None) -> None:
+        self.statuses[stage] = StageStatus(StageState.SKIPPED, detail)
 
     def fail(self, stage: Stage, error: str) -> None:
         self.statuses[stage] = StageStatus(StageState.FAILED, error)
@@ -96,6 +113,11 @@ class ChecklistView:
         elif status.state is StageState.RUNNING:
             icon = self._running_spinner
             label = Text(stage.label, style="cyan")
+        elif status.state is StageState.SKIPPED:
+            icon = Text("– ", style="yellow")
+            label = Text(stage.label, style="yellow")
+            if status.detail:
+                label.append(f" · {status.detail}", style="dim")
         elif status.state is StageState.FAILED:
             icon = Text("✗ ", style="red bold")
             label = Text(stage.label, style="red")
@@ -194,9 +216,10 @@ class BatchProcessor:
                 "[yellow]No notes to transcribe. Run `chirp record` first, or "
                 "pass --force to re-run completed notes.[/yellow]"
             )
-            return {"ok": 0, "failed": 0, "total": 0}
+            return {"ok": 0, "skipped": 0, "failed": 0, "total": 0}
 
         ok = 0
+        skipped = 0
         failed = 0
         total = len(records)
         for index, record in enumerate(records, start=1):
@@ -204,9 +227,11 @@ class BatchProcessor:
             view = ChecklistView(header)
             ctx = _PipelineContext(record=record, view=view)
             with Live(view.render(), console=console, refresh_per_second=12) as live:
-                success = self._process_one(ctx, live)
-            if success:
+                status = self._process_one(ctx, live)
+            if status == "ok":
                 ok += 1
+            elif status == "skipped":
+                skipped += 1
             else:
                 failed += 1
 
@@ -214,15 +239,14 @@ class BatchProcessor:
             self.popup_manager.show_transcription_complete(ok)
 
         console.print()
+        parts = [f"[green]{ok} ok[/green]"]
+        if skipped:
+            parts.append(f"[yellow]{skipped} skipped[/yellow]")
         if failed:
-            console.print(
-                f"[bold]done[/bold] · [green]{ok} ok[/green] · "
-                f"[red]{failed} failed[/red]"
-            )
-        else:
-            console.print(f"[bold]done[/bold] · [green]{ok} ok[/green]")
+            parts.append(f"[red]{failed} failed[/red]")
+        console.print("[bold]done[/bold] · " + " · ".join(parts))
 
-        return {"ok": ok, "failed": failed, "total": total}
+        return {"ok": ok, "skipped": skipped, "failed": failed, "total": total}
 
     def _select_queue(self, n: int | None, force: bool) -> list[NoteRecord]:
         records = list_notes(self.settings.directories.notes_root)
@@ -241,7 +265,8 @@ class BatchProcessor:
             return f"{index} of {total} · {title}"
         return title
 
-    def _process_one(self, ctx: _PipelineContext, live: Live) -> bool:
+    def _process_one(self, ctx: _PipelineContext, live: Live) -> str:
+        """Run a record through every stage; return ``"ok"``/``"skipped"``/``"failed"``."""
         steps: list[tuple[Stage, Callable[[_PipelineContext], None]]] = [
             (Stage.LOAD_AUDIO, self._stage_load_audio),
             (Stage.TRANSCRIBE, self._stage_transcribe),
@@ -249,18 +274,24 @@ class BatchProcessor:
             (Stage.INDEX, self._stage_index),
             (Stage.SAVE, self._stage_save),
         ]
-        for stage, runner in steps:
+        for position, (stage, runner) in enumerate(steps):
             ctx.view.start(stage)
             live.update(ctx.view.render())
             try:
                 runner(ctx)
+            except _StageSkipped as skip:
+                ctx.view.skip(stage, skip.detail)
+                for later_stage, _ in steps[position + 1 :]:
+                    ctx.view.skip(later_stage)
+                live.update(ctx.view.render())
+                return "skipped"
             except Exception as exc:  # noqa: BLE001 - pipeline stage; any stage can fail for many reasons
                 logger.debug("Pipeline stage %s failed: %s", stage, exc)
                 ctx.view.fail(stage, str(exc))
                 live.update(ctx.view.render())
-                return False
+                return "failed"
             live.update(ctx.view.render())
-        return True
+        return "ok"
 
     def _stage_load_audio(self, ctx: _PipelineContext) -> None:
         audio = ctx.record.audio
@@ -311,9 +342,13 @@ class BatchProcessor:
         result = NoteGenerator(
             self.settings, console=quiet_console
         ).generate_for_records([refreshed], force=True)
+        if result.get("skipped"):
+            raise _StageSkipped("recording too short to summarize")
         if not result.get("success"):
             raise RuntimeError(result.get("error") or "note generation failed")
-        ctx.view.done(Stage.GENERATE_NOTES, self.settings.models.llm)
+        ctx.view.done(
+            Stage.GENERATE_NOTES, resolved_chat_model(self.settings.models.llm)
+        )
 
     def _stage_index(self, ctx: _PipelineContext) -> None:
         if not self.settings.notes_chat.auto_index:
@@ -340,7 +375,7 @@ class BatchProcessor:
         meta_path = ctx.record.dir / META_FILENAME
         meta = _read_meta(meta_path)
         meta["whisper_model"] = self.settings.models.whisper
-        meta["llm_model"] = self.settings.models.llm
+        meta["llm_model"] = resolved_chat_model(self.settings.models.llm)
         meta["indexed_at"] = datetime.now(UTC).replace(microsecond=0).isoformat()
         if ctx.duration_seconds is not None:
             meta["duration_s"] = round(ctx.duration_seconds, 2)

--- a/transcriber/batch_processor.py
+++ b/transcriber/batch_processor.py
@@ -34,7 +34,7 @@ class Stage(Enum):
     LOAD_AUDIO = ("loaded audio", 0)
     TRANSCRIBE = ("transcribe", 1)
     GENERATE_NOTES = ("generate notes", 2)
-    INDEX = ("index to chromadb", 3)
+    INDEX = ("index notes", 3)
     SAVE = ("save", 4)
 
     def __init__(self, label: str, idx: int) -> None:


### PR DESCRIPTION
## Lexical-first retrieval — Phases 3–5

Completes the "lexical-first retrieval" effort (Phases 1–2 landed in #115/#116/#117). BM25 is the default and only required retriever; semantic (Chroma vector) search is opt-in behind `NotesChatConfig.semantic_enabled` (default `False`). This PR makes embed models invisible/un-addable while off, turns `chirp config --semantic` into a real enable/disable switch, and documents the model.

### Phase 3 — Registry hiding
- `chirp models list` drops embed-role rows (table **and** `--json`) when semantic is off; `--all` overrides; embed shows when semantic is on.
- `chirp models add` rejects embed models (inferred or `--role embed`) with an actionable pointer to `chirp config --semantic` when semantic is off — exit 2, no download, no registry write. Chat adds are unaffected.
- Factored a reusable `register_model()` helper out of `add_command`, shared with the enable flow.

### Phase 4 — `chirp config --semantic` enable/disable flow
- **Enable** registers the recommended embed model (`mlx-community/bge-small-en-v1.5`), verifies chirpd can load it, and **only then** flips `semantic_enabled=True`, saves, and rebuilds the index (`build_index(force=True)`). Any earlier failure stays lexical-only — the flag is flipped last (atomicity).
- **Disable** returns to lexical-only; `--purge` deletes `index_dir/chroma`.
- Renamed dead `NotesChatConfig.emb_model` → `recommended_embed_model = "bge-small-en-v1.5"` (pydantic ignores the stale key, so existing configs load unchanged). Removed the `--embedding-model` setter.
- `config --list` and `chirp about` now show the registry's resolved embed alias; `about` reads `lexical (BM25)` when semantic is off.

### Phase 5 — Docs
- README gains a "How search works" section (BM25 by default, `chirp config --semantic [--no-semantic] [--purge]`) and drops the embed model from manual setup.
- Reframed `.docs/{hybrid-retrieval,embeddings,architecture,chunking,DEVELOPMENT}.md` around lexical-first; documented `_route_query` weighting.

### Review
Ran an adversarial BMAD review (Blind Hunter / Edge Case Hunter / Acceptance Auditor) in a subagent and looped on its findings: fixed two silent-drop edge cases in the `config` command (co-specified scalar setters now apply with the toggle; `--purge` with `--semantic` warns) and added the coverage it flagged. Final verdict: ready to merge.

### Testing
- `make check` clean (ruff, format, codespell, mypy).
- Full suite: **1639 passed**.
- New/updated tests: Phase 3 hiding+gating, Phase 4 enable/disable/atomicity/rename, `resolved_embed_model` units, and `about` label.

https://claude.ai/code/session_01VQJGhfaeZ7uwgeMKYC8PM3
