### PR TITLE
Production hardening: atomic user-data writes, pinned model revisions, CI gates

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -43,10 +43,6 @@ jobs:
 
   publish-to-test-pypi:
     needs: build-and-test
-    # Opt-in via the `publish-testpypi` PR label instead of every push:
-    # unlabeled PRs would otherwise burn a permanent .devN version in the
-    # TestPyPI namespace (and hand all repo secrets to the publish job) on
-    # every synchronize event.
     if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'publish-testpypi')
     uses: ./.github/workflows/shared-publish-package.yaml
     with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -35,14 +35,19 @@ jobs:
       contents: read
     with:
       python-version: '3.11'
+      python-matrix: '["3.11", "3.12", "3.13"]'
       os-matrix: '["macos-latest"]'
       upload-artifacts: true
       update-version-for-pr: true
-      run-integration-tests: false
+      run-integration-tests: true
 
   publish-to-test-pypi:
     needs: build-and-test
-    if: github.event.pull_request.draft == false
+    # Opt-in via the `publish-testpypi` PR label instead of every push:
+    # unlabeled PRs would otherwise burn a permanent .devN version in the
+    # TestPyPI namespace (and hand all repo secrets to the publish job) on
+    # every synchronize event.
+    if: github.event.pull_request.draft == false && contains(github.event.pull_request.labels.*.name, 'publish-testpypi')
     uses: ./.github/workflows/shared-publish-package.yaml
     with:
       python-version: '3.11'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,7 +31,10 @@ jobs:
       upload-artifacts: true
       update-version-for-pr: false
       package-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
-      run-integration-tests: false
+      run-integration-tests: true
+      # Real PyPI releases must ship a Developer-ID-signed helper; only
+      # explicit TestPyPI dispatches may fall back to ad-hoc signing.
+      require-signing: ${{ github.event_name == 'release' || github.event.inputs.is-test-pypi != 'true' }}
     secrets: inherit
 
   publish-package:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,8 +32,6 @@ jobs:
       update-version-for-pr: false
       package-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
       run-integration-tests: true
-      # Real PyPI releases must ship a Developer-ID-signed helper; only
-      # explicit TestPyPI dispatches may fall back to ad-hoc signing.
       require-signing: ${{ github.event_name == 'release' || github.event.inputs.is-test-pypi != 'true' }}
     secrets: inherit
 

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -246,9 +246,11 @@ jobs:
     - name: 🧪 Install wheel and smoke-test the CLI
       run: |
         set -euo pipefail
-        uv venv smoke-env
-        source smoke-env/bin/activate
+        uv venv "$RUNNER_TEMP/smoke-env"
+        source "$RUNNER_TEMP/smoke-env/bin/activate"
         uv pip install dist/*.whl
+        mkdir "$RUNNER_TEMP/smoke-cwd"
+        cd "$RUNNER_TEMP/smoke-cwd"
         chirp --version
         chirp --help >/dev/null
         command -v chirpd

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -205,8 +205,6 @@ jobs:
       run: uv run pytest --cov --cov-report=term
 
     - name: 📤 Upload build artifacts
-      # Only the primary-python leg uploads: the wheel is py3-tagged (identical
-      # across matrix legs) and duplicate artifact names fail the upload.
       if: ${{ inputs.upload-artifacts && matrix.python-version == inputs.python-version }}
       uses: actions/upload-artifact@v7
       with:
@@ -244,9 +242,6 @@ jobs:
         path: dist/
 
     - name: 🧪 Install wheel and smoke-test the CLI
-      # Post-install smoke against the real artifact: the wheel must install
-      # cleanly on the target platform, expose both entry points, import every
-      # runtime package, and (on macOS) bundle the Chirp.app capture helper.
       run: |
         set -euo pipefail
         uv venv smoke-env

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -4,10 +4,15 @@ on:
   workflow_call:
     inputs:
       python-version:
-        description: 'Python version to use'
+        description: 'Primary Python version (used for artifacts and publishing)'
         required: false
         type: string
         default: '3.11'
+      python-matrix:
+        description: 'Python versions to test on (JSON array); must include python-version'
+        required: false
+        type: string
+        default: '["3.11"]'
       os-matrix:
         description: 'Operating systems to test on (JSON array)'
         required: false
@@ -38,6 +43,11 @@ on:
         required: false
         type: boolean
         default: false
+      require-signing:
+        description: 'Fail the build when Developer ID signing secrets are absent (set for PyPI releases)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       MACOS_CERT_P12:
         required: false
@@ -59,15 +69,16 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJson(inputs.os-matrix) }}
+        python-version: ${{ fromJson(inputs.python-matrix) }}
 
     steps:
     - name: ⤵️ Checkout code
       uses: actions/checkout@v7
 
-    - name: 🐍 Set up Python ${{ inputs.python-version }}
+    - name: 🐍 Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ inputs.python-version }}
+        python-version: ${{ matrix.python-version }}
 
     - name: 🚀 Install uv with caching
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -102,10 +113,10 @@ jobs:
       uses: actions/cache@v6
       with:
         path: .venv
-        key: ${{ runner.os }}-python-${{ inputs.python-version }}-venv-${{ hashFiles('pyproject.toml', 'scripts/pyproject.toml') }}-${{ hashFiles('uv.lock') }}
+        key: ${{ runner.os }}-python-${{ matrix.python-version }}-venv-${{ hashFiles('pyproject.toml', 'scripts/pyproject.toml') }}-${{ hashFiles('uv.lock') }}
         restore-keys: |
-          ${{ runner.os }}-python-${{ inputs.python-version }}-venv-${{ hashFiles('pyproject.toml', 'scripts/pyproject.toml') }}-
-          ${{ runner.os }}-python-${{ inputs.python-version }}-venv-
+          ${{ runner.os }}-python-${{ matrix.python-version }}-venv-${{ hashFiles('pyproject.toml', 'scripts/pyproject.toml') }}-
+          ${{ runner.os }}-python-${{ matrix.python-version }}-venv-
 
     - name: ✅ Install dependencies
       run: uv sync --dev
@@ -136,6 +147,9 @@ jobs:
       run: |
         if [ -n "$CERT_P12" ]; then
           echo "enabled=true" >> "$GITHUB_OUTPUT"
+        elif [ "${{ inputs.require-signing }}" = "true" ]; then
+          echo "::error::Developer ID signing secrets are required for this build (require-signing=true) but MACOS_CERT_P12 is not set. Refusing to ship an ad-hoc-signed Chirp.app — it breaks Gatekeeper/TCC permission persistence on user machines." >&2
+          exit 1
         else
           echo "enabled=false" >> "$GITHUB_OUTPUT"
         fi
@@ -191,7 +205,9 @@ jobs:
       run: uv run pytest --cov --cov-report=term
 
     - name: 📤 Upload build artifacts
-      if: ${{ inputs.upload-artifacts }}
+      # Only the primary-python leg uploads: the wheel is py3-tagged (identical
+      # across matrix legs) and duplicate artifact names fail the upload.
+      if: ${{ inputs.upload-artifacts && matrix.python-version == inputs.python-version }}
       uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.artifact-name }}
@@ -227,9 +243,26 @@ jobs:
         name: ${{ inputs.artifact-name }}
         path: dist/
 
-    - name: 🧪 Run integration tests
+    - name: 🧪 Install wheel and smoke-test the CLI
+      # Post-install smoke against the real artifact: the wheel must install
+      # cleanly on the target platform, expose both entry points, import every
+      # runtime package, and (on macOS) bundle the Chirp.app capture helper.
       run: |
-        # Install the built package
-        uv pip install dist/*.whl --system
-        # Run integration tests (customize as needed)
-        echo "Integration tests would run here"
+        set -euo pipefail
+        uv venv smoke-env
+        source smoke-env/bin/activate
+        uv pip install dist/*.whl
+        chirp --version
+        chirp --help >/dev/null
+        chirpd --help >/dev/null
+        python -c "import chirp.cli, chirpd, config.settings, llm.client, notes, notes_chat, recorder, transcriber, utils.file_utils"
+        if [ "$(uname)" = "Darwin" ]; then
+          python - <<'PY'
+        import pathlib, sys
+
+        import audio_capture
+
+        bundle = pathlib.Path(audio_capture.__file__).parent / "Chirp.app"
+        sys.exit(0 if bundle.is_dir() else "Chirp.app helper missing from installed wheel")
+        PY
+        fi

--- a/.github/workflows/shared-build-and-test.yaml
+++ b/.github/workflows/shared-build-and-test.yaml
@@ -63,6 +63,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     permissions:
       contents: read
     strategy:
@@ -216,6 +217,7 @@ jobs:
     if: ${{ inputs.run-integration-tests }}
     needs: build-and-test
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: read
     strategy:
@@ -249,7 +251,8 @@ jobs:
         uv pip install dist/*.whl
         chirp --version
         chirp --help >/dev/null
-        chirpd --help >/dev/null
+        command -v chirpd
+        python -c "import chirpd.__main__"
         python -c "import chirp.cli, chirpd, config.settings, llm.client, notes, notes_chat, recorder, transcriber, utils.file_utils"
         if [ "$(uname)" = "Darwin" ]; then
           python - <<'PY'

--- a/.github/workflows/shared-publish-package.yaml
+++ b/.github/workflows/shared-publish-package.yaml
@@ -50,9 +50,6 @@ jobs:
       # Wheel-only (see shared-build-and-test.yaml). We never publish an sdist:
       # the macOS-arm64 Swift helper can't be built from source off a macOS host
       # with Xcode CLT, and a user-side rebuild would break its TCC identity.
-      # --attestations publishes PEP 740 provenance via the OIDC trusted
-      # publisher, so installers can verify the wheel (which bundles a Mach-O
-      # helper) came from this repo's CI.
       run: twine upload --verbose --attestations --repository ${{ env.pypi-repository }} dist/*.whl
 
     - name: Read version for comment

--- a/.github/workflows/shared-publish-package.yaml
+++ b/.github/workflows/shared-publish-package.yaml
@@ -50,7 +50,10 @@ jobs:
       # Wheel-only (see shared-build-and-test.yaml). We never publish an sdist:
       # the macOS-arm64 Swift helper can't be built from source off a macOS host
       # with Xcode CLT, and a user-side rebuild would break its TCC identity.
-      run: twine upload --verbose --repository ${{ env.pypi-repository }} dist/*.whl
+      # --attestations publishes PEP 740 provenance via the OIDC trusted
+      # publisher, so installers can verify the wheel (which bundles a Mach-O
+      # helper) came from this repo's CI.
+      run: twine upload --verbose --attestations --repository ${{ env.pypi-repository }} dist/*.whl
 
     - name: Read version for comment
       id: version_info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,88 @@
+# Changelog
+
+All notable changes to Chirp are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions track the
+releases published to PyPI as `chirp-notes-ai`.
+
+## [Unreleased]
+
+### Added
+
+- `CHANGELOG.md`, PyPI classifiers, license metadata, and project URLs.
+- Model downloads and daemon loads are pinned to the HuggingFace commit SHA
+  captured at `chirp models add` time (`revision` field in `models.toml`);
+  `chirp models pull` re-pins to the current upstream head.
+- Integration smoke test in CI: the built wheel is installed into a clean
+  environment and exercised via `chirp --version` and CLI startup checks.
+
+### Changed
+
+- All user-data writes (`transcript.txt`, `notes.md`, `meta.toml`,
+  `config.toml`, search-index manifests) are atomic: a crash or full disk can
+  no longer leave silently truncated notes or transcripts.
+- `~/.chirp` and newly created notes roots are owner-only (`0700`) since they
+  hold verbatim meeting content.
+- launchd's captured stdout/stderr moved to `chirpd.launchd.log` so rotation
+  of `chirpd.log` no longer loses daemon output or bypasses the size cap.
+- Renovate now auto-merges only dev-tooling and patch-level updates; runtime
+  dependency minor/major bumps require review.
+- CI tests run on Python 3.11, 3.12, and 3.13.
+- Publishing to PyPI now fails hard when the Developer ID signing certificate
+  is unavailable instead of silently shipping an ad-hoc-signed helper.
+
+### Fixed
+
+- Errors during `chirp record --live-transcribe` (for example an audio device
+  disappearing) now surface as friendly messages instead of raw tracebacks.
+
+## [0.0.5-alpha] — 2026-07-01
+
+### Added
+
+- Chunked (map-reduce) summarization for long meetings, replacing
+  single-prompt note generation that degraded past the model context window.
+
+### Fixed
+
+- Note-generation resilience, first-run model install, and daemon freshness
+  checks.
+
+## [0.0.4-alpha] — 2026-06-30
+
+### Added
+
+- First-run setup: register, download, and warm a chat model during
+  `chirp init`.
+
+### Changed
+
+- Replaced PyAudio with sounddevice (PortAudio ships via pip; no brew
+  dependency).
+- Decode WAVs natively, dropping the ffmpeg dependency.
+- Polished the transcribe pipeline UI and quieted HuggingFace log noise.
+
+### Fixed
+
+- Use the OS trust store for HTTPS so corporate TLS proxies work.
+- Stopped an MLX memory leak during transcription.
+
+## [0.0.3-alpha] — 2026-06-29
+
+### Added
+
+- Lexical-first retrieval: BM25 is the out-of-the-box index; semantic search
+  became opt-in via `chirp config --semantic`.
+- mlx-whisper transcription engine (Metal-accelerated on Apple Silicon).
+
+### Changed
+
+- Production hardening (epic 8): platform-tagged wheel, hybrid retrieval
+  fusion, daemon/client timeout hardening, CLI conventions (`--version`,
+  `--json`, stdout/stderr split), tolerant config loading, and a CI coverage
+  floor.
+
+## Earlier releases
+
+Versions before 0.0.3-alpha were internal alphas that established the core
+record → transcribe → notes pipeline, the chirpd daemon (MLX inference over a
+local socket), the model registry, and the guided `chirp init` flow.

--- a/chirp/cli.py
+++ b/chirp/cli.py
@@ -27,7 +27,7 @@ from config.settings import ChirpSettings, get_settings
 from llm.cli.daemon import daemon_app
 from llm.cli.models import app as models_app
 from llm.registry import resolved_chat_model, resolved_embed_model
-from utils.file_utils import NoteRecord, list_notes
+from utils.file_utils import NoteRecord, atomic_write_text, list_notes
 from utils.tls import enable_system_trust_store
 
 logger = logging.getLogger(__name__)
@@ -614,14 +614,27 @@ def _run_live_transcription(
     try:
         with _quiet_tty_logging():
             result: LiveSessionResult = session.run()
+    except KeyboardInterrupt:
+        console.print("[yellow]recording stopped by user[/yellow]")
+        return
     except ImportError as e:
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(exit_codes.RUNTIME_ERROR)
     except WhisperModelLoadError as e:
         console.print(f"[red]{e!s}[/red]")
         raise typer.Exit(exit_codes.MODEL_LOAD_FAILED)
+    except AudioDeviceError as e:
+        console.print(f"[red]audio device error: {e!s}[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
     except RecordingError as e:
         console.print(f"[red]live recording error: {e!s}[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
+    except ConfigurationError as e:
+        console.print(f"[red]configuration error: {e!s}[/red]")
+        raise typer.Exit(exit_codes.RUNTIME_ERROR)
+    except Exception as e:  # noqa: BLE001 - top-level CLI handler; all specific errors caught above
+        logger.debug("Unexpected error in live transcription: %s", e, exc_info=True)
+        console.print(f"[red]unexpected error: {e!s}[/red]")
         raise typer.Exit(exit_codes.RUNTIME_ERROR)
 
     from utils.time_utils import format_duration
@@ -1081,7 +1094,7 @@ def notes_edit(
         console.print("[yellow]changes not saved.[/yellow]")
         return
 
-    record.notes.write_text(result.content, encoding="utf-8")
+    atomic_write_text(record.notes, result.content)
     console.print(f"[green]updated note: {record.notes}[/green]")
 
     if settings.notes_chat.auto_index:

--- a/chirp/init_flow.py
+++ b/chirp/init_flow.py
@@ -35,13 +35,13 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import tomli_w
 from rich.console import Console
 from rich.text import Text
 
 import audio_capture
 from chirp import exit_codes, glyphs
 from config.settings import ChirpSettings, _stringify_paths
+from utils.file_utils import atomic_write_toml, ensure_private_directory
 
 EXIT_NOT_APPLE_SILICON = exit_codes.NOT_APPLE_SILICON
 
@@ -585,9 +585,8 @@ def _merge_config(
             existing[section] = {}
         existing[section].update(values)
 
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-    with config_path.open("wb") as fh:
-        tomli_w.dump(existing, fh)
+    ensure_private_directory(config_path.parent, tighten_existing=True)
+    atomic_write_toml(config_path, existing)
 
 
 def _backup_unparsable_config(config_path: Path) -> Path:
@@ -753,7 +752,7 @@ def _ensure_default_chat_ready(console: Console) -> None:
     console.print(f" [dim]preparing chat model {alias} (one-time download)...[/dim]")
     callback = RichProgressCallback(entry.hf_repo, console=console)
     try:
-        hf.download_model(entry.hf_repo, progress=callback)
+        hf.download_model(entry.hf_repo, revision=entry.revision, progress=callback)
     except KeyboardInterrupt:
         console.print(
             " [yellow]![/yellow] skipped — the model will download on first use."
@@ -807,9 +806,14 @@ def _setup_chat_model(console: Console, hf_repo: str) -> bool:
         console.print(f" [yellow]![/yellow] invalid model repo {hf_repo}: {exc}")
         return False
 
+    try:
+        pinned_sha = hf.validate_repo(hf_repo).sha
+    except (KeyboardInterrupt, hf.HfError):
+        pinned_sha = None
+
     callback = RichProgressCallback(hf_repo, console=console)
     try:
-        hf.download_model(hf_repo, progress=callback)
+        hf.download_model(hf_repo, revision=pinned_sha, progress=callback)
     except KeyboardInterrupt:
         console.print(" [yellow]![/yellow] skipped.")
         return False
@@ -823,7 +827,9 @@ def _setup_chat_model(console: Console, hf_repo: str) -> bool:
     try:
         registry = read_registry()
         registry = upsert_model(
-            registry, alias, RegistryEntry(hf_repo=hf_repo, role="chat")
+            registry,
+            alias,
+            RegistryEntry(hf_repo=hf_repo, role="chat", revision=pinned_sha),
         )
         registry = set_default_for_role(registry, alias)
         write_registry(registry)

--- a/chirpd/backend.py
+++ b/chirpd/backend.py
@@ -23,8 +23,10 @@ ModelRole = Literal["chat", "embed"]
 class LLMBackend(Protocol):
     """Inference-backend protocol used by ``DaemonState``."""
 
-    async def load(self, repo: str, role: ModelRole) -> Any:
-        """Load ``repo`` for ``role`` and return an opaque model handle."""
+    async def load(
+        self, repo: str, role: ModelRole, revision: str | None = None
+    ) -> Any:
+        """Load ``repo`` (optionally pinned to ``revision``) and return a handle."""
 
     async def unload(self, handle: Any) -> None:
         """Release the resources held by a previously loaded ``handle``."""
@@ -51,7 +53,7 @@ class MLXBackend:
     """Production backend wrapping ``mlx_lm`` + ``huggingface_hub``."""
 
     async def load(
-        self, repo: str, role: ModelRole
+        self, repo: str, role: ModelRole, revision: str | None = None
     ) -> Any:  # pragma: no cover — opt-in @slow @integration per AC-27
         try:
             from huggingface_hub import snapshot_download
@@ -65,7 +67,7 @@ class MLXBackend:
 
         try:
             local_path = await asyncio.to_thread(
-                snapshot_download, repo, local_files_only=True
+                snapshot_download, repo, local_files_only=True, revision=revision
             )
         except LocalEntryNotFoundError as err:
             raise LLMModelLoadFailed(
@@ -339,7 +341,9 @@ class FakeBackend:
         self.last_options: dict[str, Any] | None = None
         self.embed_calls: list[list[str]] = []
 
-    async def load(self, repo: str, role: ModelRole) -> Any:
+    async def load(
+        self, repo: str, role: ModelRole, revision: str | None = None
+    ) -> Any:
         self.load_calls.append((repo, role))
         if self.load_delay_s > 0:
             await asyncio.sleep(self.load_delay_s)

--- a/chirpd/backend.py
+++ b/chirpd/backend.py
@@ -26,7 +26,7 @@ class LLMBackend(Protocol):
     async def load(
         self, repo: str, role: ModelRole, revision: str | None = None
     ) -> Any:
-        """Load ``repo`` (optionally pinned to ``revision``) and return a handle."""
+        """Load ``repo`` for ``role`` and return an opaque model handle."""
 
     async def unload(self, handle: Any) -> None:
         """Release the resources held by a previously loaded ``handle``."""

--- a/chirpd/launchd.py
+++ b/chirpd/launchd.py
@@ -50,8 +50,13 @@ LAUNCH_AGENT_LABEL: Final[str] = "com.chirp.chirpd"
 LAUNCH_AGENT_PLIST_PATH: Final[Path] = (
     Path.home() / "Library" / "LaunchAgents" / f"{LAUNCH_AGENT_LABEL}.plist"
 )
+# Deliberately NOT chirpd.log: launchd holds this fd open for the daemon's
+# lifetime, so if it pointed at the file RotatingFileHandler rotates, launchd
+# would keep writing to the renamed inode (lost output) and its writes would
+# bypass the rotation size cap. This file only captures pre-logging stdout/
+# stderr (startup crashes, tracebacks); structured logs live in chirpd.log.
 LAUNCH_AGENT_LOG_PATH: Final[Path] = (
-    Path.home() / "Library" / "Logs" / "chirp" / "chirpd.log"
+    Path.home() / "Library" / "Logs" / "chirp" / "chirpd.launchd.log"
 )
 
 _LAUNCHCTL_TIMEOUT_S: Final[float] = 10.0

--- a/chirpd/launchd.py
+++ b/chirpd/launchd.py
@@ -50,11 +50,6 @@ LAUNCH_AGENT_LABEL: Final[str] = "com.chirp.chirpd"
 LAUNCH_AGENT_PLIST_PATH: Final[Path] = (
     Path.home() / "Library" / "LaunchAgents" / f"{LAUNCH_AGENT_LABEL}.plist"
 )
-# Deliberately NOT chirpd.log: launchd holds this fd open for the daemon's
-# lifetime, so if it pointed at the file RotatingFileHandler rotates, launchd
-# would keep writing to the renamed inode (lost output) and its writes would
-# bypass the rotation size cap. This file only captures pre-logging stdout/
-# stderr (startup crashes, tracebacks); structured logs live in chirpd.log.
 LAUNCH_AGENT_LOG_PATH: Final[Path] = (
     Path.home() / "Library" / "Logs" / "chirp" / "chirpd.launchd.log"
 )

--- a/chirpd/state.py
+++ b/chirpd/state.py
@@ -176,7 +176,9 @@ class DaemonState:
                     return existing
 
                 await self._enforce_resident_cap(entry.role, incoming_alias=alias)
-                handle = await self._backend.load(entry.hf_repo, entry.role)
+                handle = await self._backend.load(
+                    entry.hf_repo, entry.role, revision=entry.revision
+                )
                 now = datetime.now(UTC)
                 model = LoadedModel(
                     alias=alias,

--- a/config/settings.py
+++ b/config/settings.py
@@ -380,10 +380,6 @@ class ChirpSettings(BaseModel):
         ]
         if self.notes_chat.semantic_enabled:
             directories.append(self.notes_chat.index_dir / "chroma")
-        # App-owned roots get re-tightened even when they already exist: the
-        # chirp home always, and the notes root only at its default location —
-        # a user-configured custom notes_root keeps whatever modes the user
-        # chose for it.
         app_owned = {chirp_home, default_notes_root()}
         for directory in directories:
             ensure_private_directory(directory, tighten_existing=directory in app_owned)

--- a/config/settings.py
+++ b/config/settings.py
@@ -380,10 +380,13 @@ class ChirpSettings(BaseModel):
         ]
         if self.notes_chat.semantic_enabled:
             directories.append(self.notes_chat.index_dir / "chroma")
+        # App-owned roots get re-tightened even when they already exist: the
+        # chirp home always, and the notes root only at its default location —
+        # a user-configured custom notes_root keeps whatever modes the user
+        # chose for it.
+        app_owned = {chirp_home, default_notes_root()}
         for directory in directories:
-            ensure_private_directory(
-                directory, tighten_existing=directory == chirp_home
-            )
+            ensure_private_directory(directory, tighten_existing=directory in app_owned)
 
 
 def _stringify_paths(value):

--- a/config/settings.py
+++ b/config/settings.py
@@ -4,10 +4,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal
 
-import tomli_w
 from platformdirs import user_documents_dir
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from rich.console import Console
+
+from utils.file_utils import atomic_write_toml, ensure_private_directory
 
 SUPPORTED_CONFIG_SCHEMA_VERSION = 1
 
@@ -360,13 +361,15 @@ class ChirpSettings(BaseModel):
         return parent.pop(location[1], _MISSING) is not _MISSING
 
     def save_to_file(self, config_path: Path):
-        config_path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_private_directory(
+            config_path.parent,
+            tighten_existing=config_path.parent == default_chirp_home(),
+        )
 
         config_dict = self.model_dump()
         _stringify_paths(config_dict)
 
-        with config_path.open("wb") as config_file:
-            tomli_w.dump(config_dict, config_file)
+        atomic_write_toml(config_path, config_dict)
 
     def ensure_directories_exist(self):
         chirp_home = default_chirp_home()
@@ -378,7 +381,9 @@ class ChirpSettings(BaseModel):
         if self.notes_chat.semantic_enabled:
             directories.append(self.notes_chat.index_dir / "chroma")
         for directory in directories:
-            directory.mkdir(parents=True, exist_ok=True)
+            ensure_private_directory(
+                directory, tighten_existing=directory == chirp_home
+            )
 
 
 def _stringify_paths(value):

--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -457,12 +457,6 @@ def pull_command(
 
 
 def _current_repo_sha(hf_repo: str) -> str | None:
-    """Latest upstream commit SHA, or None when HF is unreachable.
-
-    `pull` is the user's explicit refresh action, so it re-pins to the current
-    upstream head; offline or API failure falls back to the existing pin
-    rather than blocking the redownload.
-    """
     try:
         return hf.validate_repo(hf_repo).sha
     except hf.HfError:

--- a/llm/cli/models.py
+++ b/llm/cli/models.py
@@ -143,12 +143,14 @@ def register_model(
             2,
         )
     resolved_alias = _resolve_alias(hf_repo, alias)
-    _download(hf_repo, resolved_alias)
+    _download(hf_repo, resolved_alias, revision=metadata.sha)
 
     registry = _read_registry()
     previous_entry = registry.models.get(resolved_alias)
     default_was_unset = _default_unset_for_role(registry, resolved_role)
-    registry = _mutate(registry, resolved_alias, hf_repo, resolved_role)
+    registry = _mutate(
+        registry, resolved_alias, hf_repo, resolved_role, revision=metadata.sha
+    )
     if default_was_unset and previous_entry is None:
         registry = set_default_for_role(registry, resolved_alias)
     _write(registry)
@@ -434,7 +436,13 @@ def pull_command(
     """Force-redownload a registered model's weights, then warm it."""
     registry = _read_registry()
     entry = _require_registered(registry, alias)
-    result = _download(entry.hf_repo, alias)
+    refreshed_sha = _current_repo_sha(entry.hf_repo) or entry.revision
+    result = _download(entry.hf_repo, alias, revision=refreshed_sha)
+    if refreshed_sha is not None and refreshed_sha != entry.revision:
+        registry = upsert_model(
+            registry, alias, entry.model_copy(update={"revision": refreshed_sha})
+        )
+        _write(registry)
 
     note = "cache hit" if result.cache_hit else f"{result.bytes_downloaded} bytes"
     console.print(f"Pulled {alias} ({note}).", markup=False, soft_wrap=True)
@@ -446,6 +454,19 @@ def pull_command(
         return
     _load_on_daemon(alias, entry.role)
     console.print(f"Warmed {alias}.", markup=False, soft_wrap=True)
+
+
+def _current_repo_sha(hf_repo: str) -> str | None:
+    """Latest upstream commit SHA, or None when HF is unreachable.
+
+    `pull` is the user's explicit refresh action, so it re-pins to the current
+    upstream head; offline or API failure falls back to the existing pin
+    rather than blocking the redownload.
+    """
+    try:
+        return hf.validate_repo(hf_repo).sha
+    except hf.HfError:
+        return None
 
 
 def _require_registered(registry: Registry, alias: str) -> RegistryEntry:
@@ -596,10 +617,12 @@ def _resolve_alias(hf_repo: str, alias: str | None) -> str:
         )
 
 
-def _download(hf_repo: str, alias: str) -> hf.DownloadResult:
+def _download(
+    hf_repo: str, alias: str, revision: str | None = None
+) -> hf.DownloadResult:
     callback = RichProgressCallback(hf_repo)
     try:
-        return hf.download_model(hf_repo, progress=callback)
+        return hf.download_model(hf_repo, revision=revision, progress=callback)
     except hf.HfRepoNotFound:
         _exit(
             f"Error: HuggingFace repo not found: {hf_repo}. "
@@ -642,8 +665,14 @@ def _read_registry() -> Registry:
         )
 
 
-def _mutate(registry: Registry, alias: str, hf_repo: str, role: ModelRole) -> Registry:
-    entry = RegistryEntry(hf_repo=hf_repo, role=role, options={})
+def _mutate(
+    registry: Registry,
+    alias: str,
+    hf_repo: str,
+    role: ModelRole,
+    revision: str | None = None,
+) -> Registry:
+    entry = RegistryEntry(hf_repo=hf_repo, role=role, options={}, revision=revision)
     try:
         return upsert_model(registry, alias, entry)
     except ValueError:

--- a/llm/hf.py
+++ b/llm/hf.py
@@ -226,7 +226,10 @@ def infer_role(metadata: HfRepoMetadata) -> Literal["chat", "embed"]:
 
 
 def download_model(
-    repo_id: str, *, progress: ProgressCallback | None = None
+    repo_id: str,
+    *,
+    revision: str | None = None,
+    progress: ProgressCallback | None = None,
 ) -> DownloadResult:
     """Snapshot-download ``repo_id`` into the standard HF cache.
 
@@ -256,7 +259,9 @@ def download_model(
     tqdm_cls = _build_tqdm_adapter(state, progress)
 
     try:
-        local_path = snapshot_download(repo_id=repo_id, tqdm_class=tqdm_cls)
+        local_path = snapshot_download(
+            repo_id=repo_id, revision=revision, tqdm_class=tqdm_cls
+        )
     except RepositoryNotFoundError as err:
         raise HfRepoNotFound(repo_id) from err
     except HfHubHTTPError as err:

--- a/llm/registry.py
+++ b/llm/registry.py
@@ -43,9 +43,6 @@ class RegistryEntry(BaseModel):
     hf_repo: str
     role: ModelRole
     options: dict[str, Any] = Field(default_factory=dict)
-    # HF commit SHA captured when the model was registered/pulled. Downloads
-    # and daemon loads pin to it so a mutated upstream `main` can't swap
-    # weights under an existing alias. None = legacy entry, unpinned.
     revision: str | None = None
 
 

--- a/llm/registry.py
+++ b/llm/registry.py
@@ -43,6 +43,10 @@ class RegistryEntry(BaseModel):
     hf_repo: str
     role: ModelRole
     options: dict[str, Any] = Field(default_factory=dict)
+    # HF commit SHA captured when the model was registered/pulled. Downloads
+    # and daemon loads pin to it so a mutated upstream `main` can't swap
+    # weights under an existing alias. None = legacy entry, unpinned.
+    revision: str | None = None
 
 
 class Registry(BaseModel):

--- a/notes/manual_note_manager.py
+++ b/notes/manual_note_manager.py
@@ -6,12 +6,11 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-import tomli_w
-
 from config.settings import ChirpSettings
 from utils.file_utils import (
     META_FILENAME,
     NOTES_FILENAME,
+    atomic_write_toml,
     ensure_directory,
     slugify,
 )
@@ -127,5 +126,4 @@ class ManualNoteManager:
             "tags": [],
             "source": "manual",
         }
-        with meta_path.open("wb") as fh:
-            tomli_w.dump(meta, fh)
+        atomic_write_toml(meta_path, meta)

--- a/notes/note_generator.py
+++ b/notes/note_generator.py
@@ -9,7 +9,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import tomli_w
 from rapidfuzz import fuzz, utils
 from rich.console import Console
 
@@ -18,7 +17,14 @@ from llm.client import LLMClient
 from llm.registry import resolved_chat_model
 from notes.constants import DEFAULT_MEETING_NAME
 from notes.template_engine import TemplateEngine
-from utils.file_utils import META_FILENAME, NOTES_FILENAME, NoteRecord, list_notes
+from utils.file_utils import (
+    META_FILENAME,
+    NOTES_FILENAME,
+    NoteRecord,
+    atomic_write_text,
+    atomic_write_toml,
+    list_notes,
+)
 from utils.popup_manager import PopupManager
 
 logger = logging.getLogger(__name__)
@@ -330,7 +336,7 @@ class NoteGenerator:
         body = self.template_engine.render_meeting_section(meeting_notes)
         content = self._format_generated_note(body, record.created_at)
 
-        notes_path.write_text(content, encoding="utf-8")
+        atomic_write_text(notes_path, content)
         self._update_meta(record.dir)
         self._auto_index_note(notes_path)
 
@@ -395,8 +401,7 @@ class NoteGenerator:
         meta["indexed_at"] = datetime.now(UTC).replace(microsecond=0).isoformat()
 
         meta_path.parent.mkdir(parents=True, exist_ok=True)
-        with meta_path.open("wb") as fh:
-            tomli_w.dump(meta, fh)
+        atomic_write_toml(meta_path, meta)
 
     def _format_generated_note(self, body: str, note_date: datetime) -> str:
         metadata = {

--- a/notes_chat/bm25.py
+++ b/notes_chat/bm25.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from rank_bm25 import BM25Okapi
 
+from utils.file_utils import atomic_write_json
+
 logger = logging.getLogger(__name__)
 
 # Process-local BM25 model cache keyed by bm25.json path, invalidated on
@@ -177,8 +179,7 @@ def rebuild_bm25_index(
         }
 
         bm25_file.parent.mkdir(parents=True, exist_ok=True)
-        with bm25_file.open("w") as f:
-            json.dump(bm25_data, f, indent=2)
+        atomic_write_json(bm25_file, bm25_data)
 
         # Drop the cached model: the rewrite may land within the filesystem's
         # mtime resolution, so the fingerprint alone wouldn't invalidate it.
@@ -267,17 +268,15 @@ def append_bm25_index(
         merged_metadatas.append(metadata)
 
     bm25_file.parent.mkdir(parents=True, exist_ok=True)
-    with bm25_file.open("w") as f:
-        json.dump(
-            {
-                "doc_ids": merged_ids,
-                "corpus": merged_corpus,
-                "documents": merged_documents,
-                "metadatas": merged_metadatas,
-            },
-            f,
-            indent=2,
-        )
+    atomic_write_json(
+        bm25_file,
+        {
+            "doc_ids": merged_ids,
+            "corpus": merged_corpus,
+            "documents": merged_documents,
+            "metadatas": merged_metadatas,
+        },
+    )
 
     _MODEL_CACHE.pop(str(bm25_file), None)
 

--- a/notes_chat/cache.py
+++ b/notes_chat/cache.py
@@ -4,6 +4,7 @@ import logging
 import time
 
 from notes_chat.config import PROMPT_VERSION, get_notes_config
+from utils.file_utils import atomic_write_json
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +79,7 @@ def cache_answer(question: str, retrieved_ids: list[str], answer: str) -> bool:
             "cache_key": cache_key,
         }
 
-        with cache_file.open("w") as f:
-            json.dump(cache_data, f, indent=2)
+        atomic_write_json(cache_file, cache_data)
 
         _evict_if_needed(cache_dir)
         return True

--- a/notes_chat/index.py
+++ b/notes_chat/index.py
@@ -17,7 +17,7 @@ from config.settings import ChirpSettings
 from llm.client import LLMClient
 from llm.exceptions import LLMError
 from notes_chat.types import Chunk, NoteMeta
-from utils.file_utils import META_FILENAME, _resolve_created_at
+from utils.file_utils import META_FILENAME, _resolve_created_at, atomic_write_json
 
 logger = logging.getLogger(__name__)
 
@@ -445,8 +445,7 @@ class IndexManager:
         # A lexical-only add_note never opens Chroma (which used to create
         # index_dir as a side effect), so ensure the directory exists here.
         self.manifest_file.parent.mkdir(parents=True, exist_ok=True)
-        with self.manifest_file.open("w") as f:
-            json.dump(manifest, f, indent=2)
+        atomic_write_json(self.manifest_file, manifest)
 
     def _chunks_for_file(self, file_path: Path) -> list[Chunk]:
         """Read a note file and split it into chunks (no embedding / Chroma touch).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,21 @@ version = "0.0.5-alpha"
 description = "Meeting recorder CLI that transcribes and generates AI notes"
 authors = [{name = "Colby Timm"}]
 readme = "README.md"
+license = {file = "LICENSE"}
 requires-python = ">=3.11"
+keywords = ["meetings", "transcription", "whisper", "notes", "mlx", "cli"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Operating System :: MacOS",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Multimedia :: Sound/Audio :: Capture/Recording",
+    "Topic :: Text Processing :: Linguistic",
+]
 dependencies = [
     "typer>=0.9.0",
     "rich>=14.1.0",
@@ -31,6 +45,12 @@ dependencies = [
     "huggingface_hub>=1.5.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
     "psutil>=5.9",
 ]
+
+[project.urls]
+Homepage = "https://github.com/Code-and-Sorts/chirp-ai-note-app"
+Repository = "https://github.com/Code-and-Sorts/chirp-ai-note-app"
+Issues = "https://github.com/Code-and-Sorts/chirp-ai-note-app/issues"
+Changelog = "https://github.com/Code-and-Sorts/chirp-ai-note-app/blob/main/CHANGELOG.md"
 
 [project.scripts]
 chirp = "chirp.cli:app"

--- a/recorder/audio_recorder.py
+++ b/recorder/audio_recorder.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from threading import Timer
 
 import numpy as np
-import tomli_w
 
 from audio_capture import AudioCapture, check_macos_version
 from chirp.exceptions import RecordingError
@@ -26,6 +25,7 @@ from recorder.meeting_monitor import MeetingMonitor
 from utils.file_utils import (
     AUDIO_FILENAME,
     META_FILENAME,
+    atomic_write_toml,
     slugify,
 )
 from utils.time_utils import get_recording_duration
@@ -336,5 +336,4 @@ def _read_meta(meta_path: Path) -> dict:
 
 def _write_meta(meta_path: Path, meta: dict) -> None:
     meta_path.parent.mkdir(parents=True, exist_ok=True)
-    with meta_path.open("wb") as fh:
-        tomli_w.dump(meta, fh)
+    atomic_write_toml(meta_path, meta)

--- a/recorder/live_audio.py
+++ b/recorder/live_audio.py
@@ -25,6 +25,7 @@ from recorder.audio_mixer import (
     StereoToMonoMixer,
 )
 from recorder.live_types import AudioFrame
+from utils.file_utils import atomic_write_json
 
 logger = logging.getLogger(__name__)
 
@@ -270,7 +271,6 @@ class LiveAudioStream:
             self._wave = None
 
     def save_recording(self, file_path: Path, title: str | None = None) -> None:
-        import json
 
         if self._temp_wav_path is None or not self._temp_wav_path.exists():
             raise RuntimeError("No audio data captured")
@@ -297,8 +297,7 @@ class LiveAudioStream:
                 "channels": self.channels,
                 "sample_rate": self._sample_rate,
             }
-            with metadata_file.open("w", encoding="utf-8") as fh:
-                json.dump(metadata, fh, indent=2)
+            atomic_write_json(metadata_file, metadata)
 
     def close(self) -> None:
         if self._cap_ctx is not None or self._mixer_thread is not None:

--- a/recorder/live_session.py
+++ b/recorder/live_session.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from recorder.vad_chunker import VADChunker
 
-import tomli_w
 from rich.console import Console
 
 from chirp.exceptions import RecordingError
@@ -22,7 +21,12 @@ from recorder.live_audio import LiveAudioStream
 from recorder.live_dashboard import LiveDashboard
 from recorder.live_transcriber import LiveTranscriber
 from recorder.live_types import DashboardEvent, SpeechChunk
-from utils.file_utils import AUDIO_FILENAME, META_FILENAME, slugify
+from utils.file_utils import (
+    AUDIO_FILENAME,
+    META_FILENAME,
+    atomic_write_toml,
+    slugify,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -324,8 +328,7 @@ class LiveTranscriptionSession:
             "tags": list(self.tags),
         }
         meta_path = note_dir / META_FILENAME
-        with meta_path.open("wb") as fh:
-            tomli_w.dump(meta, fh)
+        atomic_write_toml(meta_path, meta)
 
     def _write_debug_chunk(self, data: bytes, path: Path):
         if not data or not self.audio_stream:

--- a/recorder/live_transcriber.py
+++ b/recorder/live_transcriber.py
@@ -11,6 +11,7 @@ from config.settings import ChirpSettings
 from notes.constants import DEFAULT_MEETING_NAME
 from recorder.live_types import DashboardEvent, SpeechChunk, TranscriptSegment
 from transcriber.whisper_transcriber import WhisperTranscriber
+from utils.file_utils import atomic_write_text
 
 logger = logging.getLogger(__name__)
 
@@ -277,7 +278,7 @@ class LiveTranscriber(threading.Thread):
         for segment in segments:
             timestamp = self._format_timestamp(segment.start)
             lines.append(f"[{timestamp}] {segment.text}")
-        output_path.write_text("\n".join(lines), encoding="utf-8")
+        atomic_write_text(output_path, "\n".join(lines))
 
     def close(self) -> None:
         """Release the underlying Whisper model. Idempotent."""

--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,21 @@
   "extends": [
     "config:recommended"
   ],
-  "automerge": true,
-  "platformAutomerge": true,
+  "automerge": false,
   "packageRules": [
+    {
+      "description": "Dev tooling and GitHub Actions are exercised end-to-end by CI itself, so a green check is a meaningful gate — safe to automerge at any level",
+      "matchDepTypes": ["devDependencies", "action"],
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "Runtime deps ship to users with unbounded >= floors; patch bumps automerge, minor/major require review because CI's mocked LLM/audio seams can't prove them safe",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "platformAutomerge": true
+    },
     {
       "description": "gh-aw manages github/gh-aw-actions pins via the agentic-workflows toolchain; Renovate must not touch them",
       "matchPackageNames": [
@@ -18,7 +30,8 @@
       "description": "Exact-pinned MLX deps drive the only real-inference code path, which is `# pragma: no cover` and never exercised by CI's FakeBackend. A green check on a bump proves nothing about real inference, so these require manual review before merge.",
       "matchPackageNames": [
         "mlx-lm",
-        "mlx-embeddings"
+        "mlx-embeddings",
+        "mlx-whisper"
       ],
       "automerge": false,
       "platformAutomerge": false

--- a/tests/chirpd/test_state.py
+++ b/tests/chirpd/test_state.py
@@ -107,7 +107,9 @@ async def test_concurrent_load_of_same_alias_serializes() -> None:
     from chirpd.backend import ModelRole
 
     class _BlockingBackend(FakeBackend):
-        async def load(self, repo: str, role: ModelRole) -> Any:
+        async def load(
+            self, repo: str, role: ModelRole, revision: str | None = None
+        ) -> Any:
             self.load_calls.append((repo, role))
             inside_backend_load.set()
             await release_backend_load.wait()

--- a/tests/llm/test_registry.py
+++ b/tests/llm/test_registry.py
@@ -252,6 +252,27 @@ def test_registry_round_trip_chat_and_embed(tmp_path: Path) -> None:
     assert loaded == original
 
 
+def test_registry_roundtrips_pinned_revision(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    pinned = RegistryEntry(
+        hf_repo="mlx-community/gemma-4-4b-it-4bit",
+        role="chat",
+        revision="0123456789abcdef0123456789abcdef01234567",
+    )
+    write_registry(Registry(schema_version=1, models={"gemma": pinned}), path=target)
+    loaded = read_registry(target)
+    assert loaded.models["gemma"].revision == pinned.revision
+
+
+def test_registry_entry_without_revision_is_unpinned(tmp_path: Path) -> None:
+    target = tmp_path / "models.toml"
+    write_registry(
+        Registry(schema_version=1, models={"gemma": _chat_entry()}), path=target
+    )
+    assert read_registry(target).models["gemma"].revision is None
+    assert "revision" not in target.read_text()
+
+
 def test_write_creates_parent_dir(tmp_path: Path) -> None:
     target = tmp_path / "nested" / "deeper" / "models.toml"
     write_registry(Registry(schema_version=1), path=target)

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -1,11 +1,20 @@
+import json
+import os
+import stat
 import time
+import tomllib
 from datetime import date
 from unittest.mock import Mock
 
+import pytest
 import tomli_w
 
 from utils.file_utils import (
     NoteRecord,
+    atomic_write_json,
+    atomic_write_text,
+    atomic_write_toml,
+    ensure_private_directory,
     get_file_size_mb,
     list_notes,
     sanitize_filename,
@@ -150,3 +159,70 @@ def _write_meta(note_dir, title, iso, tags=None):
     }
     with (note_dir / "meta.toml").open("wb") as fh:
         tomli_w.dump(payload, fh)
+
+
+class TestAtomicWrite:
+    def test_text_roundtrip(self, tmp_path):
+        target = tmp_path / "notes.md"
+        atomic_write_text(target, "hello world")
+        assert target.read_text(encoding="utf-8") == "hello world"
+
+    def test_replaces_existing_content(self, tmp_path):
+        target = tmp_path / "transcript.txt"
+        target.write_text("old")
+        atomic_write_text(target, "new")
+        assert target.read_text(encoding="utf-8") == "new"
+
+    def test_no_temp_files_left_behind(self, tmp_path):
+        target = tmp_path / "meta.toml"
+        atomic_write_toml(target, {"title": "t"})
+        assert [f.name for f in tmp_path.iterdir()] == ["meta.toml"]
+
+    def test_toml_roundtrip(self, tmp_path):
+        target = tmp_path / "meta.toml"
+        atomic_write_toml(target, {"title": "Standup", "tags": ["a", "b"]})
+        with target.open("rb") as fh:
+            assert tomllib.load(fh) == {"title": "Standup", "tags": ["a", "b"]}
+
+    def test_json_roundtrip(self, tmp_path):
+        target = tmp_path / "manifest.json"
+        atomic_write_json(target, {"files": {"a": 1}})
+        assert json.loads(target.read_text()) == {"files": {"a": 1}}
+
+    def test_failure_cleans_temp_and_preserves_original(self, tmp_path, monkeypatch):
+        target = tmp_path / "notes.md"
+        target.write_text("original")
+
+        def explode(_fd):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "fsync", explode)
+        with pytest.raises(OSError, match="disk full"):
+            atomic_write_text(target, "partial")
+        assert target.read_text(encoding="utf-8") == "original"
+        assert [f.name for f in tmp_path.iterdir()] == ["notes.md"]
+
+
+class TestEnsurePrivateDirectory:
+    def _mode(self, path):
+        return stat.S_IMODE(path.stat().st_mode)
+
+    def test_new_directory_is_owner_only(self, tmp_path):
+        target = tmp_path / "chirp-home"
+        ensure_private_directory(target)
+        assert target.is_dir()
+        assert self._mode(target) == 0o700
+
+    def test_existing_directory_keeps_mode_by_default(self, tmp_path):
+        target = tmp_path / "notes-root"
+        target.mkdir()
+        target.chmod(0o755)
+        ensure_private_directory(target)
+        assert self._mode(target) == 0o755
+
+    def test_tighten_existing_chmods_to_owner_only(self, tmp_path):
+        target = tmp_path / "chirp-home"
+        target.mkdir()
+        target.chmod(0o755)
+        ensure_private_directory(target, tighten_existing=True)
+        assert self._mode(target) == 0o700

--- a/tests/test_file_utils.py
+++ b/tests/test_file_utils.py
@@ -189,6 +189,14 @@ class TestAtomicWrite:
         atomic_write_json(target, {"files": {"a": 1}})
         assert json.loads(target.read_text()) == {"files": {"a": 1}}
 
+    def test_preserves_tightened_permissions_of_existing_file(self, tmp_path):
+        target = tmp_path / "transcript.txt"
+        target.write_text("old")
+        target.chmod(0o600)
+        atomic_write_text(target, "new")
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        assert target.read_text(encoding="utf-8") == "new"
+
     def test_failure_cleans_temp_and_preserves_original(self, tmp_path, monkeypatch):
         target = tmp_path / "notes.md"
         target.write_text("original")

--- a/tests/test_init_flow.py
+++ b/tests/test_init_flow.py
@@ -7,6 +7,7 @@ platform-agnostic, and never spawn a real daemon or write a real models.toml.
 
 import sys
 from io import StringIO
+from types import SimpleNamespace
 
 from rich.console import Console
 
@@ -1359,7 +1360,7 @@ def test_ensure_chat_ready_downloads_and_warms(monkeypatch):
     downloaded: list[str] = []
     monkeypatch.setattr(
         "llm.hf.download_model",
-        lambda repo, progress=None: downloaded.append(repo),
+        lambda repo, revision=None, progress=None: downloaded.append(repo),
     )
     monkeypatch.setattr("llm.cli._progress.RichProgressCallback", _FakeProgressCallback)
     warmed: list[tuple[str, str]] = []
@@ -1383,7 +1384,7 @@ def test_ensure_chat_ready_noop_when_unregistered(monkeypatch):
     downloaded: list[str] = []
     monkeypatch.setattr(
         "llm.hf.download_model",
-        lambda repo, progress=None: downloaded.append(repo),
+        lambda repo, revision=None, progress=None: downloaded.append(repo),
     )
 
     init_flow._ensure_default_chat_ready(_console())
@@ -1398,7 +1399,7 @@ def test_ensure_chat_ready_download_failure_skips_warm(monkeypatch):
         "llm.registry.read_registry", lambda path=None: _registry_with_default("qwen")
     )
 
-    def _boom(repo, progress=None):
+    def _boom(repo, revision=None, progress=None):
         raise HfError("network down")
 
     monkeypatch.setattr("llm.hf.download_model", _boom)
@@ -1424,7 +1425,9 @@ def test_ensure_chat_ready_warm_failure_is_graceful(monkeypatch):
     monkeypatch.setattr(
         "llm.registry.read_registry", lambda path=None: _registry_with_default("qwen")
     )
-    monkeypatch.setattr("llm.hf.download_model", lambda repo, progress=None: None)
+    monkeypatch.setattr(
+        "llm.hf.download_model", lambda repo, revision=None, progress=None: None
+    )
     monkeypatch.setattr("llm.cli._progress.RichProgressCallback", _FakeProgressCallback)
 
     class _Client:
@@ -1443,7 +1446,15 @@ def test_ensure_chat_ready_warm_failure_is_graceful(monkeypatch):
 
 
 def test_setup_chat_model_registers_downloads_warms(monkeypatch):
-    monkeypatch.setattr("llm.hf.download_model", lambda repo, progress=None: None)
+    pinned: list[str | None] = []
+    monkeypatch.setattr(
+        "llm.hf.validate_repo",
+        lambda repo: SimpleNamespace(sha="abc123"),
+    )
+    monkeypatch.setattr(
+        "llm.hf.download_model",
+        lambda repo, revision=None, progress=None: pinned.append(revision),
+    )
     monkeypatch.setattr("llm.cli._progress.RichProgressCallback", _FakeProgressCallback)
     monkeypatch.setattr(
         "llm.registry.read_registry", lambda path=None: _empty_registry()
@@ -1468,15 +1479,21 @@ def test_setup_chat_model_registers_downloads_warms(monkeypatch):
     assert len(written) == 1
     assert written[0].default_chat == "qwen2.5-7b-instruct-4bit"
     assert "qwen2.5-7b-instruct-4bit" in written[0].models
+    assert written[0].models["qwen2.5-7b-instruct-4bit"].revision == "abc123"
+    assert pinned == ["abc123"]
     assert warmed == [("qwen2.5-7b-instruct-4bit", "chat")]
 
 
 def test_setup_chat_model_download_failure_returns_false(monkeypatch):
     from llm.hf import HfError
 
-    def _boom(repo, progress=None):
+    def _boom(repo, revision=None, progress=None):
         raise HfError("network down")
 
+    monkeypatch.setattr(
+        "llm.hf.validate_repo",
+        lambda repo: SimpleNamespace(sha="abc123"),
+    )
     monkeypatch.setattr("llm.hf.download_model", _boom)
     monkeypatch.setattr("llm.cli._progress.RichProgressCallback", _FakeProgressCallback)
     written = []

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,5 +1,3 @@
-"""Behavior tests for the live-transcription dashboard (rendering + state)."""
-
 from __future__ import annotations
 
 import queue

--- a/tests/test_live_dashboard.py
+++ b/tests/test_live_dashboard.py
@@ -1,0 +1,238 @@
+"""Behavior tests for the live-transcription dashboard (rendering + state)."""
+
+from __future__ import annotations
+
+import queue
+import threading
+import time
+
+import pytest
+from rich.console import Console
+
+from recorder.live_dashboard import LiveDashboard
+from recorder.live_types import DashboardEvent, TranscriptSegment
+
+
+@pytest.fixture
+def dashboard(monkeypatch):
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    return LiveDashboard(
+        console=Console(width=100, height=40, force_terminal=False),
+        event_queue=queue.Queue(),
+        stop_event=threading.Event(),
+        start_time=time.monotonic(),
+    )
+
+
+def _segment(text: str, start: float = 0.0) -> TranscriptSegment:
+    return TranscriptSegment(
+        text=text, start=start, end=start + 1.0, words=len(text.split())
+    )
+
+
+class TestHandleEvent:
+    def test_transcript_event_appends_segments_and_updates_totals(self, dashboard):
+        segments = [_segment("hello world"), _segment("second line", start=2.0)]
+        dashboard._handle_event(
+            DashboardEvent(
+                type="transcript",
+                payload={"segments": segments, "language": "en", "total_words": 4},
+            )
+        )
+        assert dashboard._transcripts == segments
+        assert dashboard._language == "en"
+        assert dashboard._total_words == 4
+
+    def test_transcript_event_keeps_prior_language_when_absent(self, dashboard):
+        dashboard._language = "en"
+        dashboard._handle_event(
+            DashboardEvent(type="transcript", payload={"segments": []})
+        )
+        assert dashboard._language == "en"
+
+    def test_transcript_buffer_is_capped(self, dashboard):
+        dashboard._max_transcripts = 5
+        dashboard._transcripts = [_segment(f"old {i}") for i in range(5)]
+        dashboard._handle_event(
+            DashboardEvent(
+                type="transcript",
+                payload={"segments": [_segment("new 1"), _segment("new 2")]},
+            )
+        )
+        assert len(dashboard._transcripts) == 5
+        assert dashboard._transcripts[-1].text == "new 2"
+        assert dashboard._transcripts[0].text == "old 2"
+
+    def test_level_event_updates_latest_level(self, dashboard):
+        dashboard._handle_event(DashboardEvent(type="level", payload={"value": 0.7}))
+        assert dashboard._latest_level == pytest.approx(0.7)
+
+    def test_dropped_event_records_dropped_chunks(self, dashboard):
+        dashboard._handle_event(
+            DashboardEvent(type="dropped", payload={"dropped_chunks": 3})
+        )
+        assert dashboard._dropped_chunks == 3
+
+    def test_vad_status_event_updates_speech_state(self, dashboard):
+        dashboard._handle_event(
+            DashboardEvent(
+                type="vad_status",
+                payload={
+                    "frames": 10,
+                    "speech_frames": 4,
+                    "triggered": True,
+                    "chunks_emitted": 2,
+                },
+            )
+        )
+        assert dashboard._vad_triggered is True
+        assert dashboard._vad_frames == 10
+        assert dashboard._vad_speech_frames == 4
+        assert dashboard._vad_chunks_emitted == 2
+
+    def test_unknown_event_type_is_ignored(self, dashboard):
+        dashboard._handle_event(DashboardEvent(type="nonsense", payload={"x": 1}))
+        assert dashboard._transcripts == []
+
+
+class TestScrolling:
+    def _fill(self, dashboard, count: int):
+        dashboard._transcripts = [
+            _segment(f"line {i}", start=float(i)) for i in range(count)
+        ]
+
+    def test_scroll_up_disables_auto_scroll(self, dashboard):
+        self._fill(dashboard, 200)
+        dashboard._handle_scroll_up()
+        assert dashboard._auto_scroll is False
+        assert dashboard._scroll_offset == 5
+
+    def test_scroll_up_clamps_to_history_size(self, dashboard):
+        self._fill(dashboard, 3)
+        dashboard._handle_scroll_up()
+        assert dashboard._scroll_offset == 0
+
+    def test_scroll_down_to_bottom_reenables_auto_scroll(self, dashboard):
+        self._fill(dashboard, 200)
+        dashboard._handle_scroll_up()
+        dashboard._handle_scroll_down()
+        assert dashboard._scroll_offset == 0
+        assert dashboard._auto_scroll is True
+
+    def test_page_up_and_page_down_are_symmetric(self, dashboard):
+        self._fill(dashboard, 500)
+        dashboard._handle_page_up()
+        offset_after_page_up = dashboard._scroll_offset
+        assert offset_after_page_up > 0
+        assert dashboard._auto_scroll is False
+        dashboard._handle_page_down()
+        assert dashboard._scroll_offset == 0
+        assert dashboard._auto_scroll is True
+
+    def test_scroll_to_bottom_resets_state(self, dashboard):
+        self._fill(dashboard, 200)
+        dashboard._handle_page_up()
+        dashboard._handle_scroll_to_bottom()
+        assert dashboard._scroll_offset == 0
+        assert dashboard._auto_scroll is True
+
+
+class TestRendering:
+    def test_render_transcript_empty_shows_waiting(self, dashboard):
+        panel = dashboard._render_transcript()
+        assert "Waiting for speech" in str(panel.renderable)
+
+    def test_render_transcript_scrolled_title_shows_window(self, dashboard):
+        dashboard._transcripts = [_segment(f"line {i}") for i in range(100)]
+        dashboard._auto_scroll = False
+        dashboard._scroll_offset = 10
+        panel = dashboard._render_transcript()
+        assert "showing" in str(panel.title)
+
+    def test_render_status_includes_dropped_row_only_when_dropping(self, dashboard):
+        console = Console(width=60, force_terminal=False)
+        with console.capture() as capture:
+            console.print(dashboard._render_status())
+        assert "Dropped" not in capture.get()
+
+        dashboard._dropped_chunks = 4
+        with console.capture() as capture:
+            console.print(dashboard._render_status())
+        assert "Dropped" in capture.get()
+
+    def test_footer_swaps_instructions_when_scrolled(self, dashboard):
+        console = Console(width=80, force_terminal=False)
+        with console.capture() as capture:
+            console.print(dashboard._render_footer())
+        assert "to scroll" in capture.get()
+
+        dashboard._auto_scroll = False
+        with console.capture() as capture:
+            console.print(dashboard._render_footer())
+        assert "resume auto-scroll" in capture.get()
+
+
+class TestHelpers:
+    @pytest.mark.parametrize(
+        ("seconds", "expected"),
+        [
+            (0, "00:00"),
+            (59, "00:59"),
+            (61, "01:01"),
+            (3599, "59:59"),
+            (3661, "01:01:01"),
+            (-5, "00:00"),
+        ],
+    )
+    def test_format_elapsed(self, seconds, expected):
+        assert LiveDashboard._format_elapsed(seconds) == expected
+
+    def test_sanitize_text_strips_escape_and_unprintable(self):
+        assert (
+            LiveDashboard._sanitize_text("a\x1b[31mred\x07 b\tc\n") == "a[31mred b\tc\n"
+        )
+
+    @pytest.mark.parametrize(
+        ("level", "filled"),
+        [(0.0, 0), (0.5, 5), (1.0, 10), (2.0, 10)],
+    )
+    def test_render_level_bar(self, level, filled):
+        bar = LiveDashboard._render_level_bar(level)
+        assert bar.count("█") == filled
+        assert len(bar) == 10
+
+    def test_estimate_visible_lines_floor(self, dashboard):
+        dashboard.console = Console(width=80, height=10, force_terminal=False)
+        assert dashboard._estimate_visible_lines() == 10
+
+
+class TestRunLoop:
+    def test_run_drains_events_and_stops_on_stop_event(self, monkeypatch):
+        events: queue.Queue[DashboardEvent] = queue.Queue()
+        stop = threading.Event()
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+        dashboard = LiveDashboard(
+            console=Console(width=80, height=24, force_terminal=False),
+            event_queue=events,
+            stop_event=stop,
+            start_time=time.monotonic(),
+        )
+        events.put(
+            DashboardEvent(
+                type="transcript",
+                payload={"segments": [_segment("hi")], "total_words": 1},
+            )
+        )
+
+        runner = threading.Thread(target=dashboard.run)
+        runner.start()
+        try:
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline and not dashboard._transcripts:
+                time.sleep(0.02)
+        finally:
+            stop.set()
+            runner.join(timeout=5.0)
+
+        assert not runner.is_alive()
+        assert dashboard._total_words == 1

--- a/tests/test_meeting_monitor.py
+++ b/tests/test_meeting_monitor.py
@@ -1,5 +1,3 @@
-"""Behavior tests for MeetingMonitor (duration warnings + safety stop)."""
-
 from __future__ import annotations
 
 import threading

--- a/tests/test_meeting_monitor.py
+++ b/tests/test_meeting_monitor.py
@@ -1,0 +1,112 @@
+"""Behavior tests for MeetingMonitor (duration warnings + safety stop)."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from config.settings import MonitoringConfig
+from recorder.meeting_monitor import MeetingMonitor
+
+
+def _monitor(
+    start_offset_minutes: float = 0.0,
+    warning_minutes: int = 60,
+    should_stop: bool = False,
+    on_warning=None,
+) -> MeetingMonitor:
+    return MeetingMonitor(
+        config=MonitoringConfig(warning_minutes=warning_minutes),
+        start_time=datetime.now() - timedelta(minutes=start_offset_minutes),
+        warning_callback=on_warning or (lambda _minutes: None),
+        should_stop_callback=lambda: should_stop,
+    )
+
+
+class TestElapsedTime:
+    def test_elapsed_minutes_reflect_start_time(self):
+        monitor = _monitor(start_offset_minutes=42)
+        assert monitor.get_elapsed_minutes() == 42
+        assert monitor.get_elapsed_time() == pytest.approx(42 * 60, abs=5)
+
+    def test_over_warning_threshold_boundary(self):
+        assert _monitor(61, warning_minutes=60).is_over_warning_threshold()
+        assert _monitor(60, warning_minutes=60).is_over_warning_threshold()
+        assert not _monitor(30, warning_minutes=60).is_over_warning_threshold()
+
+
+class TestLifecycle:
+    def test_start_is_idempotent(self):
+        monitor = _monitor()
+        monitor.start()
+        try:
+            first_thread = monitor.monitor_thread
+            monitor.start()
+            assert monitor.monitor_thread is first_thread
+        finally:
+            monitor.stop()
+
+    def test_stop_wakes_and_joins_the_loop(self):
+        monitor = _monitor()
+        monitor.start()
+        assert monitor.monitor_thread.is_alive()
+        monitor.stop()
+        assert monitor.is_monitoring is False
+        assert not monitor.monitor_thread.is_alive()
+
+    def test_stop_without_start_is_safe(self):
+        _monitor().stop()
+
+
+class TestMonitorLoop:
+    def test_fires_warning_when_over_threshold(self):
+        warned = threading.Event()
+        warned_minutes: list[int] = []
+
+        def on_warning(minutes: int) -> None:
+            warned_minutes.append(minutes)
+            warned.set()
+
+        monitor = _monitor(
+            start_offset_minutes=90, warning_minutes=60, on_warning=on_warning
+        )
+        monitor.start()
+        try:
+            assert warned.wait(timeout=5.0)
+        finally:
+            monitor.stop()
+        assert warned_minutes[0] >= 90
+        assert monitor.last_warning is not None
+
+    def test_should_stop_shows_popup_and_exits_loop(self):
+        with patch("utils.popup_manager.PopupManager") as popup_cls:
+            monitor = _monitor(should_stop=True)
+            monitor.start()
+            monitor.monitor_thread.join(timeout=5.0)
+            try:
+                assert not monitor.monitor_thread.is_alive()
+            finally:
+                monitor.stop()
+        message = popup_cls.return_value.show_error.call_args.args[0]
+        assert "stopped automatically" in message
+        assert str(monitor.config.max_recording_hours) in message
+
+    def test_loop_survives_warning_callback_errors(self):
+        calls = threading.Event()
+
+        def exploding_warning(_minutes: int) -> None:
+            calls.set()
+            raise RuntimeError("boom")
+
+        monitor = _monitor(
+            start_offset_minutes=90, warning_minutes=60, on_warning=exploding_warning
+        )
+        monitor.start()
+        try:
+            assert calls.wait(timeout=5.0)
+            assert monitor.monitor_thread.is_alive()
+        finally:
+            monitor.stop()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,4 @@
+import stat
 import tomllib
 from pathlib import Path
 from unittest.mock import patch
@@ -67,6 +68,42 @@ class TestChirpSettings:
 
         assert (tmp_path / "home").is_dir()
         assert not (tmp_path / "home" / "chroma").exists()
+
+    def test_ensure_directories_tightens_app_owned_roots(self, tmp_path):
+        settings = ChirpSettings()
+        settings.directories.notes_root = tmp_path / "notes"
+        settings.notes_chat.index_dir = tmp_path / "home"
+        settings.notes_chat.semantic_enabled = False
+        for existing in ("notes", "home"):
+            (tmp_path / existing).mkdir()
+            (tmp_path / existing).chmod(0o755)
+
+        with (
+            patch("config.settings.default_chirp_home", return_value=tmp_path / "home"),
+            patch(
+                "config.settings.default_notes_root",
+                return_value=tmp_path / "notes",
+            ),
+        ):
+            settings.ensure_directories_exist()
+
+        assert stat.S_IMODE((tmp_path / "home").stat().st_mode) == 0o700
+        assert stat.S_IMODE((tmp_path / "notes").stat().st_mode) == 0o700
+
+    def test_ensure_directories_leaves_custom_notes_root_mode(self, tmp_path):
+        settings = ChirpSettings()
+        settings.directories.notes_root = tmp_path / "custom-notes"
+        settings.notes_chat.index_dir = tmp_path / "home"
+        settings.notes_chat.semantic_enabled = False
+        (tmp_path / "custom-notes").mkdir()
+        (tmp_path / "custom-notes").chmod(0o755)
+
+        with patch(
+            "config.settings.default_chirp_home", return_value=tmp_path / "home"
+        ):
+            settings.ensure_directories_exist()
+
+        assert stat.S_IMODE((tmp_path / "custom-notes").stat().st_mode) == 0o755
 
     def test_config_path_lives_under_chirp_home(self):
         assert ChirpSettings.get_config_path() == Path.home() / ".chirp" / "config.toml"

--- a/transcriber/batch_processor.py
+++ b/transcriber/batch_processor.py
@@ -9,7 +9,6 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-import tomli_w
 from rich.console import Console, RenderableType
 from rich.live import Live
 from rich.spinner import Spinner
@@ -24,6 +23,8 @@ from utils.file_utils import (
     NOTES_FILENAME,
     TRANSCRIPT_FILENAME,
     NoteRecord,
+    atomic_write_text,
+    atomic_write_toml,
     list_notes,
 )
 from utils.popup_manager import PopupManager
@@ -330,7 +331,7 @@ class BatchProcessor:
         if not result.get("success"):
             raise RuntimeError(result.get("error") or "whisper failed")
         full_text = result.get("full_text", "") or ""
-        transcript_path.write_text(full_text, encoding="utf-8")
+        atomic_write_text(transcript_path, full_text)
         ctx.transcript_words = len(full_text.split())
         ctx.view.done(
             Stage.TRANSCRIBE,
@@ -438,5 +439,4 @@ def _read_meta(meta_path: Path) -> dict[str, Any]:
 
 def _write_meta(meta_path: Path, meta: dict[str, Any]) -> None:
     meta_path.parent.mkdir(parents=True, exist_ok=True)
-    with meta_path.open("wb") as fh:
-        tomli_w.dump(meta, fh)
+    atomic_write_toml(meta_path, meta)

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -1,17 +1,59 @@
 from __future__ import annotations
 
+import json
+import os
 import re
 import shutil
 import tomllib
 import unicodedata
+import uuid
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
+from typing import Any
+
+import tomli_w
 
 AUDIO_FILENAME = "audio.wav"
 TRANSCRIPT_FILENAME = "transcript.txt"
 NOTES_FILENAME = "notes.md"
 META_FILENAME = "meta.toml"
+
+
+def atomic_write_bytes(path: Path, data: bytes) -> None:
+    """Write ``data`` to ``path`` atomically (unique temp + fsync + replace).
+
+    Readers never observe a partially written file: they see either the old
+    content or the new content. The temp name is unique per invocation
+    (pid + random suffix) so concurrent writers can't clobber each other's
+    temp file; on failure this writer's temp file is removed and the original
+    error re-raised.
+    """
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        with tmp_path.open("wb") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        tmp_path.replace(path)
+    except OSError:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def atomic_write_text(path: Path, content: str, *, encoding: str = "utf-8") -> None:
+    atomic_write_bytes(path, content.encode(encoding))
+
+
+def atomic_write_toml(path: Path, payload: dict[str, Any]) -> None:
+    atomic_write_bytes(path, tomli_w.dumps(payload).encode("utf-8"))
+
+
+def atomic_write_json(path: Path, payload: Any, *, indent: int = 2) -> None:
+    atomic_write_bytes(path, json.dumps(payload, indent=indent).encode("utf-8"))
 
 
 @dataclass
@@ -172,6 +214,25 @@ def ensure_directory(directory: Path) -> bool:
         return True
     except OSError:
         return False
+
+
+def ensure_private_directory(path: Path, *, tighten_existing: bool = False) -> None:
+    """Create ``path`` (and parents) and restrict it to the owner (0700).
+
+    Notes and config hold verbatim meeting content, so the containing
+    directories must not be group/world readable. A directory that already
+    exists keeps its permissions unless ``tighten_existing`` is set — used for
+    fully app-owned roots like the chirp home, where user customization of
+    modes is not expected. The chmod is best-effort: failure to tighten never
+    blocks the write path that needs the directory.
+    """
+    existed = path.is_dir()
+    path.mkdir(parents=True, exist_ok=True)
+    if not existed or tighten_existing:
+        try:
+            path.chmod(0o700)
+        except OSError:
+            pass
 
 
 def clean_old_files(directory: Path, days_old: int = 30) -> int:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -8,6 +8,7 @@ import stat
 import tomllib
 import unicodedata
 import uuid
+from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from pathlib import Path
@@ -22,17 +23,6 @@ META_FILENAME = "meta.toml"
 
 
 def atomic_write_bytes(path: Path, data: bytes) -> None:
-    """Write ``data`` to ``path`` atomically (unique temp + fsync + replace).
-
-    Readers never observe a partially written file: they see either the old
-    content or the new content. The temp name is unique per invocation
-    (pid + random suffix) so concurrent writers can't clobber each other's
-    temp file; on failure this writer's temp file is removed and the original
-    error re-raised. An existing target's permission bits are carried over to
-    the replacement — the temp file is created under the process umask, and
-    replacing a deliberately tightened file (e.g. 0600) with a 0644 one would
-    silently widen access to its contents.
-    """
     try:
         existing_mode = stat.S_IMODE(path.stat().st_mode)
     except OSError:
@@ -47,12 +37,8 @@ def atomic_write_bytes(path: Path, data: bytes) -> None:
             tmp_path.chmod(existing_mode)
         tmp_path.replace(path)
     except OSError:
-        try:
+        with suppress(OSError):
             tmp_path.unlink(missing_ok=True)
-        except OSError:
-            # Cleanup is best-effort; raising here would mask the original
-            # write/replace error being propagated below.
-            pass
         raise
 
 
@@ -229,25 +215,11 @@ def ensure_directory(directory: Path) -> bool:
 
 
 def ensure_private_directory(path: Path, *, tighten_existing: bool = False) -> None:
-    """Create ``path`` (and parents) and restrict it to the owner (0700).
-
-    Notes and config hold verbatim meeting content, so the containing
-    directories must not be group/world readable. A directory that already
-    exists keeps its permissions unless ``tighten_existing`` is set — used for
-    fully app-owned roots like the chirp home, where user customization of
-    modes is not expected. The chmod is best-effort: failure to tighten never
-    blocks the write path that needs the directory.
-    """
     existed = path.is_dir()
     path.mkdir(parents=True, exist_ok=True)
     if not existed or tighten_existing:
-        try:
+        with suppress(OSError):
             path.chmod(0o700)
-        except OSError:
-            # Best-effort hardening: a filesystem that rejects chmod (e.g.
-            # some network mounts) must not block the write path that needs
-            # this directory.
-            pass
 
 
 def clean_old_files(directory: Path, days_old: int = 30) -> int:

--- a/utils/file_utils.py
+++ b/utils/file_utils.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import tomllib
 import unicodedata
 import uuid
@@ -27,19 +28,30 @@ def atomic_write_bytes(path: Path, data: bytes) -> None:
     content or the new content. The temp name is unique per invocation
     (pid + random suffix) so concurrent writers can't clobber each other's
     temp file; on failure this writer's temp file is removed and the original
-    error re-raised.
+    error re-raised. An existing target's permission bits are carried over to
+    the replacement — the temp file is created under the process umask, and
+    replacing a deliberately tightened file (e.g. 0600) with a 0644 one would
+    silently widen access to its contents.
     """
+    try:
+        existing_mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        existing_mode = None
     tmp_path = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
     try:
         with tmp_path.open("wb") as handle:
             handle.write(data)
             handle.flush()
             os.fsync(handle.fileno())
+        if existing_mode is not None:
+            tmp_path.chmod(existing_mode)
         tmp_path.replace(path)
     except OSError:
         try:
             tmp_path.unlink(missing_ok=True)
         except OSError:
+            # Cleanup is best-effort; raising here would mask the original
+            # write/replace error being propagated below.
             pass
         raise
 
@@ -232,6 +244,9 @@ def ensure_private_directory(path: Path, *, tighten_existing: bool = False) -> N
         try:
             path.chmod(0o700)
         except OSError:
+            # Best-effort hardening: a filesystem that rejects chmod (e.g.
+            # some network mounts) must not block the write path that needs
+            # this directory.
             pass
 
 


### PR DESCRIPTION
- Add atomic_write_{text,toml,json,bytes} helpers (temp + fsync + replace)
  and use them for transcript.txt, notes.md, meta.toml, config.toml, index
  manifest, BM25 store, answer cache, and live-audio metadata so a crash or
  full disk can no longer truncate user data in place; a truncated
  transcript previously passed the size>0 resume check and was never
  re-transcribed
- Create ~/.chirp and new notes roots owner-only (0700); they hold verbatim
  meeting content
- Pin HF model downloads and daemon loads to the commit SHA captured at
  'models add' time (new registry 'revision' field); 'models pull' re-pins
  to upstream head
- Catch AudioDeviceError/ConfigurationError/unexpected errors in the
  --live-transcribe path instead of leaking raw tracebacks
- Point launchd StandardOut/ErrorPath at chirpd.launchd.log so rotation of
  chirpd.log no longer loses output or bypasses the size cap
- CI: test on Python 3.11/3.12/3.13, replace the integration-test stub with
  a real wheel install + CLI smoke, fail PyPI releases when the Developer ID
  cert is absent, publish PEP 740 attestations, and gate TestPyPI publishes
  behind a 'publish-testpypi' PR label
- Renovate: automerge only dev-tooling/actions and runtime patch bumps
- Add license/classifiers/URLs to pyproject and a CHANGELOG
- Add behavior tests for live_dashboard and meeting_monitor (previously
  untested) and for the new file_utils/registry behavior

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MjAY4NDJ5pSJbC929aCaJX