### PR TITLE
ci: fix sync-version-to-main (ensure labels exist before PR create)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -52,6 +52,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      issues: write
     steps:
       - name: ⤵️ Checkout main
         uses: actions/checkout@v7
@@ -117,6 +118,9 @@ jobs:
           Updates \`pyproject.toml\`'s \`[project].version\` to \`${NORMALIZED_VERSION}\` and regenerates \`uv.lock\` so future PR dev builds derive their version from the latest released base. Without this, PR builds would continue versioning off the previous \`pyproject.toml\`, and PEP 440 ordering could prevent \`pip install --upgrade chirp-notes-ai\` from picking up new releases.
           EOF
           )
+
+          gh label create automation --color ededed --description "Automated maintenance PRs" --force
+          gh label create release-sync --color 0e8a16 --description "Post-release version sync to main" --force
 
           if EXISTING=$(gh pr view "$BRANCH" --json number --jq .number 2>/dev/null); then
             echo "PR #${EXISTING} already exists for ${BRANCH}; updated branch in place."


### PR DESCRIPTION
## Problem

`sync-version-to-main` has been failing at the **📥 Open PR** step:

```
could not add label: 'release-sync' not found
##[error]Process completed with exit code 1.
```

`gh pr create` resolves label names to IDs **before** creating the PR. The repo had only the `automation` label, not `release-sync`, so the call exited 1 — after the branch was already pushed — and **no PR was ever opened**. As a result the `0.0.3-alpha` version sync never reached `main` (it was still `0.0.1a0`).

The previous fix (#111) only addressed the portaudio install step, so the job got *further* but still failed here.

## Fix

- Create both `automation` and `release-sync` labels idempotently with `gh label create --force` right before `gh pr create`, so the workflow self-heals regardless of repo label state.
- Add `issues: write` permission, required by the labels REST API.

## Verification

The exact failing command (`gh pr create --label automation --label release-sync`) was run by hand from the already-pushed sync branch after creating the label — it succeeded and attached both labels: #119 (the recovered `0.0.3-alpha` sync).

https://claude.ai/code/session_01VQJGhfaeZ7uwgeMKYC8PM3