### PR TITLE
fix: note-generation resilience + first-run model install & daemon freshness

### DIFF
--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -130,13 +130,10 @@ def _daemon_ready() -> DependencyStatus:
 
 
 def _restart_daemon_if_stale(console: Console) -> None:
-    """Restart a resident daemon left running old code after a chirp upgrade.
+    """Restart a daemon left running stale code after a chirp upgrade.
 
-    The hello handshake keeps a warm daemon across cosmetic package bumps (only
-    PROTOCOL_VERSION forces a respawn), so `pip install -U` can leave an old
-    daemon serving stale code and reporting the old version. init is a setup
-    touchpoint where dropping the warm model is acceptable, so heal the skew
-    here; `chirp daemon status` and the verify table only warn.
+    A warm daemon survives cosmetic version bumps (the hello handshake only
+    respawns on PROTOCOL_VERSION), so init heals the skew; status/verify warn.
     """
     from llm.client import LLMClient, resolve_socket_path
     from llm.exceptions import LLMError
@@ -849,8 +846,6 @@ _CHAT_MODEL_CHOICES = {"1": RECOMMENDED_CHAT_REPO, "2": SMALLER_CHAT_REPO}
 
 
 def _print_models_add_hint(console: Console) -> None:
-    """Point at the manual `chirp models add` path — the fallback when init
-    can't run the interactive picker (non-TTY) or only verified (`--recheck`)."""
     console.print(
         f"  next step: [bold]chirp models add {RECOMMENDED_CHAT_REPO}[/bold]"
         " [dim](~4.3 GB, strong quality)[/dim]"

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -28,6 +28,7 @@ import platform
 import shutil
 import subprocess
 import sys
+import time
 import tomllib
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -104,6 +105,7 @@ def _daemon_ready() -> DependencyStatus:
     """
     from llm.client import LLMClient
     from llm.exceptions import LLMDaemonSpawnFailed, LLMTransportError
+    from llm.protocol import package_version
 
     try:
         payload = LLMClient().health_sync()
@@ -116,7 +118,65 @@ def _daemon_ready() -> DependencyStatus:
     except LLMTransportError as exc:
         return DependencyStatus("chirpd", False, f"daemon unreachable: {exc}")
     version = payload.get("version", "unknown")
+    installed = package_version()
+    if version not in ("unknown", installed):
+        return DependencyStatus(
+            "chirpd",
+            True,
+            f"healthy · v{version} — running old version, "
+            f"restart to update to v{installed}",
+        )
     return DependencyStatus("chirpd", True, f"healthy · v{version}")
+
+
+def _restart_daemon_if_stale(console: Console) -> None:
+    """Restart a resident daemon left running old code after a chirp upgrade.
+
+    The hello handshake keeps a warm daemon across cosmetic package bumps (only
+    PROTOCOL_VERSION forces a respawn), so `pip install -U` can leave an old
+    daemon serving stale code and reporting the old version. init is a setup
+    touchpoint where dropping the warm model is acceptable, so heal the skew
+    here; `chirp daemon status` and the verify table only warn.
+    """
+    from llm.client import LLMClient, resolve_socket_path
+    from llm.exceptions import LLMError
+    from llm.protocol import package_version
+
+    installed = package_version()
+    try:
+        running = LLMClient().health_sync().get("version")
+    except LLMError:
+        return
+    if not running or running == installed:
+        return
+
+    console.print()
+    console.print(
+        f" [yellow]![/yellow] daemon is running v{running}, but v{installed} is "
+        "installed — restarting to load the new version..."
+    )
+    from llm.cli.daemon import _RESTART_SETTLE_S, _attempt_start, _attempt_stop
+
+    socket_path = resolve_socket_path()
+    stop_result = _attempt_stop(socket_path)
+    if not stop_result["ok"]:
+        console.print(
+            " [red]✗[/red] couldn't stop the old daemon — run "
+            "[bold]chirp daemon restart[/bold] to finish updating."
+        )
+        return
+    if stop_result["was_running"]:
+        time.sleep(_RESTART_SETTLE_S)
+    start_result = _attempt_start(socket_path)
+    if start_result["ok"]:
+        console.print(
+            f" [green]{glyphs.SUCCESS}[/green] daemon restarted · v{installed}"
+        )
+    else:
+        console.print(
+            " [red]✗[/red] daemon stopped but didn't restart — run "
+            "[bold]chirp daemon restart[/bold] to finish updating."
+        )
 
 
 def _default_chat_registered() -> DependencyStatus:
@@ -218,20 +278,11 @@ def verify(settings: ChirpSettings, console: Console) -> list[DependencyStatus]:
     console.print()
     missing_deps = [s for s in statuses if s.required and not s.installed]
     chat_row = next(s for s in statuses if s.name == "default chat model")
-    if missing_deps or not chat_row.installed:
-        console.print(" [dim]──────────────────────────────────────────────[/dim]")
     if missing_deps:
+        console.print(" [dim]──────────────────────────────────────────────[/dim]")
         plural = "s" if len(missing_deps) > 1 else ""
         console.print(
             f"  need to install: [bold]{len(missing_deps)} piece{plural}[/bold]"
-        )
-    if not chat_row.installed:
-        console.print(
-            f"  next step: [bold]chirp models add {RECOMMENDED_CHAT_REPO}[/bold]"
-            " [dim](~4.3 GB, strong quality)[/dim]"
-        )
-        console.print(
-            f"  [dim]smaller alternative: chirp models add {SMALLER_CHAT_REPO}[/dim]"
         )
     if not missing_deps and chat_row.installed:
         console.print(" [green]everything's already in place.[/green]")
@@ -797,6 +848,18 @@ def _setup_chat_model(console: Console, hf_repo: str) -> bool:
 _CHAT_MODEL_CHOICES = {"1": RECOMMENDED_CHAT_REPO, "2": SMALLER_CHAT_REPO}
 
 
+def _print_models_add_hint(console: Console) -> None:
+    """Point at the manual `chirp models add` path — the fallback when init
+    can't run the interactive picker (non-TTY) or only verified (`--recheck`)."""
+    console.print(
+        f"  next step: [bold]chirp models add {RECOMMENDED_CHAT_REPO}[/bold]"
+        " [dim](~4.3 GB, strong quality)[/dim]"
+    )
+    console.print(
+        f"  [dim]smaller alternative: chirp models add {SMALLER_CHAT_REPO}[/dim]"
+    )
+
+
 def _offer_chat_model_setup(console: Console) -> None:
     """Prompt to register a default chat model when none exists (TTY only)."""
     console.print()
@@ -840,6 +903,10 @@ def _ensure_chat_model_ready(console: Console) -> None:
         _ensure_default_chat_ready(console)
     elif _is_interactive():
         _offer_chat_model_setup(console)
+    else:
+        console.print()
+        console.print(" [bold]a chat model is needed[/bold] — notes and `ask` use one.")
+        _print_models_add_hint(console)
 
 
 def offer_first_run_setup(settings: ChirpSettings, console: Console) -> int | None:
@@ -893,10 +960,17 @@ def run_init(
         # --recheck is the migration touchpoint (Devon's journey); full init
         # is the fresh-setup flow and stays free of migration noise.
         detection = _detect_ollama_install()
-        if any(detection.values()):
+        show_migration = any(detection.values())
+        chat_row = next(s for s in statuses if s.name == "default chat model")
+        if not chat_row.installed and not show_migration:
+            console.print()
+            _print_models_add_hint(console)
+        if show_migration:
             _print_migration_plan(console, detection)
         _offer_launch_agent(settings, console, force_prompt=True)
         return 0
+
+    _restart_daemon_if_stale(console)
 
     missing = [s for s in statuses if s.required and not s.installed]
     if missing:

--- a/config/settings.py
+++ b/config/settings.py
@@ -129,9 +129,6 @@ class ModelsConfig(BaseModel):
     whisper: str = "large-v3-turbo"
     llm: str = "llama3.1:8b"
     num_predict: int = 4096
-    # Chat-model context window in tokens. Sizes how much transcript fits in a
-    # single-shot notes prompt (alongside the prompt and the reserved
-    # num_predict output). Lower it for a smaller-context model.
     context_window: int = 32768
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -129,6 +129,10 @@ class ModelsConfig(BaseModel):
     whisper: str = "large-v3-turbo"
     llm: str = "llama3.1:8b"
     num_predict: int = 4096
+    # Chat-model context window in tokens. Sizes how much transcript fits in a
+    # single-shot notes prompt (alongside the prompt and the reserved
+    # num_predict output). Lower it for a smaller-context model.
+    context_window: int = 32768
 
 
 class VadParameters(BaseModel):

--- a/llm/cli/daemon.py
+++ b/llm/cli/daemon.py
@@ -68,7 +68,7 @@ from config.settings import CHIRP_DAEMON_SOCKET_ENV
 from llm.cli._console import console, stdout_console
 from llm.client import LLMClient, resolve_socket_path
 from llm.exceptions import LLMDaemonUnreachable, LLMError
-from llm.protocol import new_request_id
+from llm.protocol import new_request_id, package_version
 
 daemon_app = typer.Typer(help="Daemon lifecycle and diagnostics", no_args_is_help=True)
 
@@ -156,6 +156,17 @@ def status(
                 markup=False,
                 soft_wrap=True,
             )
+        else:
+            installed = package_version()
+            running_version = payload.get("version")
+            if running_version and running_version != installed:
+                console.print(
+                    f"daemon is running v{running_version}, but v{installed} is "
+                    "installed — run: chirp daemon restart",
+                    style="yellow",
+                    markup=False,
+                    soft_wrap=True,
+                )
 
     if use_json:
         _render_status_json(payload, sys.stdout)

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -20,19 +20,9 @@ from utils.popup_manager import PopupManager
 
 logger = logging.getLogger(__name__)
 
-# Conservative average chars-per-token for English prose. Used only to size the
-# transcript against the model's token-denominated context window; deliberately
-# below the real ~4 so the assembled prompt lands *under* the window rather than
-# overflowing (which would silently drop the transcript tail and the trailing
-# output instruction).
+# Below the real ~4 so the assembled prompt lands under the context window, not over.
 _CHARS_PER_TOKEN = 3.5
-
-# Literal non-transcript, non-SYSTEM_PROMPT scaffolding in the note prompt (the
-# "Transcript:" framing and the trailing "Return ONLY..." line).
 _PROMPT_SCAFFOLD_CHARS = 200
-
-# Floor so a misconfigured tiny context_window still lets a short meeting
-# through instead of collapsing the budget to zero.
 _MIN_TRANSCRIPT_BUDGET_CHARS = 4000
 
 # Below this, a transcript has nothing to summarize (a silent/near-empty clip);
@@ -433,14 +423,7 @@ class NoteGenerator:
         return str(value)
 
     def _transcript_char_budget(self, title_instruction: str) -> int:
-        """Chars of transcript that fit the model context alongside the prompt
-        and the reserved output.
-
-        Derived from settings (``context_window`` minus ``num_predict`` minus the
-        prompt scaffolding) so a smaller-context model or a raised output cap
-        scales the input down automatically — versus a fixed constant that
-        silently truncated long meetings well short of what the window allows.
-        """
+        """Chars of transcript that fit alongside the prompt and reserved output."""
         models = self.settings.models
         scaffold_tokens = int(
             (len(SYSTEM_PROMPT) + len(title_instruction) + _PROMPT_SCAFFOLD_CHARS)
@@ -454,12 +437,6 @@ class NoteGenerator:
         )
 
     def _window_transcript(self, transcript_text: str, max_chars: int) -> str:
-        """Cap the transcript to ``max_chars``, warning that the tail is dropped.
-
-        Head-truncation is the interim behavior for meetings that still overflow
-        a full context window; chunked (map-reduce) summarization of the whole
-        transcript is the planned follow-up.
-        """
         if len(transcript_text) <= max_chars:
             return transcript_text
         self.console.print(
@@ -612,25 +589,17 @@ Return ONLY the XML document, no additional text before or after."""
             }
 
         except ET.ParseError:
-            # LLMs routinely emit XML that isn't well-formed — an unescaped `&`
-            # (Q&A, R&D, P&L), a stray `<`/`>` ("revenue < target"), or output
-            # truncated at the token cap before `</MEETING_NOTES>`. A single bad
-            # character otherwise loses the whole note. Recover the known tags
-            # directly instead. Only reached after the strict parse fails, so
-            # well-formed output — and the quality-regression baseline — is
-            # untouched.
+            # Reached only after the strict parse fails, so well-formed output
+            # (and the quality-regression baseline) is untouched.
             return self._extract_notes_lenient(xml_content)
         except (AttributeError, KeyError, TypeError, ValueError):
             return None
 
     def _extract_notes_lenient(self, xml_content: str) -> dict[str, Any] | None:
-        """Recover note fields from XML that ``ET.fromstring`` rejected.
+        """String-scan the known tags from XML that ``ET.fromstring`` rejected.
 
-        String-scans for each known tag rather than parsing a well-formed tree,
-        so unescaped entities and stray angle brackets in the text survive and a
-        truncated tail still yields whatever earlier tags completed. Returns
-        ``None`` when nothing usable is found so the caller still degrades rather
-        than writing an empty shell.
+        Returns ``None`` when nothing usable is found so the caller still
+        degrades rather than writing an empty shell.
         """
 
         def _inner(tag: str) -> str | None:

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import tomllib
 import wave
 import xml.etree.ElementTree as ET
@@ -19,9 +20,20 @@ from utils.popup_manager import PopupManager
 
 logger = logging.getLogger(__name__)
 
-# Bounds the prompt INPUT, not just num_predict (the OUTPUT): an unbounded
-# transcript was silently truncated mid-generation, so window it and warn.
-MAX_TRANSCRIPT_CHARS = 24000
+# Conservative average chars-per-token for English prose. Used only to size the
+# transcript against the model's token-denominated context window; deliberately
+# below the real ~4 so the assembled prompt lands *under* the window rather than
+# overflowing (which would silently drop the transcript tail and the trailing
+# output instruction).
+_CHARS_PER_TOKEN = 3.5
+
+# Literal non-transcript, non-SYSTEM_PROMPT scaffolding in the note prompt (the
+# "Transcript:" framing and the trailing "Return ONLY..." line).
+_PROMPT_SCAFFOLD_CHARS = 200
+
+# Floor so a misconfigured tiny context_window still lets a short meeting
+# through instead of collapsing the budget to zero.
+_MIN_TRANSCRIPT_BUDGET_CHARS = 4000
 
 # Below this, a transcript has nothing to summarize (a silent/near-empty clip);
 # generating notes would only yield junk that later poisons `ask`. Callers treat
@@ -420,15 +432,42 @@ class NoteGenerator:
             return value.isoformat()
         return str(value)
 
-    def _window_transcript(self, transcript_text: str) -> str:
-        """Cap the transcript to ``MAX_TRANSCRIPT_CHARS``, warning on truncation."""
-        if len(transcript_text) <= MAX_TRANSCRIPT_CHARS:
+    def _transcript_char_budget(self, title_instruction: str) -> int:
+        """Chars of transcript that fit the model context alongside the prompt
+        and the reserved output.
+
+        Derived from settings (``context_window`` minus ``num_predict`` minus the
+        prompt scaffolding) so a smaller-context model or a raised output cap
+        scales the input down automatically — versus a fixed constant that
+        silently truncated long meetings well short of what the window allows.
+        """
+        models = self.settings.models
+        scaffold_tokens = int(
+            (len(SYSTEM_PROMPT) + len(title_instruction) + _PROMPT_SCAFFOLD_CHARS)
+            / _CHARS_PER_TOKEN
+        )
+        input_token_budget = (
+            models.context_window - models.num_predict - scaffold_tokens
+        )
+        return max(
+            int(input_token_budget * _CHARS_PER_TOKEN), _MIN_TRANSCRIPT_BUDGET_CHARS
+        )
+
+    def _window_transcript(self, transcript_text: str, max_chars: int) -> str:
+        """Cap the transcript to ``max_chars``, warning that the tail is dropped.
+
+        Head-truncation is the interim behavior for meetings that still overflow
+        a full context window; chunked (map-reduce) summarization of the whole
+        transcript is the planned follow-up.
+        """
+        if len(transcript_text) <= max_chars:
             return transcript_text
         self.console.print(
-            f"[yellow]Transcript is {len(transcript_text)} chars; truncating to "
-            f"{MAX_TRANSCRIPT_CHARS} for note generation.[/yellow]"
+            f"[yellow]Transcript is {len(transcript_text)} chars; summarizing the "
+            f"first {max_chars} — the tail isn't included yet (chunked "
+            "summarization of long meetings is coming).[/yellow]"
         )
-        return transcript_text[:MAX_TRANSCRIPT_CHARS]
+        return transcript_text[:max_chars]
 
     def _generate_structured_notes(
         self, transcript_text: str, provided_title: str | None = None
@@ -440,7 +479,8 @@ class NoteGenerator:
                 f"MEETING_TITLE tag: {provided_title}"
             )
 
-        windowed_transcript = self._window_transcript(transcript_text)
+        max_chars = self._transcript_char_budget(title_instruction)
+        windowed_transcript = self._window_transcript(transcript_text, max_chars)
         prompt = f"""{SYSTEM_PROMPT}
 
 {title_instruction}
@@ -572,10 +612,94 @@ Return ONLY the XML document, no additional text before or after."""
             }
 
         except ET.ParseError:
-            # Malformed XML: let the caller retry/degrade, never write it (AC-12).
-            return None
+            # LLMs routinely emit XML that isn't well-formed — an unescaped `&`
+            # (Q&A, R&D, P&L), a stray `<`/`>` ("revenue < target"), or output
+            # truncated at the token cap before `</MEETING_NOTES>`. A single bad
+            # character otherwise loses the whole note. Recover the known tags
+            # directly instead. Only reached after the strict parse fails, so
+            # well-formed output — and the quality-regression baseline — is
+            # untouched.
+            return self._extract_notes_lenient(xml_content)
         except (AttributeError, KeyError, TypeError, ValueError):
             return None
+
+    def _extract_notes_lenient(self, xml_content: str) -> dict[str, Any] | None:
+        """Recover note fields from XML that ``ET.fromstring`` rejected.
+
+        String-scans for each known tag rather than parsing a well-formed tree,
+        so unescaped entities and stray angle brackets in the text survive and a
+        truncated tail still yields whatever earlier tags completed. Returns
+        ``None`` when nothing usable is found so the caller still degrades rather
+        than writing an empty shell.
+        """
+
+        def _inner(tag: str) -> str | None:
+            match = re.search(
+                rf"<{tag}\b[^>]*>(.*?)</{tag}>", xml_content, re.DOTALL | re.IGNORECASE
+            )
+            return match.group(1) if match else None
+
+        def _text(tag: str) -> str:
+            inner = _inner(tag)
+            if inner is None:
+                return ""
+            value = inner.strip()
+            return "" if value.lower() == "none" else value
+
+        def _items(tag: str) -> list[str]:
+            inner = _inner(tag)
+            if inner is None or inner.strip().lower() == "none":
+                return []
+            items: list[str] = []
+            for match in re.finditer(
+                r"<ITEM\b([^>]*?)/?>(.*?)(?:</ITEM>|(?=<ITEM\b)|(?=</)|$)",
+                inner,
+                re.DOTALL | re.IGNORECASE,
+            ):
+                if tag == "ACTION_ITEMS":
+                    attrs = dict(re.findall(r'(\w+)\s*=\s*"([^"]*)"', match.group(1)))
+                    parts = []
+                    if attrs.get("task", "").strip():
+                        parts.append(attrs["task"].strip())
+                    if attrs.get("owner", "").strip():
+                        parts.append(f"Owner: {attrs['owner'].strip()}")
+                    if attrs.get("deadline", "").strip():
+                        parts.append(f"Deadline: {attrs['deadline'].strip()}")
+                    if parts:
+                        items.append(" — ".join(parts))
+                else:
+                    text = match.group(2).strip()
+                    if text:
+                        items.append(text)
+            return items
+
+        title = _text("MEETING_TITLE")
+        summary = _text("EXECUTIVE_SUMMARY")
+        lists = {
+            name: _items(name)
+            for name in (
+                "AGENDA",
+                "ACTION_ITEMS",
+                "NEXT_STEPS",
+                "DECISIONS",
+                "OPEN_QUESTIONS",
+                "DISCUSSION_HIGHLIGHTS",
+            )
+        }
+        if not title and not summary and not any(lists.values()):
+            return None
+
+        logger.info("Recovered notes from malformed model XML via lenient parse")
+        return {
+            "meeting_title": title or DEFAULT_MEETING_NAME,
+            "executive_summary": summary or "No summary available",
+            "agenda": lists["AGENDA"],
+            "action_items": lists["ACTION_ITEMS"],
+            "next_steps": lists["NEXT_STEPS"],
+            "decisions": lists["DECISIONS"],
+            "open_questions": lists["OPEN_QUESTIONS"],
+            "discussion_highlights": lists["DISCUSSION_HIGHLIGHTS"],
+        }
 
     def _auto_index_note(self, notes_path: Path):
         if not self.settings.notes_chat.auto_index:

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import re
 import tomllib
 import wave
@@ -425,16 +426,20 @@ class NoteGenerator:
     def _transcript_char_budget(self, title_instruction: str) -> int:
         """Chars of transcript that fit alongside the prompt and reserved output."""
         models = self.settings.models
-        scaffold_tokens = int(
+        # ceil (not floor) so under-reserving the prompt can't push the budget
+        # over the window.
+        scaffold_tokens = math.ceil(
             (len(SYSTEM_PROMPT) + len(title_instruction) + _PROMPT_SCAFFOLD_CHARS)
             / _CHARS_PER_TOKEN
         )
         input_token_budget = (
             models.context_window - models.num_predict - scaffold_tokens
         )
-        return max(
-            int(input_token_budget * _CHARS_PER_TOKEN), _MIN_TRANSCRIPT_BUDGET_CHARS
-        )
+        if input_token_budget <= 0:
+            # num_predict left no room for input — misconfigured; a floor beats
+            # sending an empty transcript.
+            return _MIN_TRANSCRIPT_BUDGET_CHARS
+        return int(input_token_budget * _CHARS_PER_TOKEN)
 
     def _window_transcript(self, transcript_text: str, max_chars: int) -> str:
         if len(transcript_text) <= max_chars:

--- a/tests/llm/test_cli_daemon.py
+++ b/tests/llm/test_cli_daemon.py
@@ -242,6 +242,45 @@ def test_status_notes_version_mismatch_resolved(
     assert "started a new instance" not in result.stderr
 
 
+def test_status_warns_when_daemon_version_is_stale(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _mock_client(monkeypatch)  # health payload reports v0.7.0
+    monkeypatch.setattr(daemon_module, "package_version", lambda: "0.9.0")
+
+    result = runner.invoke(daemon_module.daemon_app, ["status"])
+
+    assert result.exit_code == 0
+    assert "running v0.7.0" in result.stderr
+    assert "v0.9.0 is installed" in result.stderr
+    assert "chirp daemon restart" in result.stderr
+
+
+def test_status_no_stale_warning_when_versions_match(
+    monkeypatch: pytest.MonkeyPatch, force_tty: None
+) -> None:
+    _mock_client(monkeypatch)  # health payload reports v0.7.0
+    monkeypatch.setattr(daemon_module, "package_version", lambda: "0.7.0")
+
+    result = runner.invoke(daemon_module.daemon_app, ["status"])
+
+    assert result.exit_code == 0
+    assert "chirp daemon restart" not in result.stderr
+
+
+def test_status_suppresses_stale_warning_in_json_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_client(monkeypatch)  # health payload reports v0.7.0
+    monkeypatch.setattr(daemon_module, "package_version", lambda: "0.9.0")
+
+    result = runner.invoke(daemon_module.daemon_app, ["status", "--json"])
+
+    assert result.exit_code == 0
+    assert "chirp daemon restart" not in result.stderr
+    assert json.loads(result.stdout)["version"] == "0.7.0"
+
+
 # --- formatters -------------------------------------------------------------
 
 

--- a/tests/llm/test_cli_daemon.py
+++ b/tests/llm/test_cli_daemon.py
@@ -245,7 +245,7 @@ def test_status_notes_version_mismatch_resolved(
 def test_status_warns_when_daemon_version_is_stale(
     monkeypatch: pytest.MonkeyPatch, force_tty: None
 ) -> None:
-    _mock_client(monkeypatch)  # health payload reports v0.7.0
+    _mock_client(monkeypatch)
     monkeypatch.setattr(daemon_module, "package_version", lambda: "0.9.0")
 
     result = runner.invoke(daemon_module.daemon_app, ["status"])
@@ -259,7 +259,7 @@ def test_status_warns_when_daemon_version_is_stale(
 def test_status_no_stale_warning_when_versions_match(
     monkeypatch: pytest.MonkeyPatch, force_tty: None
 ) -> None:
-    _mock_client(monkeypatch)  # health payload reports v0.7.0
+    _mock_client(monkeypatch)
     monkeypatch.setattr(daemon_module, "package_version", lambda: "0.7.0")
 
     result = runner.invoke(daemon_module.daemon_app, ["status"])
@@ -271,7 +271,7 @@ def test_status_no_stale_warning_when_versions_match(
 def test_status_suppresses_stale_warning_in_json_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _mock_client(monkeypatch)  # health payload reports v0.7.0
+    _mock_client(monkeypatch)
     monkeypatch.setattr(daemon_module, "package_version", lambda: "0.9.0")
 
     result = runner.invoke(daemon_module.daemon_app, ["status", "--json"])

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -47,6 +47,7 @@ def _stub_healthy_daemon(monkeypatch):
         "llm.client.LLMClient.health_sync",
         lambda self, **kwargs: {"event": "ready", "status": "ok", "version": "0.1.0"},
     )
+    monkeypatch.setattr("llm.protocol.package_version", lambda: "0.1.0")
 
 
 def _stub_verify_deps(monkeypatch, registry=None, arm64=True):
@@ -57,6 +58,7 @@ def _stub_verify_deps(monkeypatch, registry=None, arm64=True):
     monkeypatch.setattr(init_flow, "_which", lambda cmd: f"/usr/bin/{cmd}")
     _stub_healthy_daemon(monkeypatch)
     monkeypatch.setattr(init_flow, "_ensure_chat_model_ready", lambda console: None)
+    monkeypatch.setattr(init_flow, "_restart_daemon_if_stale", lambda console: None)
     monkeypatch.setattr(
         "llm.registry.read_registry",
         lambda path=None: (
@@ -181,6 +183,20 @@ def test_verify_handles_empty_registry(tmp_path, monkeypatch):
     assert f"chirp models add {init_flow.RECOMMENDED_CHAT_REPO}" in chat.detail
 
 
+def test_verify_omits_manual_models_add_hint(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch, registry=_empty_registry())
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+
+    console = _console()
+    statuses = init_flow.verify(_fake_settings(tmp_path), console)
+
+    output = console.file.getvalue()
+    assert "next step:" not in output
+    assert "smaller alternative" not in output
+    chat = next(s for s in statuses if s.name == "default chat model")
+    assert chat.installed is False
+
+
 def test_verify_handles_missing_registry_file(tmp_path, monkeypatch):
     _stub_verify_deps(monkeypatch)
     monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
@@ -198,9 +214,131 @@ def test_verify_handles_missing_registry_file(tmp_path, monkeypatch):
     assert "chirp models add" in chat.detail
 
 
-def test_run_init_prints_models_add_hint_when_registry_empty(tmp_path, monkeypatch):
-    _stub_verify_deps(monkeypatch, registry=_empty_registry())
+def test_verify_flags_stale_daemon_version(tmp_path, monkeypatch):
+    _stub_verify_deps(monkeypatch)
     monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        "llm.client.LLMClient.health_sync", lambda self, **kw: {"version": "0.0.1a0"}
+    )
+    monkeypatch.setattr("llm.protocol.package_version", lambda: "0.0.4a0")
+
+    statuses = init_flow.verify(_fake_settings(tmp_path), _console())
+
+    chirpd = next(s for s in statuses if s.name == "chirpd")
+    assert chirpd.installed is True
+    assert "running old version" in chirpd.detail
+    assert "0.0.4a0" in chirpd.detail
+
+
+def _stub_restart(
+    monkeypatch,
+    *,
+    running_version,
+    installed="0.0.4a0",
+    stop_ok=True,
+    was_running=True,
+    start_ok=True,
+):
+    monkeypatch.setattr(
+        "llm.client.LLMClient.health_sync",
+        lambda self, **kw: {"version": running_version},
+    )
+    monkeypatch.setattr("llm.protocol.package_version", lambda: installed)
+    monkeypatch.setattr("llm.client.resolve_socket_path", lambda: "/tmp/chirpd.sock")
+    monkeypatch.setattr(init_flow.time, "sleep", lambda *_: None)
+    calls = {"stop": [], "start": []}
+    monkeypatch.setattr(
+        "llm.cli.daemon._attempt_stop",
+        lambda p: (
+            calls["stop"].append(p)
+            or {
+                "ok": stop_ok,
+                "was_running": was_running,
+                "pid": 111,
+                "killed": False,
+                "running": False,
+                "error": None if stop_ok else {"code": "X", "message": "stuck"},
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "llm.cli.daemon._attempt_start",
+        lambda p: (
+            calls["start"].append(p)
+            or {
+                "ok": start_ok,
+                "pid": 222,
+                "spawned": True,
+                "already": False,
+                "error": None if start_ok else {"code": "Y", "message": "no start"},
+            }
+        ),
+    )
+    return calls
+
+
+def test_restart_daemon_if_stale_restarts_when_version_differs(monkeypatch):
+    calls = _stub_restart(monkeypatch, running_version="0.0.1a0")
+    console = _console()
+
+    init_flow._restart_daemon_if_stale(console)
+
+    assert calls["stop"]
+    assert calls["start"]
+    output = console.file.getvalue()
+    assert "0.0.1a0" in output
+    assert "restarted" in output
+    assert "0.0.4a0" in output
+
+
+def test_restart_daemon_if_stale_noop_when_versions_match(monkeypatch):
+    calls = _stub_restart(monkeypatch, running_version="0.0.4a0")
+    console = _console()
+
+    init_flow._restart_daemon_if_stale(console)
+
+    assert calls["stop"] == []
+    assert calls["start"] == []
+    assert console.file.getvalue() == ""
+
+
+def test_restart_daemon_if_stale_noop_when_daemon_unreachable(monkeypatch):
+    from llm.exceptions import LLMDaemonUnreachable
+
+    def _unreachable(self, **kw):
+        raise LLMDaemonUnreachable("no socket")
+
+    monkeypatch.setattr("llm.client.LLMClient.health_sync", _unreachable)
+    monkeypatch.setattr("llm.protocol.package_version", lambda: "0.0.4a0")
+    touched = []
+    monkeypatch.setattr("llm.cli.daemon._attempt_stop", lambda p: touched.append(p))
+
+    console = _console()
+    init_flow._restart_daemon_if_stale(console)
+
+    assert touched == []
+    assert console.file.getvalue() == ""
+
+
+def test_restart_daemon_if_stale_reports_stop_failure(monkeypatch):
+    _stub_restart(monkeypatch, running_version="0.0.1a0", stop_ok=False)
+    console = _console()
+
+    init_flow._restart_daemon_if_stale(console)
+
+    output = console.file.getvalue()
+    assert "chirp daemon restart" in output
+
+
+def test_run_init_prints_models_add_hint_when_registry_empty(tmp_path, monkeypatch):
+    monkeypatch.setattr(init_flow.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(init_flow.platform, "system", lambda: "Linux")
+    _stub_healthy_daemon(monkeypatch)
+    monkeypatch.setattr(
+        "llm.registry.read_registry", lambda path=None: _empty_registry()
+    )
+    monkeypatch.setattr(init_flow, "_is_interactive", lambda: False)
+    monkeypatch.setattr(init_flow, "_restart_daemon_if_stale", lambda console: None)
     monkeypatch.setattr(
         init_flow.ChirpSettings,
         "get_config_path",
@@ -409,6 +547,7 @@ def test_run_init_phases_run_in_order(tmp_path, monkeypatch):
         ),
     )
     monkeypatch.setattr(init_flow, "_confirm", lambda *args, **kwargs: True)
+    monkeypatch.setattr(init_flow, "_restart_daemon_if_stale", lambda console: None)
     monkeypatch.setattr(
         init_flow,
         "install_missing",
@@ -748,6 +887,7 @@ def test_run_init_user_declines_install(tmp_path, monkeypatch):
         ],
     )
     monkeypatch.setattr(init_flow, "_confirm", lambda *a, **k: False)
+    monkeypatch.setattr(init_flow, "_restart_daemon_if_stale", lambda console: None)
 
     console = _console()
     code = init_flow.run_init(_fake_settings(tmp_path), console)
@@ -1430,6 +1570,28 @@ def test_ensure_chat_model_ready_offers_when_unregistered(monkeypatch):
     init_flow._ensure_chat_model_ready(_console())
 
     assert called == ["offer"]
+
+
+def test_ensure_chat_model_ready_hints_when_noninteractive(monkeypatch):
+    monkeypatch.setattr(
+        "llm.registry.read_registry", lambda path=None: _empty_registry()
+    )
+    monkeypatch.setattr(init_flow, "_is_interactive", lambda: False)
+    called = []
+    monkeypatch.setattr(
+        init_flow, "_ensure_default_chat_ready", lambda console: called.append("warm")
+    )
+    monkeypatch.setattr(
+        init_flow, "_offer_chat_model_setup", lambda console: called.append("offer")
+    )
+
+    console = _console()
+    init_flow._ensure_chat_model_ready(console)
+
+    assert called == []
+    assert (
+        f"chirp models add {init_flow.RECOMMENDED_CHAT_REPO}" in console.file.getvalue()
+    )
 
 
 def test_offer_first_run_noninteractive_proceeds(monkeypatch, tmp_path):

--- a/tests/test_note_generator.py
+++ b/tests/test_note_generator.py
@@ -442,6 +442,21 @@ class TestNoteGenerator:
         assert big > small
         assert big > 24000
 
+    def test_transcript_char_budget_floors_when_no_input_room(self, mock_settings):
+        """num_predict >= context leaves no input room — fall back to the floor,
+        not an inflated budget that would overflow the window."""
+        from notes.note_generator import _MIN_TRANSCRIPT_BUDGET_CHARS
+
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+            mock_settings.models.context_window = 4096
+            mock_settings.models.num_predict = 4096
+
+            assert generator._transcript_char_budget("") == _MIN_TRANSCRIPT_BUDGET_CHARS
+
     def test_whole_transcript_used_single_shot_when_it_fits(self, mock_settings):
         """A transcript within budget is sent verbatim — no truncation, no warning."""
         with (

--- a/tests/test_note_generator.py
+++ b/tests/test_note_generator.py
@@ -160,7 +160,7 @@ class TestNoteGenerator:
             import xml.etree.ElementTree as ET
 
             with pytest.raises(ET.ParseError):
-                ET.fromstring(xml_response)  # confirm the strict parser rejects it
+                ET.fromstring(xml_response)
 
             result = generator._parse_xml_response(xml_response)
 
@@ -440,7 +440,7 @@ class TestNoteGenerator:
             small = generator._transcript_char_budget("")
 
         assert big > small
-        assert big > 24000  # the old fixed cap; a 32k model now fits far more
+        assert big > 24000
 
     def test_whole_transcript_used_single_shot_when_it_fits(self, mock_settings):
         """A transcript within budget is sent verbatim — no truncation, no warning."""
@@ -450,7 +450,7 @@ class TestNoteGenerator:
         ):
             console = Mock()
             generator = NoteGenerator(mock_settings, console=console)
-            transcript = "We discussed the quarterly roadmap. " * 500  # ~18k chars
+            transcript = "We discussed the quarterly roadmap. " * 500
 
             with (
                 patch.object(generator, "_call_llm", return_value="") as mock_llm,
@@ -464,7 +464,7 @@ class TestNoteGenerator:
 
             sent_prompt = mock_llm.call_args.args[0]
 
-        assert transcript in sent_prompt  # whole transcript, not head-truncated
+        assert transcript in sent_prompt
         assert not any(
             "summarizing the first" in str(call.args[0]).lower()
             for call in console.print.call_args_list
@@ -479,7 +479,7 @@ class TestNoteGenerator:
             console = Mock()
             generator = NoteGenerator(mock_settings, console=console)
             budget = generator._transcript_char_budget("")
-            long_transcript = "word " * ((budget // 5) + 1000)  # comfortably over
+            long_transcript = "word " * ((budget // 5) + 1000)
 
             with (
                 patch.object(generator, "_call_llm", return_value=None) as mock_llm,

--- a/tests/test_note_generator.py
+++ b/tests/test_note_generator.py
@@ -16,6 +16,7 @@ def mock_settings():
     models.llm = "llama3.1:8b"
     models.whisper = "large-v3-turbo"
     models.num_predict = 4096
+    models.context_window = 32768
     settings.models = models
     settings.notes_chat = Mock()
     settings.notes_chat.auto_index = False
@@ -138,6 +139,65 @@ class TestNoteGenerator:
             assert result["decisions"] == []
             assert result["open_questions"] == []
             assert len(result["discussion_highlights"]) == 1
+
+    def test_parse_recovers_from_unescaped_special_chars(self, mock_settings):
+        """Unescaped `&`/`<` break ET, but the known tags are still recovered."""
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+
+            xml_response = (
+                "<MEETING_NOTES>"
+                "<MEETING_TITLE>Q&A / R&D sync</MEETING_TITLE>"
+                "<EXECUTIVE_SUMMARY>Revenue < target; P&L reviewed</EXECUTIVE_SUMMARY>"
+                "<AGENDA><ITEM>Discuss P&L</ITEM></AGENDA>"
+                '<ACTION_ITEMS><ITEM task="Fix Q&A doc" owner="Jo" deadline="Fri"/>'
+                "</ACTION_ITEMS>"
+                "</MEETING_NOTES>"
+            )
+            import xml.etree.ElementTree as ET
+
+            with pytest.raises(ET.ParseError):
+                ET.fromstring(xml_response)  # confirm the strict parser rejects it
+
+            result = generator._parse_xml_response(xml_response)
+
+        assert result is not None
+        assert result["meeting_title"] == "Q&A / R&D sync"
+        assert result["executive_summary"] == "Revenue < target; P&L reviewed"
+        assert result["agenda"] == ["Discuss P&L"]
+        assert result["action_items"] == ["Fix Q&A doc — Owner: Jo — Deadline: Fri"]
+
+    def test_parse_recovers_truncated_output(self, mock_settings):
+        """Output cut off at the token cap still yields the completed tags."""
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+            truncated = (
+                "<MEETING_NOTES><MEETING_TITLE>Planning</MEETING_TITLE>"
+                "<EXECUTIVE_SUMMARY>We discussed the road"
+            )
+
+            result = generator._parse_xml_response(truncated)
+
+        assert result is not None
+        assert result["meeting_title"] == "Planning"
+
+    def test_parse_returns_none_when_nothing_recoverable(self, mock_settings):
+        """A marker with no usable tags still degrades — no empty shell note."""
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
+
+            result = generator._parse_xml_response("<MEETING_NOTES>&&& < > junk")
+
+        assert result is None
 
     def test_generate_for_record_writes_notes_and_updates_meta(
         self, mock_settings, tmp_path
@@ -366,17 +426,60 @@ class TestNoteGenerator:
         assert not (record.dir / "notes.md").exists()
         mock_index.assert_not_called()
 
-    def test_long_transcript_is_windowed_with_warning(self, mock_settings):
-        """A transcript past the cap is windowed (not silently truncated) (AC-11)."""
-        from notes.note_generator import MAX_TRANSCRIPT_CHARS
+    def test_transcript_char_budget_scales_with_context_window(self, mock_settings):
+        """The transcript budget tracks context_window (not a fixed constant)."""
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            generator = NoteGenerator(mock_settings)
 
+            mock_settings.models.context_window = 32768
+            big = generator._transcript_char_budget("")
+            mock_settings.models.context_window = 8192
+            small = generator._transcript_char_budget("")
+
+        assert big > small
+        assert big > 24000  # the old fixed cap; a 32k model now fits far more
+
+    def test_whole_transcript_used_single_shot_when_it_fits(self, mock_settings):
+        """A transcript within budget is sent verbatim — no truncation, no warning."""
         with (
             patch("notes.note_generator.TemplateEngine"),
             patch("notes.note_generator.PopupManager"),
         ):
             console = Mock()
             generator = NoteGenerator(mock_settings, console=console)
-            long_transcript = "word " * (MAX_TRANSCRIPT_CHARS)  # well over the cap
+            transcript = "We discussed the quarterly roadmap. " * 500  # ~18k chars
+
+            with (
+                patch.object(generator, "_call_llm", return_value="") as mock_llm,
+                patch.object(
+                    generator,
+                    "_parse_xml_response",
+                    return_value={"meeting_title": "T"},
+                ),
+            ):
+                generator._generate_structured_notes(transcript)
+
+            sent_prompt = mock_llm.call_args.args[0]
+
+        assert transcript in sent_prompt  # whole transcript, not head-truncated
+        assert not any(
+            "summarizing the first" in str(call.args[0]).lower()
+            for call in console.print.call_args_list
+        )
+
+    def test_long_transcript_is_windowed_with_warning(self, mock_settings):
+        """A transcript past the (dynamic) budget is windowed, not silently cut."""
+        with (
+            patch("notes.note_generator.TemplateEngine"),
+            patch("notes.note_generator.PopupManager"),
+        ):
+            console = Mock()
+            generator = NoteGenerator(mock_settings, console=console)
+            budget = generator._transcript_char_budget("")
+            long_transcript = "word " * ((budget // 5) + 1000)  # comfortably over
 
             with (
                 patch.object(generator, "_call_llm", return_value=None) as mock_llm,
@@ -390,9 +493,10 @@ class TestNoteGenerator:
 
             sent_prompt = mock_llm.call_args.args[0]
 
+        assert len(long_transcript) > budget
         assert len(sent_prompt) < len(long_transcript)
         warned = any(
-            "truncating" in str(call.args[0]).lower()
+            "summarizing the first" in str(call.args[0]).lower()
             for call in console.print.call_args_list
         )
         assert warned

--- a/tests/test_note_generator_llm_call.py
+++ b/tests/test_note_generator_llm_call.py
@@ -25,6 +25,7 @@ def mock_settings():
     models.llm = "default_chat"
     models.whisper = "large-v3-turbo"
     models.num_predict = 4096
+    models.context_window = 32768
     settings.models = models
     return settings
 


### PR DESCRIPTION
Four fixes found while working through the `transcribe` / first-run experience. Grouped into two commits (first-run/daemon, notes).

## Notes generation
- **Resilient XML parsing.** The model is asked for a `<MEETING_NOTES>` XML doc parsed with strict `ET.fromstring`; an unescaped `&` (Q&A, R&D), a stray `<`/`>`, or output truncated at the token cap raised `ParseError` → the whole note was discarded ("Could not parse structured notes"). A lenient tag-scan now recovers the known fields, but **only after the strict parse fails**, so well-formed output and the quality-regression baseline are byte-for-byte unchanged. Genuinely empty output still degrades (no junk note written/indexed).
- **Context-aware transcript budget (Phase 1).** Replaced the fixed `MAX_TRANSCRIPT_CHARS = 24000` head-truncation with a budget derived from `context_window − num_predict − prompt scaffolding`. A 32k model now summarizes ~96k chars (~2h) single-shot vs the old ~30–40 min; smaller-context models scale down automatically. New tunable `[models] context_window` (default 32768). Overflow still head-truncates, now with a clearer warning pointing at the follow-up.

## First-run / daemon
- **Model install is now the primary path.** The `1. recommended / 2. smaller / 3. skip` picker existed but only fired in an interactive TTY and was drowned out by a manual `chirp models add` hint in `verify()`. `verify()` is now a pure status report; the picker owns the call-to-action; non-interactive runs print one clear hint.
- **Stale-daemon detection.** The `hello` handshake keeps a warm daemon across cosmetic version bumps, so a `pip install -U` could leave the daemon running old code and reporting the old version. `chirp init` now restarts a stale daemon; `chirp daemon status` and the verify table warn about the skew (init restarts, elsewhere warns).

## Testing
- New/updated unit tests for all four changes (lenient recovery, budget scaling, single-shot fit, stale-daemon restart/warn, model-install messaging).
- Full `make check` clean; pre-commit (ruff, mypy, codespell, pytest) green on both commits.

## Follow-up (separate PR)
**Phase 2** — chunked / map-reduce summarization of the *whole* transcript for meetings that exceed a single context window (speaker/segment-aware packing → parallel structured extraction → consolidating reduce), based on the research writeup.

https://claude.ai/code/session_01VQJGhfaeZ7uwgeMKYC8PM3