### PR TITLE
Fix PyPI publish: pass attestation files to twine explicitly

### DIFF
--- a/.github/workflows/shared-publish-package.yaml
+++ b/.github/workflows/shared-publish-package.yaml
@@ -47,8 +47,6 @@ jobs:
       run: uv pip install twine --system
 
     - name: 🔏 Sign wheel for PyPI attestations
-      # Writes `<wheel>.publish.attestation` next to each wheel, signed with the
-      # job's id-token OIDC credential (Trusted Publishing) — no secrets required.
       run: |
         uv pip install pypi-attestations --system
         pypi-attestations sign dist/*.whl
@@ -58,12 +56,8 @@ jobs:
       # Wheel-only (see shared-build-and-test.yaml). We never publish an sdist:
       # the macOS-arm64 Swift helper can't be built from source off a macOS host
       # with Xcode CLT, and a user-side rebuild would break its TCC identity.
-      #
-      # The .publish.attestation files MUST be passed as arguments: twine only
-      # attaches attestations it receives on the command line and never scans
-      # dist/ for sibling files (see twine's commands._split_inputs). We can't
-      # use a bare `dist/*` because dist/ also holds the CI-written VERSION.txt,
-      # which twine rejects as an unknown distribution format.
+      # twine only attaches attestations passed as CLI args, and bare dist/*
+      # would include VERSION.txt.
       run: twine upload --verbose --attestations --repository ${{ env.pypi-repository }} dist/*.whl dist/*.whl.publish.attestation
 
     - name: Read version for comment

--- a/.github/workflows/shared-publish-package.yaml
+++ b/.github/workflows/shared-publish-package.yaml
@@ -47,19 +47,24 @@ jobs:
       run: uv pip install twine --system
 
     - name: 🔏 Sign wheel for PyPI attestations
-      # twine's --attestations upload looks for a sibling `<file>.publish.attestation`
-      # next to each distribution; nothing produces one unless we sign here first.
-      # Uses the job's id-token OIDC credential (Trusted Publishing) to request the
-      # Sigstore signing certificate — no secrets required.
+      # Writes `<wheel>.publish.attestation` next to each wheel, signed with the
+      # job's id-token OIDC credential (Trusted Publishing) — no secrets required.
       run: |
         uv pip install pypi-attestations --system
         pypi-attestations sign dist/*.whl
+        ls -l dist/
 
     - name: 📦 Publish to ${{ env.pypi-repository }}
       # Wheel-only (see shared-build-and-test.yaml). We never publish an sdist:
       # the macOS-arm64 Swift helper can't be built from source off a macOS host
       # with Xcode CLT, and a user-side rebuild would break its TCC identity.
-      run: twine upload --verbose --attestations --repository ${{ env.pypi-repository }} dist/*.whl
+      #
+      # The .publish.attestation files MUST be passed as arguments: twine only
+      # attaches attestations it receives on the command line and never scans
+      # dist/ for sibling files (see twine's commands._split_inputs). We can't
+      # use a bare `dist/*` because dist/ also holds the CI-written VERSION.txt,
+      # which twine rejects as an unknown distribution format.
+      run: twine upload --verbose --attestations --repository ${{ env.pypi-repository }} dist/*.whl dist/*.whl.publish.attestation
 
     - name: Read version for comment
       id: version_info


### PR DESCRIPTION
## Summary

Completes the fix started in #136. The v0.0.7-alpha publish still failed after that PR (run [29314407689](https://github.com/Code-and-Sorts/chirp-ai-note-app/actions/runs/29314407689)) with the same error:

```
InvalidDistribution: Upload with attestations requested, but
dist/chirp_notes_ai-0.0.7a0-py3-none-macosx_13_0_arm64.whl has no associated attestations
```

**Root cause:** the signing step from #136 ran and produced `dist/<wheel>.publish.attestation`, but twine never scans `dist/` for sibling attestation files. Per twine 6.2.0's `commands._split_inputs`, it only associates attestation files that are **passed as command-line arguments** — and the upload command passed only `dist/*.whl`.

## Changes

- Append `dist/*.whl.publish.attestation` to the `twine upload` arguments so the attestations produced by the sign step are actually attached. A bare `dist/*` would not work because `dist/` also holds the CI-written `VERSION.txt`, which twine rejects as an unknown distribution format.
- Add `ls -l dist/` to the sign step so runs show the produced attestation files in the log.
- Correct the workflow comments to state the real constraint (attestations must be CLI arguments; twine does not discover adjacent files).

## Verification

Reproduced and verified locally with the exact versions from the failed run (twine 6.2.0, pypi-attestations 0.0.29):

- A wheel with a valid `.publish.attestation` beside it, uploaded as `dist/*.whl` only → reproduces the CI error byte-for-byte.
- The fixed command, run against the same directory **including a `VERSION.txt`** → clears the attestation check and proceeds to trusted-publishing auth (fails locally only due to no ambient GitHub OIDC, which CI has — the same identity the sign step already used successfully in run 29314407689).

## After merging

Re-point the `v0.0.7-alpha` tag/release at the new main commit (as done for run 9) so the release workflow picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jmipd7Xy1WLU7kkYrFLeNt

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jmipd7Xy1WLU7kkYrFLeNt)_