### PR TITLE
Add PyPI attestations signing for wheel distributions

### DIFF
--- a/.github/workflows/shared-publish-package.yaml
+++ b/.github/workflows/shared-publish-package.yaml
@@ -46,6 +46,15 @@ jobs:
     - name: Install Twine
       run: uv pip install twine --system
 
+    - name: 🔏 Sign wheel for PyPI attestations
+      # twine's --attestations upload looks for a sibling `<file>.publish.attestation`
+      # next to each distribution; nothing produces one unless we sign here first.
+      # Uses the job's id-token OIDC credential (Trusted Publishing) to request the
+      # Sigstore signing certificate — no secrets required.
+      run: |
+        uv pip install pypi-attestations --system
+        pypi-attestations sign dist/*.whl
+
     - name: 📦 Publish to ${{ env.pypi-repository }}
       # Wheel-only (see shared-build-and-test.yaml). We never publish an sdist:
       # the macOS-arm64 Swift helper can't be built from source off a macOS host


### PR DESCRIPTION
## Summary
Add signing of wheel distributions using PyPI attestations to enable Trusted Publishing verification on PyPI. This leverages Sigstore and OIDC credentials for secure, keyless signing.

## Changes
- Install `pypi-attestations` package in the publish workflow
- Sign all wheel distributions before upload using the job's OIDC id-token credential
- Twine's `--attestations` flag will automatically detect and upload the generated `.publish.attestation` files alongside wheels

## Implementation Details
The signing step uses Trusted Publishing (OIDC) to request a Sigstore signing certificate without requiring any stored secrets. The attestation files are created as siblings to each wheel with the `.publish.attestation` extension, which twine automatically includes during upload.

https://claude.ai/code/session_01Jmipd7Xy1WLU7kkYrFLeNt