### PR TITLE
feat: decode WAVs without ffmpeg, drop the ffmpeg dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Chirp currently targets **macOS 13.0 (Ventura) or later** for audio capture. The
 
 - macOS 13.0+ on **Apple Silicon** (M1/M2/M3/M4 or newer — chirpd runs models on MLX)
 - Python 3.11+
-- Homebrew if you want `chirp init` to install missing macOS dependencies for you
 
 Note generation and retrieval run on-device through the bundled **chirpd** daemon
 (MLX) — no separate model server to install. You register a model once with
@@ -150,7 +149,7 @@ While semantic search is off, embed models stay hidden from `chirp models list` 
 
 ## Setup details
 
-`chirp init` is the recommended setup path. It checks for Apple Silicon, verifies Homebrew, confirms the bundled chirpd daemon is reachable, reports whether a default chat model is registered, and checks the screen-recording permission — then helps install anything missing and offers to start chirpd at login. The bundled `Chirp.app` helper records system audio and microphone directly via ScreenCaptureKit; no virtual audio driver is required.
+`chirp init` is the recommended setup path. It checks for Apple Silicon, confirms the bundled chirpd daemon is reachable, reports whether a default chat model is registered, and checks the screen-recording permission — then helps install anything missing and offers to start chirpd at login. The bundled `Chirp.app` helper records system audio and microphone directly via ScreenCaptureKit; no virtual audio driver is required.
 
 If you prefer to set things up manually on macOS (chirp itself is pip-installed; no extra system packages are required):
 

--- a/README.md
+++ b/README.md
@@ -150,17 +150,11 @@ While semantic search is off, embed models stay hidden from `chirp models list` 
 
 ## Setup details
 
-`chirp init` is the recommended setup path. It checks for Apple Silicon, verifies Homebrew and `ffmpeg`, confirms the bundled chirpd daemon is reachable, reports whether a default chat model is registered, and checks the screen-recording permission — then helps install anything missing and offers to start chirpd at login. The bundled `Chirp.app` helper records system audio and microphone directly via ScreenCaptureKit; no virtual audio driver is required.
+`chirp init` is the recommended setup path. It checks for Apple Silicon, verifies Homebrew, confirms the bundled chirpd daemon is reachable, reports whether a default chat model is registered, and checks the screen-recording permission — then helps install anything missing and offers to start chirpd at login. The bundled `Chirp.app` helper records system audio and microphone directly via ScreenCaptureKit; no virtual audio driver is required.
 
-If you prefer to set things up manually on macOS:
+If you prefer to set things up manually on macOS (chirp itself is pip-installed; no extra system packages are required):
 
-1. Install the only system dependency (chirp itself is pip-installed):
-
-   ```bash
-   brew install ffmpeg
-   ```
-
-2. Register a chat model (downloaded to the local HF cache, served on-device by chirpd):
+1. Register a chat model (downloaded to the local HF cache, served on-device by chirpd):
 
    ```bash
    # Chat — strong quality (~4.3 GB)
@@ -175,7 +169,7 @@ If you prefer to set things up manually on macOS:
    chirp config --semantic
    ```
 
-3. Re-check your environment:
+2. Re-check your environment:
 
    ```bash
    chirp init --recheck

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -4,15 +4,14 @@ Gate: require Apple Silicon. Everything downstream (the bundled
 chirpd daemon, MLX inference) is arm64-only, so a non-arm64 machine fails
 fast with exit code 7 before any other work.
 
-Verify: check homebrew, daemon readiness (via `llm.client`'s
-health handshake, which lazy-spawns chirpd), the registered default chat
-model (via `llm.registry`), and the screen-recording permission. Print a
-check table and ask whether to install what's missing.
+Verify: check daemon readiness (via `llm.client`'s health handshake, which
+lazy-spawns chirpd), the registered default chat model (via `llm.registry`),
+and the screen-recording permission. Print a check table and ask whether to
+install what's missing.
 
-Install: install missing dependencies via Homebrew (macOS only) and rebuild
-the capture_audio helper when needed. The daemon is part of the pip package
-and is never "installed" here; model registration is the user's own
-`chirp models add` step.
+Install: rebuild the capture_audio helper when needed (macOS only). The daemon
+is part of the pip package and is never "installed" here; model registration
+is the user's own `chirp models add` step.
 
 Finalize: create the config/chroma/notes directories and print the "your nest
 is ready" panel.
@@ -94,18 +93,6 @@ def require_apple_silicon(console: Console) -> int | None:
         "Python under Rosetta — install an arm64 Python and reinstall chirp.[/dim]"
     )
     return EXIT_NOT_APPLE_SILICON
-
-
-def _brew_installed() -> DependencyStatus:
-    path = _which("brew")
-    if path:
-        return DependencyStatus("homebrew", True, path)
-    return DependencyStatus(
-        "homebrew",
-        False,
-        "not found — install from https://brew.sh",
-        required=platform.system() == "Darwin",
-    )
 
 
 def _daemon_ready() -> DependencyStatus:
@@ -220,7 +207,6 @@ def verify(settings: ChirpSettings, console: Console) -> list[DependencyStatus]:
     console.print()
 
     statuses = [
-        _brew_installed(),
         _daemon_ready(),
         _default_chat_registered(),
         _screen_recording_permission(),
@@ -281,12 +267,11 @@ def _confirm(console: Console, prompt: str, default: bool = True) -> bool:
 
 
 def install_missing(console: Console, statuses: list[DependencyStatus]) -> bool:
-    """Install what's missing via Homebrew.
+    """Rebuild the capture_audio helper when it's missing.
 
     Returns True when every actionable task succeeded. Returns False on
-    non-macOS hosts, when Homebrew itself is missing, when a brew/build task
-    fails, or when manual user action remains (denied screen-recording
-    permission, a daemon that won't start)."""
+    non-macOS hosts, when a build task fails, or when manual user action
+    remains (denied screen-recording permission, a daemon that won't start)."""
     if platform.system() != "Darwin":
         console.print(
             " [yellow]automatic install is macOS-only.[/yellow] "
@@ -294,15 +279,6 @@ def install_missing(console: Console, statuses: list[DependencyStatus]) -> bool:
         )
         return False
 
-    brew = _which("brew")
-    if not brew:
-        console.print(
-            " [red]homebrew not found[/red] — install from https://brew.sh, then re-run."
-        )
-        return False
-
-    console.print()
-    console.print(" [dim]installing dependencies via homebrew...[/dim]")
     console.print()
 
     user_action_required = False

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -4,7 +4,7 @@ Gate: require Apple Silicon. Everything downstream (the bundled
 chirpd daemon, MLX inference) is arm64-only, so a non-arm64 machine fails
 fast with exit code 7 before any other work.
 
-Verify: check homebrew, ffmpeg, daemon readiness (via `llm.client`'s
+Verify: check homebrew, daemon readiness (via `llm.client`'s
 health handshake, which lazy-spawns chirpd), the registered default chat
 model (via `llm.registry`), and the screen-recording permission. Print a
 check table and ask whether to install what's missing.
@@ -106,24 +106,6 @@ def _brew_installed() -> DependencyStatus:
         "not found — install from https://brew.sh",
         required=platform.system() == "Darwin",
     )
-
-
-def _ffmpeg_installed() -> DependencyStatus:
-    path = _which("ffmpeg")
-    if not path:
-        return DependencyStatus("ffmpeg", False, "not found")
-    code, out = _run([path, "-version"])
-    if code != 0:
-        return DependencyStatus(
-            "ffmpeg",
-            False,
-            f"found at {path} but `ffmpeg -version` failed — try `brew reinstall ffmpeg`",
-        )
-    detail = path
-    first_line = out.splitlines()[0] if out else ""
-    if first_line.startswith("ffmpeg version"):
-        detail = first_line.split()[2]
-    return DependencyStatus("ffmpeg", True, detail)
 
 
 def _daemon_ready() -> DependencyStatus:
@@ -239,7 +221,6 @@ def verify(settings: ChirpSettings, console: Console) -> list[DependencyStatus]:
 
     statuses = [
         _brew_installed(),
-        _ffmpeg_installed(),
         _daemon_ready(),
         _default_chat_registered(),
         _screen_recording_permission(),
@@ -335,8 +316,6 @@ def install_missing(console: Console, statuses: list[DependencyStatus]) -> bool:
             console.print(f" [red]✗[/red] the daemon failed to start — {status.detail}")
             console.print("   run [bold]chirp daemon logs[/bold] for details.")
             user_action_required = True
-        elif status.name == "ffmpeg":
-            tasks.append(("ffmpeg", [brew, "install", "ffmpeg"]))
         elif status.name == "screen recording permission" and status.detail.startswith(
             "denied"
         ):

--- a/tests/test_audio_loader.py
+++ b/tests/test_audio_loader.py
@@ -1,0 +1,84 @@
+import wave
+
+import numpy as np
+import pytest
+
+from transcriber.audio_loader import (
+    TARGET_SAMPLE_RATE,
+    UnsupportedAudioError,
+    load_audio,
+)
+
+
+def _write_wav(path, samples_int16, *, channels=1, rate=TARGET_SAMPLE_RATE, width=2):
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(channels)
+        wav.setsampwidth(width)
+        wav.setframerate(rate)
+        wav.writeframes(samples_int16.astype("<i2").tobytes())
+
+
+def test_loads_16k_mono_pcm_as_normalized_float32(tmp_path):
+    path = tmp_path / "mono.wav"
+    samples = np.array([0, 16384, -16384, 32767, -32768], dtype=np.int16)
+    _write_wav(path, samples)
+
+    audio = load_audio(path)
+
+    assert audio.dtype == np.float32
+    np.testing.assert_allclose(audio, samples.astype(np.float32) / 32768.0, atol=1e-7)
+
+
+def test_downmixes_stereo_to_mono(tmp_path):
+    path = tmp_path / "stereo.wav"
+    interleaved = np.array([1000, 3000, -2000, 2000], dtype=np.int16)
+    _write_wav(path, interleaved, channels=2)
+
+    audio = load_audio(path)
+
+    expected = np.array([2000.0, 0.0], dtype=np.float32) / 32768.0
+    assert len(audio) == 2
+    np.testing.assert_allclose(audio, expected, atol=1e-7)
+
+
+def test_resamples_to_target_rate(tmp_path):
+    path = tmp_path / "8k.wav"
+    samples = np.zeros(800, dtype=np.int16)
+    _write_wav(path, samples, rate=8000)
+
+    audio = load_audio(path)
+
+    assert len(audio) == 1600
+
+
+def test_eight_bit_pcm_is_centered(tmp_path):
+    path = tmp_path / "8bit.wav"
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(1)
+        wav.setframerate(TARGET_SAMPLE_RATE)
+        wav.writeframes(bytes([128, 255, 0]))
+
+    audio = load_audio(path)
+
+    np.testing.assert_allclose(audio, [0.0, 127 / 128, -1.0], atol=1e-7)
+
+
+def test_rejects_non_wav(tmp_path):
+    path = tmp_path / "fake.mp3"
+    path.write_bytes(b"ID3\x04\x00not really audio")
+
+    with pytest.raises(UnsupportedAudioError):
+        load_audio(path)
+
+
+def test_rejects_unsupported_sample_width(tmp_path):
+    path = tmp_path / "24bit.wav"
+    with wave.open(str(path), "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(3)
+        wav.setframerate(TARGET_SAMPLE_RATE)
+        wav.writeframes(b"\x00\x00\x00\x01\x00\x00")
+
+    with pytest.raises(UnsupportedAudioError):
+        load_audio(path)

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -1,6 +1,6 @@
 """Unit tests for the chirp init flow.
 
-The external pieces (homebrew, the chirpd daemon, the model registry, audio
+The external pieces (the chirpd daemon, the model registry, audio
 permission probes, subprocess calls) are mocked out so the tests stay fast,
 platform-agnostic, and never spawn a real daemon or write a real models.toml.
 """
@@ -55,11 +55,6 @@ def _stub_verify_deps(monkeypatch, registry=None, arm64=True):
         init_flow.platform, "machine", lambda: "arm64" if arm64 else "x86_64"
     )
     monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
-    monkeypatch.setattr(
-        init_flow,
-        "_brew_installed",
-        lambda: init_flow.DependencyStatus("homebrew", True, "/usr/bin/brew"),
-    )
     _stub_healthy_daemon(monkeypatch)
     monkeypatch.setattr(
         "llm.registry.read_registry",
@@ -90,7 +85,7 @@ def test_run_init_fails_fast_on_intel(tmp_path, monkeypatch):
     output = console.file.getvalue()
     assert "Apple Silicon" in output
     assert "x86_64" in output
-    assert "homebrew" not in output  # no verify table printed
+    assert "checking what you've already got" not in output  # no verify table printed
     assert health_calls == []  # daemon never lazy-spawned
     assert not settings.directories.notes_root.exists()  # no filesystem mutation
     assert not settings.notes_chat.index_dir.exists()
@@ -111,7 +106,6 @@ def test_run_init_apple_silicon_passes_through(tmp_path, monkeypatch):
     assert code == 0
     output = console.file.getvalue()
     assert "checking what you've already got" in output
-    assert "homebrew" in output
 
 
 # --- verify() rows (AC-2, AC-3, AC-4) ----------------------------------------
@@ -125,18 +119,17 @@ def test_verify_includes_daemon_and_registry_rows_no_ollama(tmp_path, monkeypatc
 
     names = [s.name for s in statuses]
     assert names == [
-        "homebrew",
         "chirpd",
         "default chat model",
         "screen recording permission",
     ]
     assert not any(n == "Ollama" or n.startswith("model:") for n in names)
 
-    chirpd = statuses[1]
+    chirpd = statuses[0]
     assert chirpd.installed is True
     assert chirpd.detail == "healthy · v0.1.0"
 
-    chat = statuses[2]
+    chat = statuses[1]
     assert chat.installed is True
     assert chat.detail == "default chat: gemma-4-4b-it-4bit"
 
@@ -308,7 +301,7 @@ def test_install_missing_surfaces_daemon_failure_without_installing(monkeypatch)
     result = init_flow.install_missing(console, statuses)
 
     assert result is False
-    assert run_calls == []  # nothing brew-installable for the daemon
+    assert run_calls == []  # nothing installable for the daemon
     output = console.file.getvalue()
     assert "chirp daemon logs" in output
 
@@ -407,7 +400,11 @@ def test_run_init_phases_run_in_order(tmp_path, monkeypatch):
         "verify",
         lambda settings, console: (
             calls.append("verify")
-            or [init_flow.DependencyStatus("homebrew", False, "missing")]
+            or [
+                init_flow.DependencyStatus(
+                    "screen recording permission", False, "missing"
+                )
+            ]
         ),
     )
     monkeypatch.setattr(init_flow, "_confirm", lambda *args, **kwargs: True)
@@ -645,17 +642,6 @@ def test_run_returns_127_on_missing_binary():
     assert out
 
 
-def test_brew_missing_is_required_on_darwin(monkeypatch):
-    monkeypatch.setattr(init_flow, "_which", lambda _cmd: None)
-    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
-
-    status = init_flow._brew_installed()
-
-    assert status.installed is False
-    assert status.required is True
-    assert "brew.sh" in status.detail
-
-
 def test_confirm_answers(monkeypatch):
     console = _console()
 
@@ -677,12 +663,6 @@ def test_confirm_answers(monkeypatch):
 
 def test_install_missing_is_macos_only(monkeypatch):
     monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
-    assert init_flow.install_missing(_console(), []) is False
-
-
-def test_install_missing_requires_brew(monkeypatch):
-    monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
-    monkeypatch.setattr(init_flow, "_which", lambda _cmd: None)
     assert init_flow.install_missing(_console(), []) is False
 
 
@@ -761,7 +741,9 @@ def test_run_init_user_declines_install(tmp_path, monkeypatch):
         init_flow,
         "verify",
         lambda settings, console: [
-            init_flow.DependencyStatus("homebrew", False, "not found")
+            init_flow.DependencyStatus(
+                "screen recording permission", False, "not found"
+            )
         ],
     )
     monkeypatch.setattr(init_flow, "_confirm", lambda *a, **k: False)

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -5,6 +5,7 @@ permission probes, subprocess calls) are mocked out so the tests stay fast,
 platform-agnostic, and never spawn a real daemon or write a real models.toml.
 """
 
+import sys
 from io import StringIO
 
 from rich.console import Console
@@ -58,11 +59,6 @@ def _stub_verify_deps(monkeypatch, registry=None, arm64=True):
         init_flow,
         "_brew_installed",
         lambda: init_flow.DependencyStatus("homebrew", True, "/usr/bin/brew"),
-    )
-    monkeypatch.setattr(
-        init_flow,
-        "_ffmpeg_installed",
-        lambda: init_flow.DependencyStatus("ffmpeg", True, "7.1.1"),
     )
     _stub_healthy_daemon(monkeypatch)
     monkeypatch.setattr(
@@ -130,18 +126,17 @@ def test_verify_includes_daemon_and_registry_rows_no_ollama(tmp_path, monkeypatc
     names = [s.name for s in statuses]
     assert names == [
         "homebrew",
-        "ffmpeg",
         "chirpd",
         "default chat model",
         "screen recording permission",
     ]
     assert not any(n == "Ollama" or n.startswith("model:") for n in names)
 
-    chirpd = statuses[2]
+    chirpd = statuses[1]
     assert chirpd.installed is True
     assert chirpd.detail == "healthy · v0.1.0"
 
-    chat = statuses[3]
+    chat = statuses[2]
     assert chat.installed is True
     assert chat.detail == "default chat: gemma-4-4b-it-4bit"
 
@@ -661,23 +656,6 @@ def test_brew_missing_is_required_on_darwin(monkeypatch):
     assert "brew.sh" in status.detail
 
 
-def test_ffmpeg_version_parsed_from_output(monkeypatch):
-    monkeypatch.setattr(init_flow, "_which", lambda _cmd: "/usr/bin/ffmpeg")
-    monkeypatch.setattr(
-        init_flow, "_run", lambda args, timeout=10.0: (0, "ffmpeg version 7.1.1 etc\n")
-    )
-
-    status = init_flow._ffmpeg_installed()
-
-    assert status.installed is True
-    assert status.detail == "7.1.1"
-
-
-def test_ffmpeg_missing(monkeypatch):
-    monkeypatch.setattr(init_flow, "_which", lambda _cmd: None)
-    assert init_flow._ffmpeg_installed().installed is False
-
-
 def test_confirm_answers(monkeypatch):
     console = _console()
 
@@ -708,7 +686,7 @@ def test_install_missing_requires_brew(monkeypatch):
     assert init_flow.install_missing(_console(), []) is False
 
 
-def test_install_missing_brew_installs_ffmpeg(monkeypatch):
+def test_install_missing_rebuilds_capture_audio(monkeypatch):
     monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
 
@@ -719,19 +697,27 @@ def test_install_missing_brew_installs_ffmpeg(monkeypatch):
         lambda args, timeout=10.0: run_calls.append(list(args)) or (0, ""),
     )
 
-    statuses = [init_flow.DependencyStatus("ffmpeg", False, "not found")]
+    statuses = [
+        init_flow.DependencyStatus(
+            "screen recording permission", False, "binary not built"
+        )
+    ]
     assert init_flow.install_missing(_console(), statuses) is True
-    assert run_calls == [["/usr/bin/brew", "install", "ffmpeg"]]
+    assert run_calls == [[sys.executable, "-m", "audio_capture.build"]]
 
 
-def test_install_missing_surfaces_brew_failure(monkeypatch):
+def test_install_missing_surfaces_task_failure(monkeypatch):
     monkeypatch.setattr(init_flow.platform, "system", lambda: "Darwin")
     monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
     monkeypatch.setattr(
         init_flow, "_run", lambda args, timeout=10.0: (1, "Error: install exploded")
     )
 
-    statuses = [init_flow.DependencyStatus("ffmpeg", False, "not found")]
+    statuses = [
+        init_flow.DependencyStatus(
+            "screen recording permission", False, "binary not built"
+        )
+    ]
     console = _console()
     assert init_flow.install_missing(console, statuses) is False
     assert "install exploded" in console.file.getvalue()
@@ -775,7 +761,7 @@ def test_run_init_user_declines_install(tmp_path, monkeypatch):
         init_flow,
         "verify",
         lambda settings, console: [
-            init_flow.DependencyStatus("ffmpeg", False, "not found")
+            init_flow.DependencyStatus("homebrew", False, "not found")
         ],
     )
     monkeypatch.setattr(init_flow, "_confirm", lambda *a, **k: False)
@@ -1214,18 +1200,6 @@ def test_merge_config_replaces_non_table_section_value(tmp_path):
         merged = tomllib.load(fh)
     assert merged["init"] == {"flag": True}
     assert merged["user_custom"] == {"theme": "midnight"}
-
-
-def test_ffmpeg_on_path_but_broken_reports_not_installed(monkeypatch):
-    monkeypatch.setattr(init_flow, "_which", lambda _cmd: "/usr/bin/ffmpeg")
-    monkeypatch.setattr(
-        init_flow, "_run", lambda args, timeout=10.0: (1, "dyld: library missing")
-    )
-
-    status = init_flow._ffmpeg_installed()
-
-    assert status.installed is False
-    assert "brew reinstall ffmpeg" in status.detail
 
 
 def test_cli_init_gates_before_loading_settings(monkeypatch):

--- a/tests/test_whisper_transcriber.py
+++ b/tests/test_whisper_transcriber.py
@@ -11,13 +11,14 @@ from transcriber.whisper_transcriber import (
 )
 
 MLX_IMPORT = "transcriber.whisper_transcriber._import_mlx_whisper"
+LOAD_AUDIO_IMPORT = "transcriber.whisper_transcriber.load_audio"
+_FAKE_AUDIO_SAMPLES = 80000
 
 
-def _make_mlx_module(*, segments=None, language="en", audio_len=80000):
+def _make_mlx_module(*, segments=None, language="en"):
     """Build a stand-in for the lazily-imported mlx_whisper module."""
     module = Mock()
     module.load_models.load_model.return_value = Mock(name="whisper_model")
-    module.audio.load_audio.return_value = np.zeros(audio_len, dtype=np.float32)
     module.transcribe.return_value = {
         "text": "".join(s.get("text", "") for s in (segments or [])),
         "language": language,
@@ -27,6 +28,14 @@ def _make_mlx_module(*, segments=None, language="en", audio_len=80000):
 
 
 class TestWhisperTranscriber:
+    @pytest.fixture(autouse=True)
+    def _stub_load_audio(self):
+        with patch(
+            LOAD_AUDIO_IMPORT,
+            return_value=np.zeros(_FAKE_AUDIO_SAMPLES, dtype=np.float32),
+        ):
+            yield
+
     @pytest.fixture
     def mock_settings(self):
         settings = Mock(spec=ChirpSettings)

--- a/transcriber/audio_loader.py
+++ b/transcriber/audio_loader.py
@@ -1,0 +1,68 @@
+"""Decode WAV audio to whisper's input format without the ffmpeg CLI.
+
+mlx-whisper's own ``load_audio`` shells out to the ``ffmpeg`` binary even for a
+plain PCM WAV. Chirp records 16 kHz mono 16-bit PCM — already whisper's target
+format — so the common path is a direct ``wave`` read with no resampling. Stereo
+or off-rate WAVs (e.g. imported via ``transcribe --regen``) are downmixed and
+resampled with scipy. Non-WAV containers are rejected with a clear message
+rather than dragging the whole codec surface back in.
+"""
+
+from __future__ import annotations
+
+import wave
+from math import gcd
+from pathlib import Path
+
+import numpy as np
+
+TARGET_SAMPLE_RATE = 16000
+
+
+class UnsupportedAudioError(ValueError):
+    pass
+
+
+def load_audio(path: Path) -> np.ndarray:
+    try:
+        with wave.open(str(path), "rb") as wav:
+            n_channels = wav.getnchannels()
+            sample_width = wav.getsampwidth()
+            frame_rate = wav.getframerate()
+            frames = wav.readframes(wav.getnframes())
+    except (wave.Error, EOFError) as exc:
+        raise UnsupportedAudioError(
+            f"{path} is not a readable PCM WAV file ({exc}). Convert it to WAV "
+            "(16 kHz mono is ideal) before transcribing."
+        ) from exc
+
+    samples = _pcm_to_float32(frames, sample_width)
+    if n_channels > 1:
+        samples = samples.reshape(-1, n_channels).mean(axis=1)
+    if frame_rate != TARGET_SAMPLE_RATE:
+        samples = _resample(samples, frame_rate, TARGET_SAMPLE_RATE)
+    return np.ascontiguousarray(samples, dtype=np.float32)
+
+
+def _pcm_to_float32(frames: bytes, sample_width: int) -> np.ndarray:
+    if sample_width == 1:
+        data = np.frombuffer(frames, dtype=np.uint8).astype(np.float32)
+        return (data - 128.0) / 128.0
+    if sample_width == 2:
+        data = np.frombuffer(frames, dtype=np.int16).astype(np.float32)
+        return data / 32768.0
+    if sample_width == 4:
+        data = np.frombuffer(frames, dtype=np.int32).astype(np.float32)
+        return data / 2147483648.0
+    raise UnsupportedAudioError(
+        f"unsupported WAV sample width: {sample_width * 8}-bit. "
+        "Convert to 16-bit PCM WAV before transcribing."
+    )
+
+
+def _resample(samples: np.ndarray, src_rate: int, dst_rate: int) -> np.ndarray:
+    from scipy.signal import resample_poly
+
+    divisor = gcd(src_rate, dst_rate)
+    resampled = resample_poly(samples, dst_rate // divisor, src_rate // divisor)
+    return np.asarray(resampled, dtype=np.float32)

--- a/transcriber/whisper_transcriber.py
+++ b/transcriber/whisper_transcriber.py
@@ -9,6 +9,7 @@ from typing import Any
 from chirp.exceptions import WhisperModelLoadError
 from config.settings import ChirpSettings
 from notes.constants import DEFAULT_MEETING_NAME
+from transcriber.audio_loader import load_audio
 from utils.file_utils import META_FILENAME, get_file_size_mb
 from utils.time_utils import derive_recording_id, parse_timestamp_from_filename
 
@@ -37,7 +38,6 @@ def _import_mlx_whisper():
     # Imported lazily: mlx-whisper only installs on macOS arm64, so a top-level
     # import would break imports/tests on every other platform.
     import mlx_whisper
-    import mlx_whisper.audio
     import mlx_whisper.load_models
 
     return mlx_whisper
@@ -106,7 +106,7 @@ class WhisperTranscriber:
             hallucination_silence_threshold = 2.0
 
         try:
-            audio = mlx_whisper.audio.load_audio(str(audio_file_path))
+            audio = load_audio(audio_file_path)
             duration = len(audio) / SAMPLE_RATE
 
             # mlx-whisper has no built-in VAD. We feed silero-detected speech


### PR DESCRIPTION
## Why

mlx-whisper's `load_audio` shells out to the **ffmpeg CLI** even for a plain PCM WAV. But chirp records exclusively **16 kHz mono 16-bit PCM** (`audio_recorder.py`, `live_audio.py`) — already whisper's exact input format. So ffmpeg was decoding audio into the format it was *already in*, while adding a large C media-parsing surface to the trust boundary for zero functional gain. (Context: this came out of a question about ffmpeg's security footprint — the real issue isn't that ffmpeg is exploitable here, it's that the simplest dependency is the one you don't have.)

## What

- **New `transcriber/audio_loader.py`** — a `wave` + `numpy` reader replacing `mlx_whisper.audio.load_audio`. Returns mono float32 @ 16 kHz with the **same `/32768.0` normalization** mlx-whisper used (bit-for-bit parity on the common path). `scipy` (already a dependency) handles downmix + resample only for the rare stereo/off-rate WAV from `transcribe --regen`. Non-WAV containers (mp3/m4a) are rejected with a clear *"convert to WAV"* message rather than dragging the codec surface back in.
- **`chirp init`** no longer checks for or installs ffmpeg.
- **Docs** — removed `brew install ffmpeg`; chirp needs no extra system packages now.

mlx-whisper's `transcribe` accepts `np.ndarray` directly (verified against its type signature), so this is a drop-in for the downstream call.

## Verification

- **End to end with `ffmpeg` stripped from `PATH`**: a recorded 16 kHz WAV decodes correctly (`float32`, right length, normalized range), `shutil.which("ffmpeg") is None`.
- New `tests/test_audio_loader.py`: normalization, stereo downmix, resample, 8-bit centering, non-WAV rejection, unsupported-width rejection.
- Updated transcriber/init tests for the new path.
- **Full suite: 1657 passed**; `ruff`, `ruff format`, and configured `mypy` (74 source files) all clean.

## One open decision (deliberately out of scope)

Homebrew's *only* `chirp init` install task was ffmpeg. With it gone, the brew check is likely **vestigial** (the remaining `capture_audio` rebuild uses `python -m audio_capture.build`, not brew). I left the brew check in place rather than expand this PR — happy to remove it (code + docs + tests) as a follow-up if you want.

https://claude.ai/code/session_01VQJGhfaeZ7uwgeMKYC8PM3