### PR TITLE
fix: use OS trust store for HTTPS (corporate TLS proxies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ Check the daemon with `chirp daemon status` and your registered models with `chi
 **No notes found**
 Run `chirp transcribe` first, or check `chirp config --list` to confirm the notes root you are using.
 
+**Model download fails with `CERTIFICATE_VERIFY_FAILED` / `self-signed certificate in certificate chain`**
+Your network has a TLS-intercepting proxy (common on corporate machines). Chirp verifies downloads against your operating system trust store, which already trusts that proxy's root CA, so this usually resolves itself. If you still hit it, set `CHIRP_DISABLE_TRUSTSTORE=1` to fall back to the bundled CA list, or point `REQUESTS_CA_BUNDLE` and `SSL_CERT_FILE` at your proxy's root CA.
+
 ## Development
 
 Contributor docs live in `AGENTS.md` and `.docs/DEVELOPMENT.md`.

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -28,6 +28,7 @@ from llm.cli.daemon import daemon_app
 from llm.cli.models import app as models_app
 from llm.registry import resolved_chat_model, resolved_embed_model
 from utils.file_utils import NoteRecord, list_notes
+from utils.tls import enable_system_trust_store
 
 logger = logging.getLogger(__name__)
 
@@ -204,6 +205,7 @@ def main(
     """Chirp · AI notes for your terminal."""
     _configure_cli_logging(verbose)
     apply_color_mode(no_color)
+    enable_system_trust_store()
 
 
 def _prompt_title() -> str:

--- a/chirpd/__main__.py
+++ b/chirpd/__main__.py
@@ -27,6 +27,7 @@ from config.settings import (
     resolve_max_resident_embed,
 )
 from llm.registry import read_registry
+from utils.tls import enable_system_trust_store
 
 _logger = logging.getLogger("chirpd")
 
@@ -47,6 +48,7 @@ def main() -> int:
         return 2
 
     configure_logging(to_stderr=sys.stdout.isatty())
+    enable_system_trust_store()
     ensure_runtime_dirs()
 
     socket_path = _resolve_socket_path()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "prompt-toolkit>=3.0.52",
     "numpy>=1.24.0",
     "silero-vad>=5.1",
+    "truststore>=0.10.0",
     "mlx-whisper==0.4.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "mlx-lm==0.31.3; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "mlx-embeddings==0.1.0; sys_platform == 'darwin' and platform_machine == 'arm64'",

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,24 +1,52 @@
+import ssl
+
 import pytest
 import truststore
 
 from utils import tls
 
 
+class _NotInjected:
+    pass
+
+
 @pytest.fixture(autouse=True)
-def _reset_injection_flag():
-    tls._injected = False
-    yield
-    tls._injected = False
+def _baseline_uninjected_ssl(monkeypatch):
+    monkeypatch.setattr(ssl, "SSLContext", _NotInjected, raising=False)
 
 
-def test_injects_into_ssl_once(monkeypatch):
+def test_injects_when_not_already_active(monkeypatch):
     calls = []
     monkeypatch.setattr(truststore, "inject_into_ssl", lambda: calls.append(1))
+
+    tls.enable_system_trust_store()
+
+    assert calls == [1]
+
+
+def test_injection_is_idempotent_across_calls(monkeypatch):
+    calls = []
+
+    def fake_inject():
+        calls.append(1)
+        monkeypatch.setattr(ssl, "SSLContext", truststore.SSLContext)
+
+    monkeypatch.setattr(truststore, "inject_into_ssl", fake_inject)
 
     tls.enable_system_trust_store()
     tls.enable_system_trust_store()
 
     assert calls == [1]
+
+
+def test_skips_when_already_active(monkeypatch):
+    calls = []
+    monkeypatch.setattr(ssl, "SSLContext", truststore.SSLContext)
+    monkeypatch.setattr(truststore, "inject_into_ssl", lambda: calls.append(1))
+
+    tls.enable_system_trust_store()
+
+    assert calls == []
 
 
 def test_opt_out_env_var_skips_injection(monkeypatch):
@@ -38,5 +66,3 @@ def test_injection_failure_does_not_raise(monkeypatch):
     monkeypatch.setattr(truststore, "inject_into_ssl", _boom)
 
     tls.enable_system_trust_store()
-
-    assert tls._injected is False

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,0 +1,42 @@
+import pytest
+import truststore
+
+from utils import tls
+
+
+@pytest.fixture(autouse=True)
+def _reset_injection_flag():
+    tls._injected = False
+    yield
+    tls._injected = False
+
+
+def test_injects_into_ssl_once(monkeypatch):
+    calls = []
+    monkeypatch.setattr(truststore, "inject_into_ssl", lambda: calls.append(1))
+
+    tls.enable_system_trust_store()
+    tls.enable_system_trust_store()
+
+    assert calls == [1]
+
+
+def test_opt_out_env_var_skips_injection(monkeypatch):
+    calls = []
+    monkeypatch.setattr(truststore, "inject_into_ssl", lambda: calls.append(1))
+    monkeypatch.setenv(tls.DISABLE_ENV_VAR, "1")
+
+    tls.enable_system_trust_store()
+
+    assert calls == []
+
+
+def test_injection_failure_does_not_raise(monkeypatch):
+    def _boom():
+        raise RuntimeError("no system trust store")
+
+    monkeypatch.setattr(truststore, "inject_into_ssl", _boom)
+
+    tls.enable_system_trust_store()
+
+    assert tls._injected is False

--- a/utils/tls.py
+++ b/utils/tls.py
@@ -1,0 +1,45 @@
+"""Route HTTPS verification through the operating system trust store.
+
+Corporate machines commonly sit behind a TLS-intercepting proxy whose root CA
+is installed in the system keychain but not in certifi's bundle. huggingface_hub
+(and requests) verify against certifi by default, so model downloads fail with
+``CERTIFICATE_VERIFY_FAILED: self-signed certificate in certificate chain``.
+truststore makes the stdlib ``ssl`` module consult the OS trust store instead,
+which already trusts that proxy CA.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+DISABLE_ENV_VAR = "CHIRP_DISABLE_TRUSTSTORE"
+
+_injected = False
+
+
+def enable_system_trust_store() -> None:
+    """Inject truststore into ``ssl`` so HTTPS uses the OS trust store.
+
+    Idempotent, best-effort, and opt-out via ``CHIRP_DISABLE_TRUSTSTORE``. Any
+    failure leaves the default certifi-backed verification in place rather than
+    breaking startup.
+    """
+    global _injected
+    if _injected or os.environ.get(DISABLE_ENV_VAR):
+        return
+    try:
+        import truststore
+    except ImportError:
+        return
+    try:
+        truststore.inject_into_ssl()
+    except Exception:  # noqa: BLE001 - trust-store setup must never break startup
+        logger.debug(
+            "truststore injection failed; using default certifi bundle",
+            exc_info=True,
+        )
+        return
+    _injected = True

--- a/utils/tls.py
+++ b/utils/tls.py
@@ -12,12 +12,11 @@ from __future__ import annotations
 
 import logging
 import os
+import ssl
 
 logger = logging.getLogger(__name__)
 
 DISABLE_ENV_VAR = "CHIRP_DISABLE_TRUSTSTORE"
-
-_injected = False
 
 
 def enable_system_trust_store() -> None:
@@ -27,12 +26,13 @@ def enable_system_trust_store() -> None:
     failure leaves the default certifi-backed verification in place rather than
     breaking startup.
     """
-    global _injected
-    if _injected or os.environ.get(DISABLE_ENV_VAR):
+    if os.environ.get(DISABLE_ENV_VAR):
         return
     try:
         import truststore
     except ImportError:
+        return
+    if ssl.SSLContext is truststore.SSLContext:
         return
     try:
         truststore.inject_into_ssl()
@@ -41,5 +41,3 @@ def enable_system_trust_store() -> None:
             "truststore injection failed; using default certifi bundle",
             exc_info=True,
         )
-        return
-    _injected = True

--- a/uv.lock
+++ b/uv.lock
@@ -334,6 +334,7 @@ dependencies = [
     { name = "rich" },
     { name = "silero-vad" },
     { name = "tomli-w" },
+    { name = "truststore" },
     { name = "typer" },
 ]
 
@@ -393,6 +394,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "silero-vad", specifier = ">=5.1" },
     { name = "tomli-w", specifier = ">=1.0.0" },
+    { name = "truststore", specifier = ">=0.10.0" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "types-python-dateutil", marker = "extra == 'dev'", specifier = ">=2.8.0" },
 ]
@@ -3346,6 +3348,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

First-time `chirp transcribe` on a corporate MacBook fails to download the Whisper model:

```
Could not download or load the Whisper model 'mlx-community/whisper-large-v3-turbo'.
Underlying error: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed:
self-signed certificate in certificate chain (_ssl.c:1010)
```

Model downloads run through `huggingface_hub` → `requests`, which verify TLS against **certifi's** CA bundle, *not* the macOS keychain. On a machine behind a TLS-intercepting proxy (corporate Zscaler/Netskope, some VPNs/AV), the proxy's root CA is trusted by the OS keychain but absent from certifi — so verification fails. The browser works because macOS trusts that root; Python just never looks there.

The error's hint to change `models.whisper` is a red herring: every model downloads from the same Hub over the same intercepted TLS.

## Fix

Inject [`truststore`](https://truststore.readthedocs.io/) at both TLS-using entry points — the `chirp` CLI callback (`chirp/cli.py`) and the `chirpd` daemon (`chirpd/__main__.py`) — so the stdlib `ssl` module consults the **OS trust store**, which already trusts the proxy CA.

- Single helper `utils/tls.py::enable_system_trust_store()` — idempotent, best-effort, **never blocks startup** on failure.
- Opt-out via `CHIRP_DISABLE_TRUSTSTORE=1` (falls back to certifi).
- `truststore` added as a core dependency (pure-Python; also helps Linux/Windows corporate setups).
- README troubleshooting entry added.

## Verification

On this (non-intercepted) machine — confirms no regression on a normal network:

```
ssl.SSLContext patched: True -> truststore._api.SSLContext
live HTTPS via OS trust store: 200
idempotent second call: ok
```

- New unit tests (`tests/test_tls.py`): injects once, opt-out env skips it, injection failure doesn't raise. 3 passed.
- Slices green: `test_tls` + `test_cli_commands` + `chirpd/` → 213 passed. `ruff` + `mypy` clean.

I cannot reproduce the corporate-proxy case from here, so the real proof is @timmcolby running `chirp transcribe` on the affected MacBook. With the proxy CA in the system keychain (it is — Safari works), this should now succeed with no env vars set.

https://claude.ai/code/session_01VQJGhfaeZ7uwgeMKYC8PM3